### PR TITLE
feat(skills): add codflow-setup skill and automated setup scripts

### DIFF
--- a/.agents/skills/codflow-setup/SKILL.md
+++ b/.agents/skills/codflow-setup/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: codflow-setup
+description: >-
+  Autonomous setup guide for CodFlow — sets up prerequisites, Cloudflare resources (D1, R2, KV),
+  environment variables (.dev.vars), database migrations, demo store seeding, admin account generation,
+  and local or production execution. Use when a developer wants to set up CodFlow locally, bind Cloudflare
+  resources, run migrations, seed sample data, create an admin user, or deploy to Cloudflare Workers.
+---
+
+# CodFlow Setup — Developer & Agent Runbook
+
+CodFlow is an open-source, cash-on-delivery (COD) e-commerce platform for Algeria and emerging markets, built on Cloudflare Workers, Next.js 16, Astro 7, and D1 SQLite.
+
+This skill provides an exact, verified procedure for setting up CodFlow from a fresh clone into a fully operational local development stack or production deployment on Cloudflare.
+
+---
+
+## Essential Cloudflare Prerequisites & Account Setup
+
+> [!IMPORTANT]
+> **1. Cloudflare Login & Browser OAuth:**
+> Before running any remote deployment or provisioning commands, the developer must authenticate with Cloudflare:
+> ```bash
+> npx wrangler whoami
+> ```
+> If not logged in, run:
+> ```bash
+> npx wrangler login
+> ```
+> This command will open a browser window for Cloudflare OAuth authorization. The user must approve the connection in their browser before continuing.
+
+> [!WARNING]
+> **2. Cloudflare R2 Activation & Credit Card Requirement:**
+> - Cloudflare R2 provides a **generous Free Tier** (10 GB storage, 1,000,000 Class A write operations, and 10,000,000 Class B read operations per month at $0.00 cost).
+> - **However**, Cloudflare requires an **active payment method (credit/debit card) on file** in the Cloudflare Dashboard to enable the R2 subscription on the account before creating buckets.
+> - **How to activate R2:**
+>   1. Open [https://dash.cloudflare.com](https://dash.cloudflare.com) and navigate to **R2 Object Storage**.
+>   2. Click **Enable R2** / **Subscribe to R2** (select the default Free Tier).
+>   3. Add a payment card to activate the service.
+>   4. Once activated, R2 buckets can be created via `npx wrangler r2 bucket create <bucket-name>`.
+> - **Note for Local Development:** Local dev runs 100% offline using Miniflare / SQLite emulation in `.wrangler-shared` and **does NOT require a Cloudflare account or credit card**.
+
+---
+
+## Interactive Setup Workflow for AI Agents
+
+When a developer asks to set up CodFlow, follow this decision path:
+
+1. **Clarify Setup Mode & Preferences with the Developer:**
+   - **Mode**: Local Development (default, 100% free offline emulation) OR Cloudflare Cloud / Production?
+   - **Store/Project Name**: Resource name prefix (default: `codflow` or custom store brand).
+   - **Admin Account**: Email (default: `admin@example.com`) and Name (default: `Admin`).
+   - If Cloudflare Cloud is selected: Verify `npx wrangler whoami` and remind about the R2 card-on-file activation.
+2. **Execute Setup Autonomously:**
+   - Install dependencies in strict order (`cod-shared` first).
+   - Configure `.dev.vars` with cryptographic keys.
+   - Run D1 migrations to shared state (`.wrangler-shared` for local, or remote D1).
+   - Seed sample products, categories, 58-wilaya shipping rates, and store API key.
+   - Create admin credentials with Better Auth hashed passwords.
+3. **Verify the Running Services:**
+   - Verify Backend API & Swagger Docs: `http://localhost:8787/api/docs`.
+   - Verify Merchant Dashboard: `http://localhost:3000`.
+   - Verify Storefront: `http://localhost:4321`.
+
+---
+
+## Quick Automation Scripts
+
+The skill includes pre-tested, zero-assumption automation scripts in `scripts/`:
+
+### 1. Automated Local Setup (One Command)
+```bash
+node .agents/skills/codflow-setup/scripts/setup-local.mjs
+
+# Or with custom admin parameters:
+ADMIN_EMAIL=you@example.dz ADMIN_NAME="Store Owner" node .agents/skills/codflow-setup/scripts/setup-local.mjs
+```
+
+### 2. Automated Cloudflare Remote Provisioning
+```bash
+# Verify authentication first:
+npx wrangler whoami || npx wrangler login
+
+# Run automated provisioning:
+PROJECT_NAME=mystore ADMIN_EMAIL=admin@mystore.dz node .agents/skills/codflow-setup/scripts/setup-cloudflare.mjs
+```
+
+---
+
+## Detailed Step-by-Step Runbook (Manual / Autonomous Execution)
+
+### Step 1: Install Dependencies in Strict Order
+
+> [!IMPORTANT]
+> There is no root `package.json` and no npm workspaces. Dependencies must be installed per-package, starting with `cod-shared` because other packages resolve it via relative paths.
+
+```bash
+# 1. cod-shared (MUST BE FIRST)
+cd cod-shared && npm install
+
+# 2. Backend Worker (cod-server)
+cd ../cod-server && npm install
+
+# 3. Merchant Dashboard (cod-client)
+cd ../cod-client && npm install
+
+# 4. Storefront Theme (cod-astro)
+cd ../cod-astro/theme01 && npm install
+cd ../..
+```
+
+---
+
+### Step 2: Configure Environment Files (`.dev.vars`)
+
+Create `.dev.vars` files from examples across the three runtime applications:
+
+#### 1. Backend (`cod-server/.dev.vars`)
+```ini
+STORE_API_KEY=codflow-dev-store-key
+ENVIRONMENT=development
+WORKER_URL=http://localhost:8787
+WORKER_SELF_URL=http://localhost:8787/
+BETTER_AUTH_URL=http://localhost:3000/api/auth
+MEDIA_DOMAIN=media.example.com
+R2_BUCKET_NAME=codflow-images
+ALLOWED_ORIGINS=*
+```
+
+#### 2. Dashboard (`cod-client/.dev.vars`)
+Generate a 32-byte base64 string for `BETTER_AUTH_SECRET`:
+```bash
+# Generate secret:
+# node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+```
+```ini
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_WORKER_URL=http://localhost:8787
+BETTER_AUTH_SECRET=<32_BYTE_BASE64_SECRET>
+```
+
+#### 3. Storefront (`cod-astro/theme01/.dev.vars`)
+```ini
+STORE_API_KEY=codflow-dev-store-key
+COD_SERVER_URL=http://localhost:8787
+```
+
+---
+
+### Step 3: Run Database Migrations & Seed Local Store
+
+Local D1 SQLite database is persisted to `<repo-root>/.wrangler-shared` so `cod-server` and `cod-client` share the exact same state without split-brain.
+
+```bash
+cd cod-server
+# Apply 10 D1 migrations (0000 to 0009) to .wrangler-shared
+npm run db:migrate:local
+
+# Seed demo store (متجر التطوير), 4 categories, 8 products, variants, and API key
+npm run db:seed:local
+```
+
+---
+
+### Step 4: Create Local Merchant Admin Account
+
+Create an admin credentials account in Better Auth:
+
+```bash
+cd ../cod-client
+ADMIN_EMAIL=admin@example.com ADMIN_NAME=Admin node scripts/seed-admin.mjs [optional-password]
+```
+
+*Output displays generated password and admin API key.*
+
+---
+
+### Step 5: Start Local Development Servers
+
+Open three terminals or launch background processes:
+
+| Package | Directory | Command | URL | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **API Server** | `cod-server` | `npm run dev` | `http://localhost:8787` | Hono Worker, OpenAPI at `/api/docs`, MCP at `/mcp` |
+| **Dashboard** | `cod-client` | `npm run dev` | `http://localhost:3000` | Next.js 16 Merchant UI (Sign in with admin credentials) |
+| **Storefront** | `cod-astro/theme01` | `npm run dev` | `http://localhost:4321` | Astro 7 COD Storefront (Place test orders) |
+
+---
+
+## Cloudflare Remote Provisioning & Production Setup
+
+When deploying to a live Cloudflare account:
+
+### 1. Authenticate with Cloudflare
+```bash
+npx wrangler whoami
+# If not authenticated, run:
+npx wrangler login
+```
+
+### 2. Verify R2 Activation & Provision Cloudflare Resources
+```bash
+# 1. Create D1 Database (save the database_id from output)
+npx wrangler d1 create codflow-db
+
+# 2. Create R2 Image Bucket (ensure card is on file in dash.cloudflare.com → R2)
+npx wrangler r2 bucket create codflow-images
+
+# 3. Create KV Namespace for Rate Limiting & Auth Cache (save the id)
+npx wrangler kv namespace create RATE_LIMIT_KV
+```
+
+### 3. Bind Resources in `wrangler.toml` Files
+
+- In `cod-server/wrangler.toml`:
+  - Set `[[d1_databases]]`: `database_name = "codflow-db"`, `database_id = "<your-d1-uuid>"`
+  - Set `[[r2_buckets]]`: `bucket_name = "codflow-images"`
+  - Set `[[kv_namespaces]]`: `id = "<your-kv-id>"`
+- In `cod-client/wrangler.toml`:
+  - Set `[[d1_databases]]`: `database_name = "codflow-db"`, `database_id = "<your-d1-uuid>"`
+  - Set `[[kv_namespaces]]`: `id = "<your-kv-id>"`
+
+### 4. Upload Cloudflare Production Secrets
+```bash
+# 1. Set Auth Secret on Server and Dashboard
+cd cod-server
+echo "<BETTER_AUTH_SECRET>" | npx wrangler secret put BETTER_AUTH_SECRET
+
+cd ../cod-client
+echo "<BETTER_AUTH_SECRET>" | npx wrangler secret put BETTER_AUTH_SECRET
+
+# 2. Set Store Key and Server URL on Storefront
+cd ../cod-astro/theme01
+echo "<STORE_API_KEY>" | npx wrangler secret put STORE_API_KEY
+echo "https://api.yourdomain.com" | npx wrangler secret put COD_SERVER_URL
+```
+
+### 5. Apply Migrations & Seed Remote Admin
+```bash
+# Apply schema to remote Cloudflare D1
+cd ../cod-server
+npm run db:migrate:remote
+
+# Seed remote admin user
+cd ../cod-client
+ADMIN_EMAIL=admin@yourdomain.com ADMIN_NAME=Admin node scripts/seed-admin.mjs <password> --remote
+```
+
+### 6. Deploy Workers
+```bash
+cd ../cod-server && npm run deploy
+cd ../cod-client && npm run deploy
+cd ../cod-astro/theme01 && npm run deploy
+```
+
+---
+
+## Troubleshooting & Common Traps
+
+| Problem | Cause | Solution |
+| :--- | :--- | :--- |
+| **`wrangler login` fails in headless/SSH** | No GUI browser available | Run `npx wrangler login` on a local machine, or configure `CLOUDFLARE_API_TOKEN` in the environment. |
+| **`wrangler r2 bucket create` fails** | R2 subscription not enabled on Cloudflare account | Navigate to `https://dash.cloudflare.com → R2`, add a payment card to activate the Free Tier, then retry. |
+| **Local D1 split-brain / missing tables** | Wrangler ran without `--persist-to` | Always run local migrations and commands with `--persist-to ../.wrangler-shared`. |
+| **`npm test` fails after git pull** | `cod-shared` was not installed first | Run `cd cod-shared && npm install` before running tests in other packages. |
+| **Better Auth 500 on sign-in** | `BETTER_AUTH_SECRET` missing | Ensure `BETTER_AUTH_SECRET` is set in `cod-client/.dev.vars` (local) or via `wrangler secret put` (production). |
+| **Image uploads fail in browser** | R2 CORS not configured for PUT requests | Run `node scripts/setup-r2-cors.mjs` in `cod-server` with R2 API tokens. |

--- a/.agents/skills/codflow-setup/scripts/setup-cloudflare.mjs
+++ b/.agents/skills/codflow-setup/scripts/setup-cloudflare.mjs
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+/**
+ * CodFlow Cloudflare Remote Setup Script
+ *
+ * Automates:
+ * 1. Cloudflare authentication check (wrangler whoami)
+ * 2. Remote Cloudflare resource creation (D1, R2, KV)
+ * 3. Configuration of wrangler.toml files (database_id, bucket_name, kv id)
+ * 4. Secret generation & upload to Cloudflare (BETTER_AUTH_SECRET, STORE_API_KEY)
+ * 5. Remote D1 database migration execution
+ * 6. Remote admin account seeding
+ *
+ * Usage:
+ *   node scripts/setup-cloudflare.mjs
+ *   PROJECT_NAME=mystore ADMIN_EMAIL=admin@mystore.dz ADMIN_NAME="Store Admin" node scripts/setup-cloudflare.mjs
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function findRepoRoot(startDir) {
+  let dir = startDir;
+  while (dir !== dirname(dir)) {
+    if (existsSync(resolve(dir, "cod-server")) && existsSync(resolve(dir, "cod-client"))) {
+      return dir;
+    }
+    dir = dirname(dir);
+  }
+  return process.cwd();
+}
+
+const repoRoot = findRepoRoot(__dirname);
+
+function logStep(step, message) {
+  console.log(`\n\x1b[1m\x1b[36m[Step ${step}]\x1b[0m \x1b[1m${message}\x1b[0m`);
+}
+
+function logSuccess(message) {
+  console.log(`  \x1b[32m✓\x1b[0m ${message}`);
+}
+
+function run(cmd, cwd = repoRoot, capture = false) {
+  if (capture) {
+    return execSync(cmd, { cwd, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] });
+  }
+  return execSync(cmd, { cwd, stdio: "inherit" });
+}
+
+async function main() {
+  console.log("\n╔══════════════════════════════════════════════════════════╗");
+  console.log("║      CodFlow Cloudflare Production Automated Setup       ║");
+  console.log("╚══════════════════════════════════════════════════════════╝");
+
+  // Step 1: Check Cloudflare Authentication
+  logStep(1, "Checking Cloudflare Authentication");
+  try {
+    const whoami = run("npx wrangler whoami", repoRoot, true);
+    console.log(whoami.trim());
+    logSuccess("Authenticated with Cloudflare");
+  } catch (err) {
+    console.error("\n❌ Cloudflare authentication required.");
+    console.error("The developer must log into Cloudflare before deploying or creating resources.");
+    console.error("\nTo authenticate:");
+    console.error("  1. Run: npx wrangler login");
+    console.error("  2. Wrangler will open a browser window for Cloudflare OAuth authorization.");
+    console.error("  3. Approve the connection in the browser.");
+    console.error("  4. Re-run this setup script.\n");
+    process.exit(1);
+  }
+
+  const projectName = process.env.PROJECT_NAME || "codflow";
+  const dbName = `${projectName}-db`;
+  const bucketName = `${projectName}-images`;
+  const kvName = `RATE_LIMIT_KV`;
+
+  console.log(`\nUsing Resource Names:`);
+  console.log(`  D1 Database : ${dbName}`);
+  console.log(`  R2 Bucket   : ${bucketName}`);
+  console.log(`  KV Namespace: ${kvName}`);
+
+  // Step 2: Create or retrieve D1 Database
+  logStep(2, `Provisioning D1 Database: ${dbName}`);
+  let databaseId = "";
+  try {
+    const d1Output = run(`npx wrangler d1 create ${dbName}`, repoRoot, true);
+    const idMatch = d1Output.match(/database_id\s*=\s*"([^"]+)"/);
+    if (idMatch) {
+      databaseId = idMatch[1];
+      logSuccess(`Created D1 database with ID: ${databaseId}`);
+    }
+  } catch (err) {
+    const combined = (err.stdout || "") + (err.stderr || "") + err.message;
+    if (combined.includes("already exists") || combined.includes("A database with that name already exists")) {
+      console.log(`  Database ${dbName} already exists. Fetching info...`);
+      try {
+        const listOutput = run("npx wrangler d1 list --json", repoRoot, true);
+        const list = JSON.parse(listOutput);
+        const found = list.find((db) => db.name === dbName);
+        if (found) {
+          databaseId = found.uuid;
+          logSuccess(`Found existing D1 database ID: ${databaseId}`);
+        }
+      } catch (listErr) {
+        console.warn("  Could not fetch D1 list automatically.");
+      }
+    } else {
+      console.error("  Error creating D1:", combined);
+    }
+  }
+
+  if (!databaseId) {
+    console.error("\n❌ Could not resolve D1 database_id. Please check your Cloudflare dashboard.");
+    process.exit(1);
+  }
+
+  // Step 3: Provision R2 Bucket
+  logStep(3, `Provisioning R2 Bucket: ${bucketName}`);
+  try {
+    run(`npx wrangler r2 bucket create ${bucketName}`, repoRoot, true);
+    logSuccess(`Created R2 bucket: ${bucketName}`);
+  } catch (err) {
+    const combined = (err.stdout || "") + (err.stderr || "") + err.message;
+    if (combined.includes("already exists")) {
+      logSuccess(`R2 bucket ${bucketName} already exists`);
+    } else {
+      console.warn(`\n  ⚠️  R2 Provisioning Notice: ${combined.trim()}`);
+      console.warn("  ─────────────────────────────────────────────────────────────");
+      console.warn("  Cloudflare requires R2 to be activated on your account.");
+      console.warn("  While R2 has a generous Free Tier (10 GB storage, 1M writes,");
+      console.warn("  10M reads per month), Cloudflare requires a card on file to");
+      console.warn("  activate the R2 service.");
+      console.warn("");
+      console.warn("  To activate R2:");
+      console.warn("    1. Go to https://dash.cloudflare.com → R2 Object Storage");
+      console.warn("    2. Click 'Enable R2' or 'Purchase R2' (Free Tier selected)");
+      console.warn("    3. After enabling, run: npx wrangler r2 bucket create " + bucketName);
+      console.warn("  ─────────────────────────────────────────────────────────────\n");
+    }
+  }
+
+  // Step 4: Provision KV Namespace
+  logStep(4, `Provisioning KV Namespace: ${kvName}`);
+  let kvId = "";
+  try {
+    const kvOutput = run(`npx wrangler kv namespace create ${kvName}`, repoRoot, true);
+    const idMatch = kvOutput.match(/id\s*=\s*"([^"]+)"/);
+    if (idMatch) {
+      kvId = idMatch[1];
+      logSuccess(`Created KV namespace with ID: ${kvId}`);
+    }
+  } catch (err) {
+    const combined = (err.stdout || "") + (err.stderr || "") + err.message;
+    if (combined.includes("already exists")) {
+      try {
+        const kvList = JSON.parse(run("npx wrangler kv namespace list", repoRoot, true));
+        const found = kvList.find((kv) => kv.title && kv.title.includes(kvName));
+        if (found) {
+          kvId = found.id;
+          logSuccess(`Found existing KV ID: ${kvId}`);
+        }
+      } catch (listErr) {
+        console.warn("  Could not automatically resolve KV ID from list.");
+      }
+    } else {
+      console.warn(`  KV Notice: ${combined.trim()}`);
+    }
+  }
+
+  if (!kvId) {
+    kvId = "00000000000000000000000000000000";
+    console.warn("  ⚠️ Warning: KV ID not resolved automatically. Using placeholder.");
+  }
+
+  // Step 5: Update wrangler.toml files
+  logStep(5, "Updating configuration files (wrangler.toml)");
+
+  // 5a. cod-server/wrangler.toml
+  const serverWranglerPath = resolve(repoRoot, "cod-server/wrangler.toml");
+  let serverWrangler = readFileSync(serverWranglerPath, "utf8");
+  serverWrangler = serverWrangler.replace(/database_name\s*=\s*"[^"]+"/, `database_name = "${dbName}"`);
+  serverWrangler = serverWrangler.replace(/database_id\s*=\s*"[^"]+"/, `database_id = "${databaseId}"`);
+  serverWrangler = serverWrangler.replace(/bucket_name\s*=\s*"[^"]+"/g, `bucket_name = "${bucketName}"`);
+  serverWrangler = serverWrangler.replace(/R2_BUCKET_NAME\s*=\s*"[^"]+"/g, `R2_BUCKET_NAME = "${bucketName}"`);
+  if (kvId !== "00000000000000000000000000000000") {
+    serverWrangler = serverWrangler.replace(/id\s*=\s*"[0-9a-f]{32}"/, `id = "${kvId}"`);
+  }
+  writeFileSync(serverWranglerPath, serverWrangler, "utf8");
+  logSuccess("Updated cod-server/wrangler.toml with D1, R2, and KV bindings");
+
+  // 5b. cod-client/wrangler.toml
+  const clientWranglerPath = resolve(repoRoot, "cod-client/wrangler.toml");
+  let clientWrangler = readFileSync(clientWranglerPath, "utf8");
+  clientWrangler = clientWrangler.replace(/database_name\s*=\s*"[^"]+"/, `database_name = "${dbName}"`);
+  clientWrangler = clientWrangler.replace(/database_id\s*=\s*"[^"]+"/, `database_id = "${databaseId}"`);
+  if (kvId !== "00000000000000000000000000000000") {
+    clientWrangler = clientWrangler.replace(/id\s*=\s*"[0-9a-f]{32}"/, `id = "${kvId}"`);
+  }
+  writeFileSync(clientWranglerPath, clientWrangler, "utf8");
+  logSuccess("Updated cod-client/wrangler.toml with D1 and KV bindings");
+
+  // Step 6: Generate and Set Secrets
+  logStep(6, "Generating and uploading production secrets");
+  const betterAuthSecret = process.env.BETTER_AUTH_SECRET || randomBytes(32).toString("base64");
+  const storeApiKey = process.env.STORE_API_KEY || randomBytes(16).toString("hex");
+
+  // Put secret to cod-server
+  try {
+    execSync(`echo "${betterAuthSecret}" | npx wrangler secret put BETTER_AUTH_SECRET`, {
+      cwd: resolve(repoRoot, "cod-server"),
+      stdio: "pipe",
+    });
+    logSuccess("Configured BETTER_AUTH_SECRET on cod-server");
+  } catch (e) {
+    console.warn("  Could not put secret to cod-server:", e.message);
+  }
+
+  // Put secret to cod-client
+  try {
+    execSync(`echo "${betterAuthSecret}" | npx wrangler secret put BETTER_AUTH_SECRET`, {
+      cwd: resolve(repoRoot, "cod-client"),
+      stdio: "pipe",
+    });
+    logSuccess("Configured BETTER_AUTH_SECRET on cod-client");
+  } catch (e) {
+    console.warn("  Could not put secret to cod-client:", e.message);
+  }
+
+  // Put secret to cod-astro/theme01
+  try {
+    execSync(`echo "${storeApiKey}" | npx wrangler secret put STORE_API_KEY`, {
+      cwd: resolve(repoRoot, "cod-astro/theme01"),
+      stdio: "pipe",
+    });
+    logSuccess("Configured STORE_API_KEY on cod-astro/theme01");
+  } catch (e) {
+    console.warn("  Could not put secret to cod-astro/theme01:", e.message);
+  }
+
+  // Step 7: Apply remote D1 migrations
+  logStep(7, "Applying migrations to remote D1 database");
+  run("npm run db:migrate:remote", resolve(repoRoot, "cod-server"));
+  logSuccess("Applied all schema migrations to remote D1");
+
+  // Step 8: Seed remote admin account
+  logStep(8, "Creating remote admin account");
+  const adminEmail = process.env.ADMIN_EMAIL || "admin@example.com";
+  const adminName = process.env.ADMIN_NAME || "Admin";
+  const adminPassword = process.env.ADMIN_PASSWORD || randomBytes(9).toString("base64url");
+
+  const seedAdminRemoteCmd = `ADMIN_EMAIL="${adminEmail}" ADMIN_NAME="${adminName}" node scripts/seed-admin.mjs "${adminPassword}" --remote`;
+  run(seedAdminRemoteCmd, resolve(repoRoot, "cod-client"));
+  logSuccess("Seeded admin user to remote D1");
+
+  // Step 9: Summary & Next Steps
+  console.log("\n╔══════════════════════════════════════════════════════════╗");
+  console.log("║         Cloudflare Resource Provisioning Complete!       ║");
+  console.log("╠══════════════════════════════════════════════════════════╣");
+  console.log(`║  D1 Database ID: ${databaseId.padEnd(39)} ║`);
+  console.log(`║  R2 Bucket     : ${bucketName.padEnd(39)} ║`);
+  console.log(`║  Admin Email   : ${adminEmail.padEnd(39)} ║`);
+  console.log(`║  Admin Pass    : ${adminPassword.padEnd(39)} ║`);
+  console.log(`║  Store API Key : ${storeApiKey.padEnd(39)} ║`);
+  console.log("╚══════════════════════════════════════════════════════════╝");
+  console.log("\nTo deploy the applications to Cloudflare Workers:\n");
+  console.log("  1. cd cod-server && npm run deploy");
+  console.log("  2. cd cod-client && npm run deploy");
+  console.log("  3. cd cod-astro/theme01 && npm run deploy\n");
+}
+
+main().catch((err) => {
+  console.error("\n❌ Remote setup failed:", err.message);
+  process.exit(1);
+});

--- a/.agents/skills/codflow-setup/scripts/setup-local.mjs
+++ b/.agents/skills/codflow-setup/scripts/setup-local.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * CodFlow Automated Local Setup Script
+ *
+ * Automates:
+ * 1. Dependency verification & installation order
+ * 2. .dev.vars generation with cryptographic secrets
+ * 3. Local D1 database migrations (shared state in .wrangler-shared)
+ * 4. Sample store and product seeding
+ * 5. Admin user creation
+ *
+ * Usage:
+ *   node scripts/setup-local.mjs
+ *   ADMIN_EMAIL=me@store.dz ADMIN_NAME="Store Owner" node scripts/setup-local.mjs
+ */
+
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function findRepoRoot(startDir) {
+  let dir = startDir;
+  while (dir !== dirname(dir)) {
+    if (existsSync(resolve(dir, "cod-server")) && existsSync(resolve(dir, "cod-client"))) {
+      return dir;
+    }
+    dir = dirname(dir);
+  }
+  return process.cwd();
+}
+
+const repoRoot = findRepoRoot(__dirname);
+
+function logStep(step, message) {
+  console.log(`\n\x1b[1m\x1b[36m[Step ${step}]\x1b[0m \x1b[1m${message}\x1b[0m`);
+}
+
+function logSuccess(message) {
+  console.log(`  \x1b[32m✓\x1b[0m ${message}`);
+}
+
+function run(cmd, cwd = repoRoot) {
+  return execSync(cmd, { cwd, stdio: "inherit" });
+}
+
+async function main() {
+  console.log("\n╔══════════════════════════════════════════════════════════╗");
+  console.log("║         CodFlow Local Environment Automated Setup        ║");
+  console.log("╚══════════════════════════════════════════════════════════╝");
+
+  // Step 1: Check Node & dependencies
+  logStep(1, "Checking package dependencies");
+  const packages = [
+    { name: "cod-shared", dir: resolve(repoRoot, "cod-shared") },
+    { name: "cod-server", dir: resolve(repoRoot, "cod-server") },
+    { name: "cod-client", dir: resolve(repoRoot, "cod-client") },
+    { name: "cod-astro/theme01", dir: resolve(repoRoot, "cod-astro/theme01") },
+  ];
+
+  for (const pkg of packages) {
+    if (!existsSync(resolve(pkg.dir, "node_modules"))) {
+      console.log(`  Installing dependencies in ${pkg.name}...`);
+      run("npm install", pkg.dir);
+      logSuccess(`Installed ${pkg.name} dependencies`);
+    } else {
+      logSuccess(`${pkg.name} dependencies ready`);
+    }
+  }
+
+  // Step 2: Configure .dev.vars across packages
+  logStep(2, "Configuring local environment files (.dev.vars)");
+
+  // 2a. cod-server .dev.vars
+  const serverDevVarsPath = resolve(repoRoot, "cod-server/.dev.vars");
+  if (!existsSync(serverDevVarsPath)) {
+    const serverDevVars = `# Local development secrets for cod-server
+STORE_API_KEY=codflow-dev-store-key
+ENVIRONMENT=development
+WORKER_URL=http://localhost:8787
+WORKER_SELF_URL=http://localhost:8787/
+BETTER_AUTH_URL=http://localhost:3000/api/auth
+MEDIA_DOMAIN=media.example.com
+R2_BUCKET_NAME=codflow-images
+ALLOWED_ORIGINS=*
+`;
+    writeFileSync(serverDevVarsPath, serverDevVars, "utf8");
+    logSuccess("Created cod-server/.dev.vars");
+  } else {
+    logSuccess("cod-server/.dev.vars exists");
+  }
+
+  // 2b. cod-client .dev.vars
+  const clientDevVarsPath = resolve(repoRoot, "cod-client/.dev.vars");
+  let betterAuthSecret = randomBytes(32).toString("base64");
+  if (!existsSync(clientDevVarsPath)) {
+    const clientDevVars = `# Local development secrets for cod-client
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_WORKER_URL=http://localhost:8787
+BETTER_AUTH_SECRET=${betterAuthSecret}
+`;
+    writeFileSync(clientDevVarsPath, clientDevVars, "utf8");
+    logSuccess("Created cod-client/.dev.vars with generated BETTER_AUTH_SECRET");
+  } else {
+    const existingContent = readFileSync(clientDevVarsPath, "utf8");
+    const match = existingContent.match(/^BETTER_AUTH_SECRET=(.+)$/m);
+    if (match && match[1].trim()) {
+      betterAuthSecret = match[1].trim();
+    }
+    logSuccess("cod-client/.dev.vars exists");
+  }
+
+  // 2c. cod-astro/theme01 .dev.vars
+  const astroDevVarsPath = resolve(repoRoot, "cod-astro/theme01/.dev.vars");
+  if (!existsSync(astroDevVarsPath)) {
+    const astroDevVars = `# Local development secrets for cod-astro storefront
+STORE_API_KEY=codflow-dev-store-key
+COD_SERVER_URL=http://localhost:8787
+`;
+    writeFileSync(astroDevVarsPath, astroDevVars, "utf8");
+    logSuccess("Created cod-astro/theme01/.dev.vars");
+  } else {
+    logSuccess("cod-astro/theme01/.dev.vars exists");
+  }
+
+  // Step 3: Run local D1 migrations and seed demo store
+  logStep(3, "Applying local database migrations & seeding sample products");
+  run("npm run db:setup:local", resolve(repoRoot, "cod-server"));
+  logSuccess("Applied migrations and seeded store-local-dev to .wrangler-shared");
+
+  // Step 4: Seed admin user
+  logStep(4, "Creating local admin account");
+  const email = process.env.ADMIN_EMAIL ?? "admin@example.com";
+  const name = process.env.ADMIN_NAME ?? "Admin";
+  const password = process.env.ADMIN_PASSWORD ?? randomBytes(9).toString("base64url");
+
+  const seedAdminCmd = `ADMIN_EMAIL="${email}" ADMIN_NAME="${name}" node scripts/seed-admin.mjs "${password}"`;
+  run(seedAdminCmd, resolve(repoRoot, "cod-client"));
+  logSuccess("Admin account created successfully");
+
+  // Step 5: Summary
+  console.log("\n╔══════════════════════════════════════════════════════════╗");
+  console.log("║                 Local Setup Complete!                    ║");
+  console.log("╠══════════════════════════════════════════════════════════╣");
+  console.log("║  Backend API   : http://localhost:8787                   ║");
+  console.log("║  Swagger Docs  : http://localhost:8787/api/docs          ║");
+  console.log("║  OpenAPI Spec  : http://localhost:8787/api/openapi.json  ║");
+  console.log("║  Dashboard UI  : http://localhost:3000                   ║");
+  console.log("║  Storefront    : http://localhost:4321                   ║");
+  console.log("╠══════════════════════════════════════════════════════════╣");
+  console.log(`║  Admin Email   : ${email.padEnd(39)} ║`);
+  console.log(`║  Admin Pass    : ${password.padEnd(39)} ║`);
+  console.log("╚══════════════════════════════════════════════════════════╝");
+  console.log("\nTo start all services, open three terminals:\n");
+  console.log("  Terminal 1: cd cod-server && npm run dev");
+  console.log("  Terminal 2: cd cod-client && npm run dev");
+  console.log("  Terminal 3: cd cod-astro/theme01 && npm run dev\n");
+}
+
+main().catch((err) => {
+  console.error("\n❌ Setup failed:", err.message);
+  process.exit(1);
+});

--- a/.opencode/skills/codflow-setup/SKILL.md
+++ b/.opencode/skills/codflow-setup/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: codflow-setup
+description: >-
+  Autonomous setup guide for CodFlow — sets up prerequisites, Cloudflare resources (D1, R2, KV),
+  environment variables (.dev.vars), database migrations, demo store seeding, admin account generation,
+  and local or production execution. Use when a developer wants to set up CodFlow locally, bind Cloudflare
+  resources, run migrations, seed sample data, create an admin user, or deploy to Cloudflare Workers.
+---
+
+# CodFlow Setup — Developer & Agent Runbook
+
+CodFlow is an open-source, cash-on-delivery (COD) e-commerce platform for Algeria and emerging markets, built on Cloudflare Workers, Next.js 16, Astro 7, and D1 SQLite.
+
+This skill provides an exact, verified procedure for setting up CodFlow from a fresh clone into a fully operational local development stack or production deployment on Cloudflare.
+
+---
+
+## Essential Cloudflare Prerequisites & Account Setup
+
+> [!IMPORTANT]
+> **1. Cloudflare Login & Browser OAuth:**
+> Before running any remote deployment or provisioning commands, the developer must authenticate with Cloudflare:
+> ```bash
+> npx wrangler whoami
+> ```
+> If not logged in, run:
+> ```bash
+> npx wrangler login
+> ```
+> This command will open a browser window for Cloudflare OAuth authorization. The user must approve the connection in their browser before continuing.
+
+> [!WARNING]
+> **2. Cloudflare R2 Activation & Credit Card Requirement:**
+> - Cloudflare R2 provides a **generous Free Tier** (10 GB storage, 1,000,000 Class A write operations, and 10,000,000 Class B read operations per month at $0.00 cost).
+> - **However**, Cloudflare requires an **active payment method (credit/debit card) on file** in the Cloudflare Dashboard to enable the R2 subscription on the account before creating buckets.
+> - **How to activate R2:**
+>   1. Open [https://dash.cloudflare.com](https://dash.cloudflare.com) and navigate to **R2 Object Storage**.
+>   2. Click **Enable R2** / **Subscribe to R2** (select the default Free Tier).
+>   3. Add a payment card to activate the service.
+>   4. Once activated, R2 buckets can be created via `npx wrangler r2 bucket create <bucket-name>`.
+> - **Note for Local Development:** Local dev runs 100% offline using Miniflare / SQLite emulation in `.wrangler-shared` and **does NOT require a Cloudflare account or credit card**.
+
+---
+
+## Interactive Setup Workflow for AI Agents
+
+When a developer asks to set up CodFlow, follow this decision path:
+
+1. **Clarify Setup Mode & Preferences with the Developer:**
+   - **Mode**: Local Development (default, 100% free offline emulation) OR Cloudflare Cloud / Production?
+   - **Store/Project Name**: Resource name prefix (default: `codflow` or custom store brand).
+   - **Admin Account**: Email (default: `admin@example.com`) and Name (default: `Admin`).
+   - If Cloudflare Cloud is selected: Verify `npx wrangler whoami` and remind about the R2 card-on-file activation.
+2. **Execute Setup Autonomously:**
+   - Install dependencies in strict order (`cod-shared` first).
+   - Configure `.dev.vars` with cryptographic keys.
+   - Run D1 migrations to shared state (`.wrangler-shared` for local, or remote D1).
+   - Seed sample products, categories, 58-wilaya shipping rates, and store API key.
+   - Create admin credentials with Better Auth hashed passwords.
+3. **Verify the Running Services:**
+   - Verify Backend API & Swagger Docs: `http://localhost:8787/api/docs`.
+   - Verify Merchant Dashboard: `http://localhost:3000`.
+   - Verify Storefront: `http://localhost:4321`.
+
+---
+
+## Quick Automation Scripts
+
+The skill includes pre-tested, zero-assumption automation scripts in `scripts/`:
+
+### 1. Automated Local Setup (One Command)
+```bash
+node .agents/skills/codflow-setup/scripts/setup-local.mjs
+
+# Or with custom admin parameters:
+ADMIN_EMAIL=you@example.dz ADMIN_NAME="Store Owner" node .agents/skills/codflow-setup/scripts/setup-local.mjs
+```
+
+### 2. Automated Cloudflare Remote Provisioning
+```bash
+# Verify authentication first:
+npx wrangler whoami || npx wrangler login
+
+# Run automated provisioning:
+PROJECT_NAME=mystore ADMIN_EMAIL=admin@mystore.dz node .agents/skills/codflow-setup/scripts/setup-cloudflare.mjs
+```
+
+---
+
+## Detailed Step-by-Step Runbook (Manual / Autonomous Execution)
+
+### Step 1: Install Dependencies in Strict Order
+
+> [!IMPORTANT]
+> There is no root `package.json` and no npm workspaces. Dependencies must be installed per-package, starting with `cod-shared` because other packages resolve it via relative paths.
+
+```bash
+# 1. cod-shared (MUST BE FIRST)
+cd cod-shared && npm install
+
+# 2. Backend Worker (cod-server)
+cd ../cod-server && npm install
+
+# 3. Merchant Dashboard (cod-client)
+cd ../cod-client && npm install
+
+# 4. Storefront Theme (cod-astro)
+cd ../cod-astro/theme01 && npm install
+cd ../..
+```
+
+---
+
+### Step 2: Configure Environment Files (`.dev.vars`)
+
+Create `.dev.vars` files from examples across the three runtime applications:
+
+#### 1. Backend (`cod-server/.dev.vars`)
+```ini
+STORE_API_KEY=codflow-dev-store-key
+ENVIRONMENT=development
+WORKER_URL=http://localhost:8787
+WORKER_SELF_URL=http://localhost:8787/
+BETTER_AUTH_URL=http://localhost:3000/api/auth
+MEDIA_DOMAIN=media.example.com
+R2_BUCKET_NAME=codflow-images
+ALLOWED_ORIGINS=*
+```
+
+#### 2. Dashboard (`cod-client/.dev.vars`)
+Generate a 32-byte base64 string for `BETTER_AUTH_SECRET`:
+```bash
+# Generate secret:
+# node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+```
+```ini
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_WORKER_URL=http://localhost:8787
+BETTER_AUTH_SECRET=<32_BYTE_BASE64_SECRET>
+```
+
+#### 3. Storefront (`cod-astro/theme01/.dev.vars`)
+```ini
+STORE_API_KEY=codflow-dev-store-key
+COD_SERVER_URL=http://localhost:8787
+```
+
+---
+
+### Step 3: Run Database Migrations & Seed Local Store
+
+Local D1 SQLite database is persisted to `<repo-root>/.wrangler-shared` so `cod-server` and `cod-client` share the exact same state without split-brain.
+
+```bash
+cd cod-server
+# Apply 10 D1 migrations (0000 to 0009) to .wrangler-shared
+npm run db:migrate:local
+
+# Seed demo store (متجر التطوير), 4 categories, 8 products, variants, and API key
+npm run db:seed:local
+```
+
+---
+
+### Step 4: Create Local Merchant Admin Account
+
+Create an admin credentials account in Better Auth:
+
+```bash
+cd ../cod-client
+ADMIN_EMAIL=admin@example.com ADMIN_NAME=Admin node scripts/seed-admin.mjs [optional-password]
+```
+
+*Output displays generated password and admin API key.*
+
+---
+
+### Step 5: Start Local Development Servers
+
+Open three terminals or launch background processes:
+
+| Package | Directory | Command | URL | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **API Server** | `cod-server` | `npm run dev` | `http://localhost:8787` | Hono Worker, OpenAPI at `/api/docs`, MCP at `/mcp` |
+| **Dashboard** | `cod-client` | `npm run dev` | `http://localhost:3000` | Next.js 16 Merchant UI (Sign in with admin credentials) |
+| **Storefront** | `cod-astro/theme01` | `npm run dev` | `http://localhost:4321` | Astro 7 COD Storefront (Place test orders) |
+
+---
+
+## Cloudflare Remote Provisioning & Production Setup
+
+When deploying to a live Cloudflare account:
+
+### 1. Authenticate with Cloudflare
+```bash
+npx wrangler whoami
+# If not authenticated, run:
+npx wrangler login
+```
+
+### 2. Verify R2 Activation & Provision Cloudflare Resources
+```bash
+# 1. Create D1 Database (save the database_id from output)
+npx wrangler d1 create codflow-db
+
+# 2. Create R2 Image Bucket (ensure card is on file in dash.cloudflare.com → R2)
+npx wrangler r2 bucket create codflow-images
+
+# 3. Create KV Namespace for Rate Limiting & Auth Cache (save the id)
+npx wrangler kv namespace create RATE_LIMIT_KV
+```
+
+### 3. Bind Resources in `wrangler.toml` Files
+
+- In `cod-server/wrangler.toml`:
+  - Set `[[d1_databases]]`: `database_name = "codflow-db"`, `database_id = "<your-d1-uuid>"`
+  - Set `[[r2_buckets]]`: `bucket_name = "codflow-images"`
+  - Set `[[kv_namespaces]]`: `id = "<your-kv-id>"`
+- In `cod-client/wrangler.toml`:
+  - Set `[[d1_databases]]`: `database_name = "codflow-db"`, `database_id = "<your-d1-uuid>"`
+  - Set `[[kv_namespaces]]`: `id = "<your-kv-id>"`
+
+### 4. Upload Cloudflare Production Secrets
+```bash
+# 1. Set Auth Secret on Server and Dashboard
+cd cod-server
+echo "<BETTER_AUTH_SECRET>" | npx wrangler secret put BETTER_AUTH_SECRET
+
+cd ../cod-client
+echo "<BETTER_AUTH_SECRET>" | npx wrangler secret put BETTER_AUTH_SECRET
+
+# 2. Set Store Key and Server URL on Storefront
+cd ../cod-astro/theme01
+echo "<STORE_API_KEY>" | npx wrangler secret put STORE_API_KEY
+echo "https://api.yourdomain.com" | npx wrangler secret put COD_SERVER_URL
+```
+
+### 5. Apply Migrations & Seed Remote Admin
+```bash
+# Apply schema to remote Cloudflare D1
+cd ../cod-server
+npm run db:migrate:remote
+
+# Seed remote admin user
+cd ../cod-client
+ADMIN_EMAIL=admin@yourdomain.com ADMIN_NAME=Admin node scripts/seed-admin.mjs <password> --remote
+```
+
+### 6. Deploy Workers
+```bash
+cd ../cod-server && npm run deploy
+cd ../cod-client && npm run deploy
+cd ../cod-astro/theme01 && npm run deploy
+```
+
+---
+
+## Troubleshooting & Common Traps
+
+| Problem | Cause | Solution |
+| :--- | :--- | :--- |
+| **`wrangler login` fails in headless/SSH** | No GUI browser available | Run `npx wrangler login` on a local machine, or configure `CLOUDFLARE_API_TOKEN` in the environment. |
+| **`wrangler r2 bucket create` fails** | R2 subscription not enabled on Cloudflare account | Navigate to `https://dash.cloudflare.com → R2`, add a payment card to activate the Free Tier, then retry. |
+| **Local D1 split-brain / missing tables** | Wrangler ran without `--persist-to` | Always run local migrations and commands with `--persist-to ../.wrangler-shared`. |
+| **`npm test` fails after git pull** | `cod-shared` was not installed first | Run `cd cod-shared && npm install` before running tests in other packages. |
+| **Better Auth 500 on sign-in** | `BETTER_AUTH_SECRET` missing | Ensure `BETTER_AUTH_SECRET` is set in `cod-client/.dev.vars` (local) or via `wrangler secret put` (production). |
+| **Image uploads fail in browser** | R2 CORS not configured for PUT requests | Run `node scripts/setup-r2-cors.mjs` in `cod-server` with R2 API tokens. |

--- a/.opencode/skills/codflow-setup/scripts/setup-cloudflare.mjs
+++ b/.opencode/skills/codflow-setup/scripts/setup-cloudflare.mjs
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+/**
+ * CodFlow Cloudflare Remote Setup Script
+ *
+ * Automates:
+ * 1. Cloudflare authentication check (wrangler whoami)
+ * 2. Remote Cloudflare resource creation (D1, R2, KV)
+ * 3. Configuration of wrangler.toml files (database_id, bucket_name, kv id)
+ * 4. Secret generation & upload to Cloudflare (BETTER_AUTH_SECRET, STORE_API_KEY)
+ * 5. Remote D1 database migration execution
+ * 6. Remote admin account seeding
+ *
+ * Usage:
+ *   node scripts/setup-cloudflare.mjs
+ *   PROJECT_NAME=mystore ADMIN_EMAIL=admin@mystore.dz ADMIN_NAME="Store Admin" node scripts/setup-cloudflare.mjs
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function findRepoRoot(startDir) {
+  let dir = startDir;
+  while (dir !== dirname(dir)) {
+    if (existsSync(resolve(dir, "cod-server")) && existsSync(resolve(dir, "cod-client"))) {
+      return dir;
+    }
+    dir = dirname(dir);
+  }
+  return process.cwd();
+}
+
+const repoRoot = findRepoRoot(__dirname);
+
+function logStep(step, message) {
+  console.log(`\n\x1b[1m\x1b[36m[Step ${step}]\x1b[0m \x1b[1m${message}\x1b[0m`);
+}
+
+function logSuccess(message) {
+  console.log(`  \x1b[32m✓\x1b[0m ${message}`);
+}
+
+function run(cmd, cwd = repoRoot, capture = false) {
+  if (capture) {
+    return execSync(cmd, { cwd, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] });
+  }
+  return execSync(cmd, { cwd, stdio: "inherit" });
+}
+
+async function main() {
+  console.log("\n╔══════════════════════════════════════════════════════════╗");
+  console.log("║      CodFlow Cloudflare Production Automated Setup       ║");
+  console.log("╚══════════════════════════════════════════════════════════╝");
+
+  // Step 1: Check Cloudflare Authentication
+  logStep(1, "Checking Cloudflare Authentication");
+  try {
+    const whoami = run("npx wrangler whoami", repoRoot, true);
+    console.log(whoami.trim());
+    logSuccess("Authenticated with Cloudflare");
+  } catch (err) {
+    console.error("\n❌ Cloudflare authentication required.");
+    console.error("The developer must log into Cloudflare before deploying or creating resources.");
+    console.error("\nTo authenticate:");
+    console.error("  1. Run: npx wrangler login");
+    console.error("  2. Wrangler will open a browser window for Cloudflare OAuth authorization.");
+    console.error("  3. Approve the connection in the browser.");
+    console.error("  4. Re-run this setup script.\n");
+    process.exit(1);
+  }
+
+  const projectName = process.env.PROJECT_NAME || "codflow";
+  const dbName = `${projectName}-db`;
+  const bucketName = `${projectName}-images`;
+  const kvName = `RATE_LIMIT_KV`;
+
+  console.log(`\nUsing Resource Names:`);
+  console.log(`  D1 Database : ${dbName}`);
+  console.log(`  R2 Bucket   : ${bucketName}`);
+  console.log(`  KV Namespace: ${kvName}`);
+
+  // Step 2: Create or retrieve D1 Database
+  logStep(2, `Provisioning D1 Database: ${dbName}`);
+  let databaseId = "";
+  try {
+    const d1Output = run(`npx wrangler d1 create ${dbName}`, repoRoot, true);
+    const idMatch = d1Output.match(/database_id\s*=\s*"([^"]+)"/);
+    if (idMatch) {
+      databaseId = idMatch[1];
+      logSuccess(`Created D1 database with ID: ${databaseId}`);
+    }
+  } catch (err) {
+    const combined = (err.stdout || "") + (err.stderr || "") + err.message;
+    if (combined.includes("already exists") || combined.includes("A database with that name already exists")) {
+      console.log(`  Database ${dbName} already exists. Fetching info...`);
+      try {
+        const listOutput = run("npx wrangler d1 list --json", repoRoot, true);
+        const list = JSON.parse(listOutput);
+        const found = list.find((db) => db.name === dbName);
+        if (found) {
+          databaseId = found.uuid;
+          logSuccess(`Found existing D1 database ID: ${databaseId}`);
+        }
+      } catch (listErr) {
+        console.warn("  Could not fetch D1 list automatically.");
+      }
+    } else {
+      console.error("  Error creating D1:", combined);
+    }
+  }
+
+  if (!databaseId) {
+    console.error("\n❌ Could not resolve D1 database_id. Please check your Cloudflare dashboard.");
+    process.exit(1);
+  }
+
+  // Step 3: Provision R2 Bucket
+  logStep(3, `Provisioning R2 Bucket: ${bucketName}`);
+  try {
+    run(`npx wrangler r2 bucket create ${bucketName}`, repoRoot, true);
+    logSuccess(`Created R2 bucket: ${bucketName}`);
+  } catch (err) {
+    const combined = (err.stdout || "") + (err.stderr || "") + err.message;
+    if (combined.includes("already exists")) {
+      logSuccess(`R2 bucket ${bucketName} already exists`);
+    } else {
+      console.warn(`\n  ⚠️  R2 Provisioning Notice: ${combined.trim()}`);
+      console.warn("  ─────────────────────────────────────────────────────────────");
+      console.warn("  Cloudflare requires R2 to be activated on your account.");
+      console.warn("  While R2 has a generous Free Tier (10 GB storage, 1M writes,");
+      console.warn("  10M reads per month), Cloudflare requires a card on file to");
+      console.warn("  activate the R2 service.");
+      console.warn("");
+      console.warn("  To activate R2:");
+      console.warn("    1. Go to https://dash.cloudflare.com → R2 Object Storage");
+      console.warn("    2. Click 'Enable R2' or 'Purchase R2' (Free Tier selected)");
+      console.warn("    3. After enabling, run: npx wrangler r2 bucket create " + bucketName);
+      console.warn("  ─────────────────────────────────────────────────────────────\n");
+    }
+  }
+
+  // Step 4: Provision KV Namespace
+  logStep(4, `Provisioning KV Namespace: ${kvName}`);
+  let kvId = "";
+  try {
+    const kvOutput = run(`npx wrangler kv namespace create ${kvName}`, repoRoot, true);
+    const idMatch = kvOutput.match(/id\s*=\s*"([^"]+)"/);
+    if (idMatch) {
+      kvId = idMatch[1];
+      logSuccess(`Created KV namespace with ID: ${kvId}`);
+    }
+  } catch (err) {
+    const combined = (err.stdout || "") + (err.stderr || "") + err.message;
+    if (combined.includes("already exists")) {
+      try {
+        const kvList = JSON.parse(run("npx wrangler kv namespace list", repoRoot, true));
+        const found = kvList.find((kv) => kv.title && kv.title.includes(kvName));
+        if (found) {
+          kvId = found.id;
+          logSuccess(`Found existing KV ID: ${kvId}`);
+        }
+      } catch (listErr) {
+        console.warn("  Could not automatically resolve KV ID from list.");
+      }
+    } else {
+      console.warn(`  KV Notice: ${combined.trim()}`);
+    }
+  }
+
+  if (!kvId) {
+    kvId = "00000000000000000000000000000000";
+    console.warn("  ⚠️ Warning: KV ID not resolved automatically. Using placeholder.");
+  }
+
+  // Step 5: Update wrangler.toml files
+  logStep(5, "Updating configuration files (wrangler.toml)");
+
+  // 5a. cod-server/wrangler.toml
+  const serverWranglerPath = resolve(repoRoot, "cod-server/wrangler.toml");
+  let serverWrangler = readFileSync(serverWranglerPath, "utf8");
+  serverWrangler = serverWrangler.replace(/database_name\s*=\s*"[^"]+"/, `database_name = "${dbName}"`);
+  serverWrangler = serverWrangler.replace(/database_id\s*=\s*"[^"]+"/, `database_id = "${databaseId}"`);
+  serverWrangler = serverWrangler.replace(/bucket_name\s*=\s*"[^"]+"/g, `bucket_name = "${bucketName}"`);
+  serverWrangler = serverWrangler.replace(/R2_BUCKET_NAME\s*=\s*"[^"]+"/g, `R2_BUCKET_NAME = "${bucketName}"`);
+  if (kvId !== "00000000000000000000000000000000") {
+    serverWrangler = serverWrangler.replace(/id\s*=\s*"[0-9a-f]{32}"/, `id = "${kvId}"`);
+  }
+  writeFileSync(serverWranglerPath, serverWrangler, "utf8");
+  logSuccess("Updated cod-server/wrangler.toml with D1, R2, and KV bindings");
+
+  // 5b. cod-client/wrangler.toml
+  const clientWranglerPath = resolve(repoRoot, "cod-client/wrangler.toml");
+  let clientWrangler = readFileSync(clientWranglerPath, "utf8");
+  clientWrangler = clientWrangler.replace(/database_name\s*=\s*"[^"]+"/, `database_name = "${dbName}"`);
+  clientWrangler = clientWrangler.replace(/database_id\s*=\s*"[^"]+"/, `database_id = "${databaseId}"`);
+  if (kvId !== "00000000000000000000000000000000") {
+    clientWrangler = clientWrangler.replace(/id\s*=\s*"[0-9a-f]{32}"/, `id = "${kvId}"`);
+  }
+  writeFileSync(clientWranglerPath, clientWrangler, "utf8");
+  logSuccess("Updated cod-client/wrangler.toml with D1 and KV bindings");
+
+  // Step 6: Generate and Set Secrets
+  logStep(6, "Generating and uploading production secrets");
+  const betterAuthSecret = process.env.BETTER_AUTH_SECRET || randomBytes(32).toString("base64");
+  const storeApiKey = process.env.STORE_API_KEY || randomBytes(16).toString("hex");
+
+  // Put secret to cod-server
+  try {
+    execSync(`echo "${betterAuthSecret}" | npx wrangler secret put BETTER_AUTH_SECRET`, {
+      cwd: resolve(repoRoot, "cod-server"),
+      stdio: "pipe",
+    });
+    logSuccess("Configured BETTER_AUTH_SECRET on cod-server");
+  } catch (e) {
+    console.warn("  Could not put secret to cod-server:", e.message);
+  }
+
+  // Put secret to cod-client
+  try {
+    execSync(`echo "${betterAuthSecret}" | npx wrangler secret put BETTER_AUTH_SECRET`, {
+      cwd: resolve(repoRoot, "cod-client"),
+      stdio: "pipe",
+    });
+    logSuccess("Configured BETTER_AUTH_SECRET on cod-client");
+  } catch (e) {
+    console.warn("  Could not put secret to cod-client:", e.message);
+  }
+
+  // Put secret to cod-astro/theme01
+  try {
+    execSync(`echo "${storeApiKey}" | npx wrangler secret put STORE_API_KEY`, {
+      cwd: resolve(repoRoot, "cod-astro/theme01"),
+      stdio: "pipe",
+    });
+    logSuccess("Configured STORE_API_KEY on cod-astro/theme01");
+  } catch (e) {
+    console.warn("  Could not put secret to cod-astro/theme01:", e.message);
+  }
+
+  // Step 7: Apply remote D1 migrations
+  logStep(7, "Applying migrations to remote D1 database");
+  run("npm run db:migrate:remote", resolve(repoRoot, "cod-server"));
+  logSuccess("Applied all schema migrations to remote D1");
+
+  // Step 8: Seed remote admin account
+  logStep(8, "Creating remote admin account");
+  const adminEmail = process.env.ADMIN_EMAIL || "admin@example.com";
+  const adminName = process.env.ADMIN_NAME || "Admin";
+  const adminPassword = process.env.ADMIN_PASSWORD || randomBytes(9).toString("base64url");
+
+  const seedAdminRemoteCmd = `ADMIN_EMAIL="${adminEmail}" ADMIN_NAME="${adminName}" node scripts/seed-admin.mjs "${adminPassword}" --remote`;
+  run(seedAdminRemoteCmd, resolve(repoRoot, "cod-client"));
+  logSuccess("Seeded admin user to remote D1");
+
+  // Step 9: Summary & Next Steps
+  console.log("\n╔══════════════════════════════════════════════════════════╗");
+  console.log("║         Cloudflare Resource Provisioning Complete!       ║");
+  console.log("╠══════════════════════════════════════════════════════════╣");
+  console.log(`║  D1 Database ID: ${databaseId.padEnd(39)} ║`);
+  console.log(`║  R2 Bucket     : ${bucketName.padEnd(39)} ║`);
+  console.log(`║  Admin Email   : ${adminEmail.padEnd(39)} ║`);
+  console.log(`║  Admin Pass    : ${adminPassword.padEnd(39)} ║`);
+  console.log(`║  Store API Key : ${storeApiKey.padEnd(39)} ║`);
+  console.log("╚══════════════════════════════════════════════════════════╝");
+  console.log("\nTo deploy the applications to Cloudflare Workers:\n");
+  console.log("  1. cd cod-server && npm run deploy");
+  console.log("  2. cd cod-client && npm run deploy");
+  console.log("  3. cd cod-astro/theme01 && npm run deploy\n");
+}
+
+main().catch((err) => {
+  console.error("\n❌ Remote setup failed:", err.message);
+  process.exit(1);
+});

--- a/.opencode/skills/codflow-setup/scripts/setup-local.mjs
+++ b/.opencode/skills/codflow-setup/scripts/setup-local.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * CodFlow Automated Local Setup Script
+ *
+ * Automates:
+ * 1. Dependency verification & installation order
+ * 2. .dev.vars generation with cryptographic secrets
+ * 3. Local D1 database migrations (shared state in .wrangler-shared)
+ * 4. Sample store and product seeding
+ * 5. Admin user creation
+ *
+ * Usage:
+ *   node scripts/setup-local.mjs
+ *   ADMIN_EMAIL=me@store.dz ADMIN_NAME="Store Owner" node scripts/setup-local.mjs
+ */
+
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function findRepoRoot(startDir) {
+  let dir = startDir;
+  while (dir !== dirname(dir)) {
+    if (existsSync(resolve(dir, "cod-server")) && existsSync(resolve(dir, "cod-client"))) {
+      return dir;
+    }
+    dir = dirname(dir);
+  }
+  return process.cwd();
+}
+
+const repoRoot = findRepoRoot(__dirname);
+
+function logStep(step, message) {
+  console.log(`\n\x1b[1m\x1b[36m[Step ${step}]\x1b[0m \x1b[1m${message}\x1b[0m`);
+}
+
+function logSuccess(message) {
+  console.log(`  \x1b[32m✓\x1b[0m ${message}`);
+}
+
+function run(cmd, cwd = repoRoot) {
+  return execSync(cmd, { cwd, stdio: "inherit" });
+}
+
+async function main() {
+  console.log("\n╔══════════════════════════════════════════════════════════╗");
+  console.log("║         CodFlow Local Environment Automated Setup        ║");
+  console.log("╚══════════════════════════════════════════════════════════╝");
+
+  // Step 1: Check Node & dependencies
+  logStep(1, "Checking package dependencies");
+  const packages = [
+    { name: "cod-shared", dir: resolve(repoRoot, "cod-shared") },
+    { name: "cod-server", dir: resolve(repoRoot, "cod-server") },
+    { name: "cod-client", dir: resolve(repoRoot, "cod-client") },
+    { name: "cod-astro/theme01", dir: resolve(repoRoot, "cod-astro/theme01") },
+  ];
+
+  for (const pkg of packages) {
+    if (!existsSync(resolve(pkg.dir, "node_modules"))) {
+      console.log(`  Installing dependencies in ${pkg.name}...`);
+      run("npm install", pkg.dir);
+      logSuccess(`Installed ${pkg.name} dependencies`);
+    } else {
+      logSuccess(`${pkg.name} dependencies ready`);
+    }
+  }
+
+  // Step 2: Configure .dev.vars across packages
+  logStep(2, "Configuring local environment files (.dev.vars)");
+
+  // 2a. cod-server .dev.vars
+  const serverDevVarsPath = resolve(repoRoot, "cod-server/.dev.vars");
+  if (!existsSync(serverDevVarsPath)) {
+    const serverDevVars = `# Local development secrets for cod-server
+STORE_API_KEY=codflow-dev-store-key
+ENVIRONMENT=development
+WORKER_URL=http://localhost:8787
+WORKER_SELF_URL=http://localhost:8787/
+BETTER_AUTH_URL=http://localhost:3000/api/auth
+MEDIA_DOMAIN=media.example.com
+R2_BUCKET_NAME=codflow-images
+ALLOWED_ORIGINS=*
+`;
+    writeFileSync(serverDevVarsPath, serverDevVars, "utf8");
+    logSuccess("Created cod-server/.dev.vars");
+  } else {
+    logSuccess("cod-server/.dev.vars exists");
+  }
+
+  // 2b. cod-client .dev.vars
+  const clientDevVarsPath = resolve(repoRoot, "cod-client/.dev.vars");
+  let betterAuthSecret = randomBytes(32).toString("base64");
+  if (!existsSync(clientDevVarsPath)) {
+    const clientDevVars = `# Local development secrets for cod-client
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_WORKER_URL=http://localhost:8787
+BETTER_AUTH_SECRET=${betterAuthSecret}
+`;
+    writeFileSync(clientDevVarsPath, clientDevVars, "utf8");
+    logSuccess("Created cod-client/.dev.vars with generated BETTER_AUTH_SECRET");
+  } else {
+    const existingContent = readFileSync(clientDevVarsPath, "utf8");
+    const match = existingContent.match(/^BETTER_AUTH_SECRET=(.+)$/m);
+    if (match && match[1].trim()) {
+      betterAuthSecret = match[1].trim();
+    }
+    logSuccess("cod-client/.dev.vars exists");
+  }
+
+  // 2c. cod-astro/theme01 .dev.vars
+  const astroDevVarsPath = resolve(repoRoot, "cod-astro/theme01/.dev.vars");
+  if (!existsSync(astroDevVarsPath)) {
+    const astroDevVars = `# Local development secrets for cod-astro storefront
+STORE_API_KEY=codflow-dev-store-key
+COD_SERVER_URL=http://localhost:8787
+`;
+    writeFileSync(astroDevVarsPath, astroDevVars, "utf8");
+    logSuccess("Created cod-astro/theme01/.dev.vars");
+  } else {
+    logSuccess("cod-astro/theme01/.dev.vars exists");
+  }
+
+  // Step 3: Run local D1 migrations and seed demo store
+  logStep(3, "Applying local database migrations & seeding sample products");
+  run("npm run db:setup:local", resolve(repoRoot, "cod-server"));
+  logSuccess("Applied migrations and seeded store-local-dev to .wrangler-shared");
+
+  // Step 4: Seed admin user
+  logStep(4, "Creating local admin account");
+  const email = process.env.ADMIN_EMAIL ?? "admin@example.com";
+  const name = process.env.ADMIN_NAME ?? "Admin";
+  const password = process.env.ADMIN_PASSWORD ?? randomBytes(9).toString("base64url");
+
+  const seedAdminCmd = `ADMIN_EMAIL="${email}" ADMIN_NAME="${name}" node scripts/seed-admin.mjs "${password}"`;
+  run(seedAdminCmd, resolve(repoRoot, "cod-client"));
+  logSuccess("Admin account created successfully");
+
+  // Step 5: Summary
+  console.log("\n╔══════════════════════════════════════════════════════════╗");
+  console.log("║                 Local Setup Complete!                    ║");
+  console.log("╠══════════════════════════════════════════════════════════╣");
+  console.log("║  Backend API   : http://localhost:8787                   ║");
+  console.log("║  Swagger Docs  : http://localhost:8787/api/docs          ║");
+  console.log("║  OpenAPI Spec  : http://localhost:8787/api/openapi.json  ║");
+  console.log("║  Dashboard UI  : http://localhost:3000                   ║");
+  console.log("║  Storefront    : http://localhost:4321                   ║");
+  console.log("╠══════════════════════════════════════════════════════════╣");
+  console.log(`║  Admin Email   : ${email.padEnd(39)} ║`);
+  console.log(`║  Admin Pass    : ${password.padEnd(39)} ║`);
+  console.log("╚══════════════════════════════════════════════════════════╝");
+  console.log("\nTo start all services, open three terminals:\n");
+  console.log("  Terminal 1: cd cod-server && npm run dev");
+  console.log("  Terminal 2: cd cod-client && npm run dev");
+  console.log("  Terminal 3: cd cod-astro/theme01 && npm run dev\n");
+}
+
+main().catch((err) => {
+  console.error("\n❌ Setup failed:", err.message);
+  process.exit(1);
+});

--- a/cod-client/scripts/seed-admin.mjs
+++ b/cod-client/scripts/seed-admin.mjs
@@ -93,7 +93,7 @@ WHERE account_id = '${email}' AND provider_id = 'credential';
 
   try {
     console.log("\n=== Seeding admin (local) ===");
-    run(`npx wrangler d1 execute codflow-db --local --file "${tmpFile}"`);
+    run(`npx wrangler d1 execute codflow-db --local --persist-to ../.wrangler-shared --file "${tmpFile}"`);
 
     if (remote) {
       console.log("\n=== Seeding admin (remote) ===");


### PR DESCRIPTION
## Summary
- Added `codflow-setup` skill to `.agents/skills/` and `.opencode/skills/` for autonomous setup by AI agents and developers.
- Added `setup-local.mjs` script: one-command local environment setup (dependency check, `.dev.vars` generation, D1 migrations to `.wrangler-shared`, demo store seeding, and admin user creation).
- Added `setup-cloudflare.mjs` script: automated remote Cloudflare resource provisioning (D1, R2, KV), secret generation/upload, remote migrations, and admin seeding.
- Added Cloudflare authentication guidance (`npx wrangler login`) and R2 activation/card-on-file prerequisite details.
- Fixed `cod-client/scripts/seed-admin.mjs` to include `--persist-to ../.wrangler-shared` for local D1 execution.

## Verification
- `setup-local.mjs` tested and validated end-to-end.
- Tests passing:
  - cod-server: 745/745 tests passing + typecheck clean
  - cod-client: 141/141 tests passing + typecheck clean
  - cod-astro: 6/6 tests passing + build clean