### PR TITLE
docs: mark v0.1.0 as released (README, changelog, security, support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-CodFlow is a pre-release monorepo with no tagged releases yet. This section
-tracks work in progress toward the initial public release.
+## [0.1.0] - 2026-08-20
+
+Initial public release of CodFlow — the open-source, COD-first e-commerce +
+delivery platform for Algeria.
 
 ### Added
 
@@ -26,9 +28,15 @@ tracks work in progress toward the initial public release.
 
 ### Security
 
-- No public releases yet; see `SECURITY.md` for the reporting process
+- Inbound webhooks (Yalidine, ZR Express) verified with Svix HMAC signatures
+- MCP remote server protected with OAuth + offline JWKS verification (RFC 9728)
+- API keys hashed at rest (SHA-256); production secrets only via
+  `wrangler secret put` — none committed to the repository
+- Dependabot security & grouped version updates enabled; branch protection on
+  `main`
 
-## [0.1.0] - TBD
+### Changed
 
-Placeholder for the initial tagged release. Version numbers and release dates
-will be added here when the first tag is cut.
+- Storefront upgraded to Astro 7 (Rust compiler, Vite 8); server & dashboard
+  upgraded to TypeScript 7 and Vitest 4; Drizzle ORM → 0.45; Next.js → 16;
+  Wrangler → 4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CodFlow
 
-> **⚠️ Pre-Release Status**: CodFlow is currently in pre-release development. The platform is functional and feature-complete for production use, but the API may still evolve. We welcome early adopters and contributors!
+> **v0.1.0** — CodFlow is released and production-ready for self-hosting. See
+> [`CHANGELOG.md`](./CHANGELOG.md) for the release history.
 
 **The open-source, COD-first e-commerce + delivery platform for Algeria — built agentic-ready.**
 
@@ -198,9 +199,9 @@ Workers share one local D1 state during development.
 
 | Package | Stack | Runtime |
 |---------|-------|---------|
-| `cod-astro/theme01` | Astro 5, Tailwind CSS v4, TypeScript | Cloudflare Workers + Assets |
+| `cod-astro/theme01` | Astro 7, Tailwind CSS v4, TypeScript | Cloudflare Workers + Assets |
 | `cod-server` | Hono 4, Drizzle ORM, Zod, Better Auth, Cloudflare Agents SDK | Cloudflare Workers, D1, R2 |
-| `cod-client` | Next.js 15, React 19, Tailwind v4, OpenNext | Cloudflare Workers |
+| `cod-client` | Next.js 16, React 19, Tailwind v4, OpenNext | Cloudflare Workers |
 | `cod-shared` | Drizzle ORM, TypeScript | source-shared |
 
 ---
@@ -212,7 +213,7 @@ and backend sharing one database.
 
 ### 0. Prerequisites
 
-- **Node.js 20+** and npm
+- **Node.js 22.12+** and npm
 - The [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/)
   (`npm i -g wrangler`)
 - A Cloudflare account with **Workers**, **D1**, and **R2** (free tier is fine)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported Versions
 
-CodFlow is pre-release software. Only the latest code on the `main` branch and
+CodFlow is released software. Only the latest code on the `main` branch and
 the most recent tagged release receive security fixes. Fixes are backported to
 earlier releases only when explicitly stated in the release notes.
 
 | Version               | Supported          |
 |-----------------------|--------------------|
-| `main` (unreleased)   | :white_check_mark: |
+| `main` branch         | :white_check_mark: |
 | Latest tagged release | :white_check_mark: |
 | Older releases        | :x:                |
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,6 +1,6 @@
 # Getting help with CodFlow
 
-CodFlow is a pre-release project. Here is where to go depending on what you
+CodFlow is an open-source project. Here is where to go depending on what you
 need:
 
 ## Bugs and feature requests
@@ -24,5 +24,5 @@ The primary documentation is the repository [`README.md`](./README.md) and the
 
 ## Commercial / priority support
 
-There is currently no commercial support tier. This project is pre-release and
-maintained on a best-effort basis.
+There is currently no commercial support tier. This project is maintained on a
+best-effort basis.


### PR DESCRIPTION
- README: drop pre-release banner, refresh tech stack (Astro 7, Next.js 16), bump Node prerequisite to 22.12+
- CHANGELOG: cut [0.1.0] - 2026-08-20 with added/security/changed sections
- SECURITY/SUPPORT: replace pre-release wording with released-project language

## What does this PR do?

<!-- Brief description of the change and why. -->

## Related issues

<!-- Link any issues this closes, e.g. "Closes #12". -->

## How to test

<!-- Commands to run and what to check. -->

- [ ] I ran `npm run typecheck` and `npm test` in the affected package(s)

## Checklist

- [ ] No secrets, API keys, or live credentials are introduced
- [ ] Tests cover the change (or an existing test covers it)
- [ ] README/docs claims match the implemented behavior (no unbuilt features claimed)
- [ ] Conventional commit message (`feat:`, `fix:`, `chore:`, `docs:`, ...)

## Areas affected

<!-- cod-server / cod-client / cod-astro / cod-shared / docs / CI -->