### PR TITLE
docs: add video setup guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 
 **The open-source, COD-first e-commerce + delivery platform for Algeria — built agentic-ready.**
 
+## 📺 Video Setup Guide
+
+Watch the complete setup walkthrough to get CodFlow deployed to Cloudflare in minutes:
+
+[![CodFlow Setup Guide](https://img.youtube.com/vi/rJPCGQnDZ18/maxresdefault.jpg)](https://youtu.be/rJPCGQnDZ18)
+
+**[▶️ Watch: CodFlow Setup & Deployment Guide](https://youtu.be/rJPCGQnDZ18)**
+
+---
+
 CodFlow is a self-hosted commerce engine, merchant dashboard, and high-performance storefront designed specifically for the realities of **Cash on Delivery** (COD) in Algeria and emerging markets. It runs entirely on your own Cloudflare serverless account (Workers + D1 + R2 + KV) with **zero transaction fees**, connects to Algeria's major delivery carriers, and feeds **actual cash deliveries** back to Meta Ads so your ad algorithms stop burning budget on door refusals.
 
 ```


### PR DESCRIPTION
## Summary

Adds the YouTube video setup guide to the README in the first section, right after the banner and version info.

## Changes

- Added new "📺 Video Setup Guide" section with embedded video thumbnail
- Video link: https://youtu.be/rJPCGQnDZ18
- Positioned prominently at the top for immediate visibility

## Preview

The video section includes:
- Clickable thumbnail from YouTube
- Direct text link to the video
- Clear call-to-action for new users

This helps users quickly get started with CodFlow by watching the complete setup walkthrough before diving into written documentation.