### PR TITLE
docs: consolidate agent guidelines, fix stale claims

### DIFF
--- a/.opencode/skills/codflow-governance/SKILL.md
+++ b/.opencode/skills/codflow-governance/SKILL.md
@@ -1,125 +1,90 @@
 ---
 name: codflow-governance
-description: CodFlow repository governance — build, test, and ship code that meets this repo's standards. Use when making ANY change to CodFlow (cod-server, cod-client, cod-shared, cod-astro/theme01, README, docs, CI), before committing or opening a PR, writing README feature claims, touching migrations or the D1 schema, adding dependencies, or reviewing contributions. Enforces: code-verified README claims, no secrets, typecheck+tests verification, conventional commits, changelog updates, Apache-2.0/NOTICE, and SECURITY.md reporting rules.
+description: CodFlow repository workflow — the process for making and shipping a change that meets this repo's standards. Use when making ANY change to CodFlow (cod-server, cod-client, cod-shared, cod-astro/theme01, README, docs, CI), before committing or opening a PR, writing README feature claims, touching migrations or the D1 schema, adding dependencies, or reviewing contributions. Loads and defers to AGENTS.md for the repo contract; this skill is the step-by-step workflow, not a duplicate of it.
 ---
 
-# CodFlow Governance
+# CodFlow Governance — change workflow
 
 CodFlow is an Apache-2.0, self-hosted, cash-on-delivery (COD) e-commerce
-platform for Algeria, open-sourced for the first time. Every change must keep
-the repo **honest, tested, and secure**. This skill is the contract for how
-code lands here.
+platform for Algeria, open-sourced for the first time. This skill is the
+**workflow** for landing a change. The repo contract (layout, commands,
+verification, boundaries, traps, security rules) lives in the root
+`AGENTS.md` — read it first; it is the source of truth. Package-specific
+commands and boundaries live in each package's `AGENTS.md`
+(`cod-astro/theme01/AGENTS.md`).
 
-## Repo layout (know where things live)
+## When to use
 
-- `cod-server/` — Cloudflare Workers API (Hono). Merchant `/api/*`, public
-  `/store/*`, `/webhooks`, `/images`, `/mcp`. D1 via Drizzle.
-- `cod-client/` — Next.js merchant dashboard (App Router, `"use client"`
-  heavy). `app/(dashboard)/*` is the merchant UI.
-- `cod-shared/` — single source of truth for the D1 schema, shared queries,
-  RBAC scopes, and error codes. Imported via relative path
-  (`../../cod-shared/...`). **Not published.**
-- `cod-astro/theme01/` — swappable storefront theme (Astro). No package.json.
-  Keep engine logic out of it.
+- You are about to change code, docs, schema, or CI in this repo.
+- You are writing README feature claims.
+- You are reviewing a contribution.
 
-There is **no root package.json and no npm workspaces**. Each package installs
-its own dependencies.
+## The change workflow
 
-## Commands (exact, run inside the package dir)
+### 1. Locate the change
+
+- Identify the package(s) affected (cod-server / cod-client / cod-shared /
+  cod-astro/theme01). Read the root `AGENTS.md`, then the package's `AGENTS.md`.
+- Respect the `cod-shared` boundary: schema, queries, RBAC scopes, and error
+  codes are defined there and only there. Do not duplicate them in a package.
+- Migrations: add a new migration; never rewrite an already-applied one.
+- Ask before adding a production dependency or changing the D1 schema.
+- Keep engine logic out of `cod-astro/theme01` (swappable theme layer).
+
+### 2. Install dependencies
+
+Run in this order — cod-server/cod-client tests and typecheck fail if
+`cod-shared` deps are not installed first:
 
 ```sh
-cd cod-shared && npm ci        # always first — others resolve cod-shared deps
-cd cod-server && npm ci        # then
-cd cod-server && npm run typecheck
-cd cod-server && npm test
-cd cod-server && npm run dev   # wrangler dev :8787
+cd cod-shared && npm ci
+cd cod-server && npm ci   # and/or cd cod-client && npm ci
 ```
 
-Same for `cod-client` (`npm ci`, `npm run typecheck`, `npm test`, `npm run dev`).
-`cod-astro/theme01` needs no install (`npm run dev` starts Astro).
-CI runs exactly these commands in `.github/workflows/ci.yml`.
+### 3. Make the change
 
-## Verification — NEVER skip
+- One logical change per commit. Conventional Commits
+  (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `ci:`).
+- No explanatory code comments unless asked.
+- Never commit secrets (API keys, carrier tokens, credentials). Real secrets go
+  in `wrangler secrets` / `.dev.vars` (gitignored).
+- Add or update a **focused test** for behavior changes.
+
+### 4. Verify — never skip
 
 - After **any TypeScript change**: run `npm run typecheck` in the affected
-  package. Failing typecheck is a blocker.
+  package (theme01: `npx astro check`).
 - After **any behavior change**: run `npm test` in the affected package.
-  (cod-server currently: 689 tests; cod-client: 141.)
-- Add or update a **focused test** for the behavior you changed. Do not rely on
-  "it compiles" — behavior changes need coverage.
+- README claims must be code-verified: never write a feature claim the code
+  does not implement. If a feature is partially built, say exactly that.
 - Do not mark work complete until typecheck + tests actually pass.
 
-## README claims MUST be code-verified
+### 5. Commit, branch, PR
 
-This is the repo's non-negotiable rule:
-
-> Never write a feature claim in the README that is not actually implemented.
-
-- Before editing a README feature list, confirm the code exists (read the
-  handler/route/component).
-- If a feature is only partially built (e.g. backend done, UI is a "Coming
-  Soon" placeholder), say exactly that — do not claim it as complete.
-- Use the ✅/❌/🧭 markers the README already uses; keep them accurate.
-- If you discover a README claim that the code does not support, fix the README
-  or flag it — never leave an overclaim.
-
-## Secrets — NEVER
-
-- No live API keys, carrier tokens, or credentials in source, tests, or
-  fixtures. Ever.
-- Real secrets go in `wrangler secrets` or `.dev.vars` (gitignored).
-- Before committing, scan your diff for tokens (`API_TOKEN=`, `SECRET_KEY=`,
-  `Bearer`, long base64/high-entropy strings).
-- If you find a committed secret: rotate it, remove it from history, and report
-  via `SECURITY.md` process — do not silently leave it.
-
-## Commits & branches
-
-- One logical change per commit. Conventional Commits:
-  `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `ci:`.
-- Branch naming: `feat/…`, `fix/…`, `chore/…`, `docs/…`.
-- Work on a branch; merge via a PR (CI runs on it). Never force-push shared
-  branches.
-
-## Pull requests
-
+- Work on a branch named `feat/…`, `fix/…`, `chore/…`, `docs/…`.
 - PRs must be small enough to review in one sitting (< ~500 lines).
-- PR template checklist must pass: no secrets, tests cover the change, README
-  claims match code, conventional commit message.
-- CI (typecheck + tests for cod-server and cod-client) must be green before
-  merge.
-- When reviewing a contribution, check: does the README claim only what the
-  code does? Are secrets absent? Are tests included?
+- The PR template checklist must pass: no secrets, tests cover the change,
+  README claims match code, conventional commit message.
+- CI (typecheck + tests for cod-server and cod-client) must be green.
+- When reviewing: README claims only what code does? Secrets absent? Tests
+  included? Migrations additive?
 
-## Changelog & releases
+### 6. Changelog
 
-- `CHANGELOG.md` uses Keep a Changelog. New user-visible changes go under
-  `[Unreleased]` grouped by Added / Changed / Deprecated / Removed / Fixed /
+- User-visible changes go under `[Unreleased]` in `CHANGELOG.md` (Keep a
+  Changelog), grouped by Added / Changed / Deprecated / Removed / Fixed /
   Security.
-- Releases follow SemVer (`v0.1.x` patch, `v0.x.0` minor, `v1.0.0` major), are
-  git-tagged, and announced via GitHub Releases.
-- Update the CHANGELOG when you add, change, or fix user-visible behavior.
+- Releases follow SemVer, are git-tagged, and announced via GitHub Releases.
 
-## Boundaries (don't cross without asking)
+## Review checklist (use when reviewing a contribution)
 
-- `cod-shared` is the single source of truth for schema, queries, RBAC scopes,
-  and error codes. Do NOT duplicate them in cod-server or cod-client.
-- Migrations: add a NEW migration; never rewrite an already-applied one.
-- Ask before adding a production dependency or changing the D1 schema.
-- Keep engine logic out of `cod-astro/theme01` (it must stay swappable).
-
-## Known traps (verify before blaming CI)
-
-- cod-server/cod-client tests or typecheck fail if `cod-shared` deps are not
-  installed first — run `cd cod-shared && npm ci` first.
-- Inbound webhooks exist only for **Yalidine** and **ZR Express**. NOEST and
-  EcoTrack tracking is pulled on demand via `GET /orders/:id/tracking`; there is
-  no inbound receiver for them.
-- The abandoned-order dashboard page
-  (`cod-client/app/(dashboard)/orders/abandoned`) is a "Coming Soon"
-  placeholder — backend collection + cron exist, the merchant UI does not.
-- cod-server tests run on miniflare + better-sqlite3 locally; no network or
-  credentials required.
+- [ ] README claims only what the code actually does
+- [ ] No secrets / credentials in the diff
+- [ ] Tests cover the change (or an existing test covers it)
+- [ ] Migrations are additive (new file, not a rewrite)
+- [ ] `cod-shared` boundaries respected (no duplicated schema/scopes)
+- [ ] Conventional commit message
+- [ ] Typecheck + tests pass for affected packages
 
 ## Security reports
 
@@ -127,9 +92,3 @@ This is the repo's non-negotiable rule:
   GitHub private vulnerability reporting (see `SECURITY.md`).
 - Acknowledgment target: 3 business days; coordinated disclosure.
 - Supported versions: only `main` and the latest tag.
-
-## License
-
-- The project is Apache-2.0 (`LICENSE`) with copyright attribution in
-  `NOTICE`. Preserve both; do not change the license without the owner's
-  explicit decision.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,9 @@ TypeScript, deployed on Cloudflare (Workers, D1, R2, KV).
 - `cod-shared/` — shared Drizzle schema, queries, RBAC scopes, error codes.
   Imported by both apps via relative path (`../../cod-shared/...`). **Not
   published.**
-- `cod-astro/theme01/` — storefront theme (Astro). No package.json; it is a
-  swappable theme layer, not a Node package.
+- `cod-astro/theme01/` — storefront theme (Astro). It is a swappable theme
+  layer, not a platform package; keep engine logic out. Its commands and
+  boundaries differ — read `cod-astro/theme01/AGENTS.md` before editing it.
 
 There is **no root package.json and no npm workspaces**. Each package installs
 its own dependencies.
@@ -32,7 +33,8 @@ cd cod-server && npm run dev   # wrangler dev :8787
 
 Same for `cod-client` (`npm ci`, `npm run typecheck`, `npm test`, `npm run dev`).
 
-`cod-astro/theme01` needs no install (`npm run dev` inside it starts Astro).
+`cod-astro/theme01` is a separate package with its own lockfile — see
+`cod-astro/theme01/AGENTS.md` for its commands.
 
 ## Verification
 
@@ -59,7 +61,7 @@ Same for `cod-client` (`npm ci`, `npm run typecheck`, `npm test`, `npm run dev`)
 - Migrations: add a new migration; never rewrite an already-applied one.
 - Ask before adding a production dependency or changing the D1 schema.
 - Keep engine logic out of `cod-astro/theme01`; the theme layer is meant to be
-  swappable.
+  swappable (see `cod-astro/theme01/AGENTS.md`).
 
 ## Known traps
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,14 +8,15 @@ Algerian market, built as a monorepo of four packages running on Cloudflare.
 ## Table of contents
 
 1. [Repository layout](#repository-layout)
-2. [First-time setup](#first-time-setup)
-3. [Local development](#local-development)
-4. [Configuration](#configuration)
-5. [Architecture & code conventions](#architecture--code-conventions)
-6. [Testing](#testing)
-7. [Commit & PR guidelines](#commit--pr-guidelines)
-8. [Hard rules](#hard-rules)
-9. [Getting help](#getting-help)
+2. [Where do I start? (first contribution)](#where-do-i-start-first-contribution)
+3. [First-time setup](#first-time-setup)
+4. [Local development](#local-development)
+5. [Configuration](#configuration)
+6. [Architecture & code conventions](#architecture--code-conventions)
+7. [Testing](#testing)
+8. [Commit & PR guidelines](#commit--pr-guidelines)
+9. [Hard rules](#hard-rules)
+10. [Getting help](#getting-help)
 
 ---
 
@@ -24,7 +25,7 @@ Algerian market, built as a monorepo of four packages running on Cloudflare.
 ```
 codflow-os/
 ├── cod-server/   # Backend API  — Cloudflare Worker (Hono + D1 + R2)
-├── cod-client/   # Merchant dashboard — Next.js 15 + OpenNext on Cloudflare
+├── cod-client/   # Merchant dashboard — Next.js 16 + OpenNext on Cloudflare
 ├── cod-astro/    # Customer storefront — Astro, trilingual (AR/FR/EN)
 │   └── theme01/  #   the default theme (theme layer is swappable)
 └── cod-shared/   # Source-shared TS — D1 schema, RBAC scopes, read queries
@@ -44,13 +45,44 @@ imports (`../../cod-shared/...`) — it has no build step.
 
 ---
 
+## Where do I start? (first contribution)
+
+New here? Here's the shortest path to a merged change:
+
+1. **Find an issue.** Look for issues labeled `good first issue`. They are
+   scoped so a first-time contributor can finish them in one sitting.
+2. **Pick your package.** Each package is self-contained (see the layout above).
+   The `Area` dropdown in the issue tells you which one a task touches.
+3. **Set up once.** Complete the [First-time setup](#first-time-setup) section —
+   it takes about 10 minutes and applies to every later contribution.
+4. **Make a small change.** Keep it under ~500 lines. Follow the conventions in
+   [Architecture & code conventions](#architecture--code-conventions) — if the
+   task touches `cod-shared`, read that boundary first.
+5. **Verify before pushing.** Run `npm run typecheck` and `npm test` in the
+   package you changed (theme01: `npx astro check` + `npm test`). CI runs the
+   same checks.
+6. **Open a PR** using the PR template. Mention the issue with "Closes #N".
+7. **Review happens on the PR.** Keep it small, respond to feedback, and CI must
+   be green.
+
+> Tips:
+> - `cod-astro/theme01` is the most self-contained package — a good place to
+>   start if you are new to the platform.
+> - The storefront's `src/core/` is **off-limits** (platform-owned engine). New
+>   storefront work goes in `src/theme/`.
+> - Never put a real secret in your PR — secrets live in `.dev.vars` and
+>   `wrangler secret put`, never in a wrangler config file or source.
+
 ## First-time setup
 
 ### Prerequisites
 
-- **Node.js 20+** and npm
+- **Node.js 22.12+** and npm
 - The [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/) (`npm i -g wrangler`)
 - A Cloudflare account (D1 + R2 are free-tier friendly)
+
+> The repo's `.nvmrc` pins Node 24; CI runs Node 24. Astro 7 (the storefront)
+> requires Node 22.12+.
 
 ### 1. Install
 
@@ -71,8 +103,10 @@ wrangler kv namespace create RATE_LIMIT_KV   # only needed for cod-client
 
 ### 3. Configure
 
-Every package ships a **`wrangler.toml` with placeholder values** and a
-**`.dev.vars.example`**. Copy the example files and paste your own resource IDs:
+Every package ships a Cloudflare config with placeholder values
+(`wrangler.toml` in cod-server/cod-client, `wrangler.jsonc` in
+cod-astro/theme01) and a **`.dev.vars.example`**. Copy the example files and
+paste your own resource IDs:
 
 ```bash
 # backend
@@ -130,15 +164,16 @@ Open **four terminals**, one per package (D1 state is shared through
 ## Configuration
 
 **There is no hardcoded configuration.** URLs, domains, database IDs, and bucket
-names are placeholders in each `wrangler.toml`; secrets go in gitignored
-`.dev.vars` files or `wrangler secret put` in production.
+names are placeholders in each package's Cloudflare config (`wrangler.toml` in
+cod-server/cod-client, `wrangler.jsonc` in cod-astro/theme01); secrets go in
+gitignored `.dev.vars` files or `wrangler secret put` in production.
 
 | Variable | Owner | Purpose |
 |----------|-------|---------|
 | `WORKER_URL`, `MEDIA_DOMAIN`, `R2_BUCKET_NAME`, `BETTER_AUTH_URL`, `WORKER_SELF_URL` | `cod-server` | public URLs + R2 (see `src/types/env.ts`) |
 | `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_WORKER_URL` | `cod-client` | dashboard origin + API origin (auth base URL, MCP audience, email sender domain) |
 | `COD_SERVER_URL`, `STORE_API_KEY`, `MEDIA_DOMAIN` | `cod-astro/theme01` | backend base URL + store key + media CDN |
-| `BETTER_AUTH_SECRET`, R2 creds, `CF_ACCOUNT_ID` | all | secrets — never in `wrangler.toml` |
+| `BETTER_AUTH_SECRET`, R2 creds, `CF_ACCOUNT_ID` | all | secrets — never in a wrangler config file |
 
 ---
 
@@ -202,8 +237,8 @@ orders/
 Run the full suite of a package before pushing:
 
 ```bash
-cd cod-server        && npm test       # ~700 tests
-cd cod-client        && npm test       # ~140 tests
+cd cod-server        && npm test       # 698 tests
+cd cod-client        && npm test       # 141 tests
 cd cod-astro/theme01 && npm test       # property + behavior tests
 ```
 
@@ -231,7 +266,7 @@ cd cod-astro/theme01 && npm test       # property + behavior tests
 
 ## Hard rules
 
-1. **No secrets in `wrangler.toml`** — they go in `.dev.vars` (local) or
+1. **No secrets in a wrangler config file** — they go in `.dev.vars` (local) or
    `wrangler secret put` (prod).
 2. **No hardcoded URLs/domains** in source or config. Everything must be swappable
    so a fresh clone can run against its own Cloudflare account.
@@ -246,5 +281,7 @@ cd cod-astro/theme01 && npm test       # property + behavior tests
 - Read the per-package READMEs: `cod-server/README.md`, `cod-client/README.md`,
   `cod-astro/theme01/THEME_GUIDE.md`, and the endpoint docs under
   `cod-server/src/endpoints/*/README.md`.
+- Coding agents should read the repo instructions: `AGENTS.md` (root) and
+  `cod-astro/theme01/AGENTS.md` (storefront).
 
 Happy shipping! 🚚

--- a/cod-astro/theme01/AGENTS.md
+++ b/cod-astro/theme01/AGENTS.md
@@ -1,0 +1,53 @@
+# theme01 — repository instructions for coding agents
+
+`cod-astro/theme01` is the swappable storefront theme for CodFlow (Astro,
+Cloudflare Workers, AR/FR/EN). It is a **theme layer, not a platform package**:
+engine logic lives in the CodFlow platform (see `cod-server`). Read the root
+`AGENTS.md` too — this file only overrides what differs here.
+
+## Layout
+
+- `src/core/` — platform-owned engine. **Do not modify.** All HTTP calls go
+  through `src/core/api/client.ts`; Astro action/middleware proxies at
+  `src/actions/index.ts` and `src/middleware.ts` re-export from here.
+- `src/theme/` — the swappable theme layer: components, layouts, styles,
+  config, content (AR/FR/EN string packs). This is where customization lands.
+- `public/`, `scripts/` — static assets and repo-owned validator scripts.
+
+## Commands
+
+This is a standalone package with its own lockfile. Install and run inside this
+directory:
+
+```sh
+npm ci              # install
+npm run dev         # astro dev :4321 (expects cod-server on :8787)
+npm run build       # astro build
+npm test            # vitest --run (6 unit/property tests)
+npx astro check     # typecheck + diagnostics
+npm run validate    # string + style validators, then build
+```
+
+There is no `typecheck` script; `npx astro check` is the typecheck for this
+package. CI runs only cod-server and cod-client, so theme changes must be
+verified manually with the commands above.
+
+## Boundaries
+
+- Keep engine logic out of the theme. Changes that belong in the platform
+  (API shape, validation, order flow) go in `cod-server` / `cod-shared`, not
+  here.
+- Never modify `src/core/` — the core is versioned with the platform and
+  breakage there breaks orders.
+- All user-facing text needs AR/FR/EN translations and must keep RTL working.
+- The theme stays swappable: a new theme is a new folder, not edits to core.
+
+## Conventions & traps
+
+- **No hardcoded user-facing strings** — add content keys to the language packs.
+- **No hardcoded design tokens** (colors, radii, fonts) in component styles.
+  See `THEME_GUIDE.md`.
+- `wrangler.jsonc` ships a local `COD_SERVER_URL` var. Real secrets go in
+  `.dev.vars` (gitignored) or `wrangler secret put` — never in `wrangler.jsonc`.
+- `MEDIA_DOMAIN` is optional; unset, the image optimizer passes URLs through
+  unchanged.

--- a/cod-astro/theme01/README.md
+++ b/cod-astro/theme01/README.md
@@ -1,7 +1,7 @@
 # theme01 — CodFlow Storefront
 
 The default storefront theme for CodFlow: a mobile-first, multi-locale,
-conversion-focused **Astro 5** storefront that talks to the CodFlow backend
+conversion-focused **Astro 7** storefront that talks to the CodFlow backend
 (`cod-server`) over the public `/store/*` API.
 
 theme01 is part of the [CodFlow monorepo](../../README.md). It is one of three
@@ -25,7 +25,7 @@ Workers that make up the platform:
 
 ## Quick start
 
-Prereqs: Node 20+, the [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/),
+Prereqs: Node 22.12+, the [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/),
 and a running `cod-server` (the storefront reads all data from its `/store/*` API).
 
 ```bash

--- a/cod-client/README.md
+++ b/cod-client/README.md
@@ -1,6 +1,6 @@
 # CodFlow Dashboard
 
-CodFlow's admin dashboard for Algerian e-commerce businesses — orders, customers, products, drivers, delivery-carrier integration, and MCP agent access. Built with Next.js 15, OpenNext on Cloudflare Workers, and D1.
+CodFlow's admin dashboard for Algerian e-commerce businesses — orders, customers, products, drivers, delivery-carrier integration, and MCP agent access. Built with Next.js 16, OpenNext on Cloudflare Workers, and D1.
 
 ## Reads vs writes
 
@@ -58,7 +58,7 @@ npm run build
 
 ```
 cod-client/
-├── app/              # Next.js 15 App Router (routes and pages)
+├── app/              # Next.js 16 App Router (routes and pages)
 ├── components/       # React components (UI and features)
 ├── hooks/            # Custom React hooks
 ├── lib/              # Utility functions and helpers (auth, api, email, rbac)
@@ -84,7 +84,7 @@ Each major directory has its own README with detailed documentation:
 ## 🛠️ Tech Stack
 
 ### Frontend
-- **Next.js 15** - React framework with App Router
+- **Next.js 16** - React framework with App Router
 - **React 19** - UI library
 - **TypeScript** - Type safety
 - **Tailwind CSS** - Utility-first CSS

--- a/cod-client/app/README.md
+++ b/cod-client/app/README.md
@@ -1,6 +1,6 @@
 # App Directory
 
-This directory contains the Next.js 15 App Router structure with all application routes and layouts.
+This directory contains the Next.js 16 App Router structure with all application routes and layouts.
 
 ## Structure
 


### PR DESCRIPTION
Fixes stale/wrong facts and consolidates the three overlapping governance docs into a single source of truth.

## Changes

- **AGENTS.md**: corrected `cod-astro/theme01` (it *does* have a package.json + own lockfile — root said "No package.json / needs no install"). Root now defers to the nested AGENTS.md instead of carrying theme exceptions.
- **cod-astro/theme01/AGENTS.md** (new): nearest-file-wins package instructions — astro check (no typecheck script), vitest tests, core-layer boundary ("do not modify"), theme rules, wrangler.jsonc secrets trap.
- **codflow-governance skill**: slimmed from a 135-line copy of AGENTS.md into a change *workflow* that defers to AGENTS.md for the contract (research: redundant instructions across files hurt agent performance and consistency).
- **CONTRIBUTING.md**: Next.js 15 → 16, Node 20+ → 22.12+ (Astro 7 requirement, .nvmrc = 24), exact test counts (698 / 141), wrangler.toml vs wrangler.jsonc accuracy, secrets rule generalized to "a wrangler config file". Added a **first-contribution path** section.
- **theme01 README**: Astro 5 → 7, Node 20+ → 22.12+.

## Verification

- `npx astro check` on theme01: 0 errors, 12 hints
- `npm test` on theme01: 6/6 passed
- `npm test` on cod-server: 698/698 passed
- No TS changes in cod-server/cod-client, so no typecheck needed there

Docs-only change; CI (cod-server/cod-client) unaffected.