### PR TITLE
docs: reference codflow-setup skill and automated setup in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,12 +84,31 @@ New here? Here's the shortest path to a merged change:
 > The repo's `.nvmrc` pins Node 24; CI runs Node 24. Astro 7 (the storefront)
 > requires Node 22.12+.
 
-### 1. Install
+### ⚡ Fast Track: Automated Setup (AI Agents & Contributors)
+
+You can bootstrap the entire local environment in **one command**:
 
 ```bash
-cd cod-server        && npm install
+# Automated setup (installs deps in order, generates .dev.vars, migrates D1, seeds store & admin)
+node .agents/skills/codflow-setup/scripts/setup-local.mjs
+```
+
+> 🤖 **Working with an AI Coding Assistant?** CodFlow includes an autonomous setup skill. Instruct your agent: *"Set up CodFlow locally"* and it will follow the [`codflow-setup` runbook](./.agents/skills/codflow-setup/SKILL.md).
+
+---
+
+### Manual Setup Step-by-Step
+
+#### 1. Install Dependencies (in order)
+
+`cod-shared` MUST be installed first because other packages resolve its dependencies:
+
+```bash
+cd cod-shared        && npm install
+cd ../cod-server     && npm install
 cd ../cod-client     && npm install
 cd ../cod-astro/theme01 && npm install
+cd ../..
 ```
 
 ### 2. Create Cloudflare resources

--- a/README.md
+++ b/README.md
@@ -189,22 +189,38 @@ Deploy CodFlow to your own Cloudflare account in minutes. Your customer records,
 
 Run the full platform locally — storefront, merchant dashboard, and backend sharing a single local D1 database.
 
-### 0. Prerequisites
+### ⚡ Fast Track: Automated Setup (AI Agents & Developers)
+
+You can bootstrap the entire local environment in **one command**:
+
+```bash
+# Automated setup (installs deps, generates .dev.vars, runs migrations, seeds store & admin)
+node .agents/skills/codflow-setup/scripts/setup-local.mjs
+```
+
+> 🤖 **Using an AI Coding Assistant?** CodFlow includes an autonomous setup skill. Tell your agent: *"Set up CodFlow locally"* and it will follow the [`codflow-setup` runbook](./.agents/skills/codflow-setup/SKILL.md).
+
+---
+
+### Manual Step-by-Step Setup
+
+#### 0. Prerequisites
 - **Node.js 22.12+** and npm
 - **Wrangler CLI**: `npm install -g wrangler`
 - A free **Cloudflare account** (for D1, R2, KV bindings)
 
-### 1. Clone & Install Dependencies
+#### 1. Clone & Install Dependencies
 
 ```bash
 git clone https://github.com/bighadj22/codflow.git
 cd codflow
 
-# Install each package (isolated lockfiles)
+# Install each package (isolated lockfiles — cod-shared MUST be first)
 cd cod-shared && npm install
 cd ../cod-server && npm install
 cd ../cod-client && npm install
 cd ../cod-astro/theme01 && npm install
+cd ../..
 ```
 
 ### 2. Create Cloudflare Resources
@@ -325,6 +341,7 @@ cd ../cod-client && npm run typecheck
 
 - **[`CONTRIBUTING.md`](./CONTRIBUTING.md)** — Guide on development standards, PR workflows, and branch conventions.
 - **[`AGENTS.md`](./AGENTS.md)** — Repository instructions and architectural rules for AI coding assistants.
+- **[`codflow-setup` Skill](./.agents/skills/codflow-setup/SKILL.md)** — Autonomous setup and Cloudflare provisioning runbook for AI agents and developers.
 - **[`cod-astro/theme01/THEME_GUIDE.md`](./cod-astro/theme01/THEME_GUIDE.md)** — Storefront customization and theming guide.
 - **[`SECURITY.md`](./SECURITY.md)** — Security policies and vulnerability reporting procedures.
 - **[`CHANGELOG.md`](./CHANGELOG.md)** — Detailed version history and upgrade notes.


### PR DESCRIPTION
## Summary
- Added **⚡ Fast Track: Automated Setup** section to `README.md` and `CONTRIBUTING.md` with the one-command setup:
  ```bash
  node .agents/skills/codflow-setup/scripts/setup-local.mjs
  ```
- Added AI assistant callouts linking to the [`codflow-setup` runbook](.agents/skills/codflow-setup/SKILL.md).
- Added `codflow-setup` skill to the **Documentation & Resources** list in `README.md`.
- Fixed manual dependency installation sequence in `CONTRIBUTING.md` to ensure `cod-shared` is installed first.

## Verification
- All links verified.
- Tests & typechecks green.