### PR TITLE
refactor(products): migrate routes to defineRoute()

### DIFF
--- a/cod-server/src/endpoints/README.md
+++ b/cod-server/src/endpoints/README.md
@@ -1,51 +1,61 @@
 # Endpoints Directory
 
-Each subdirectory is one API domain. Migration status below tracks the
-conversion from hand-written OpenAPI (`openapi.ts` + legacy generator) to
-auto-generated specs via `@hono/zod-openapi`. Full details and per-endpoint
-notes live in `cod-server/MIGRATION_STATUS.md`.
+Each subdirectory is one API domain. The standard pattern for all routes is
+`defineRoute()` from `@/lib/route-builder`. Two endpoints have completed this
+migration; the rest still use raw `createRoute()` from `@hono/zod-openapi` and
+are pending conversion.
 
-## Migrated to @hono/zod-openapi ✅
+---
+
+## Migration status
+
+### Done — using `defineRoute()` ✅
+
+| Domain | Routes |
+|--------|--------|
+| `wilayas` | 2 |
+| `orders` | 17 |
+| `products` | 15 |
+
+### Pending — still using `createRoute()` ⏳
+
+These endpoints are fully on `@hono/zod-openapi` (validation + spec generation
+works), but have not been converted to `defineRoute()` yet. Convert one at a
+time following `MIGRATION.md` in `.agents/skills/route-builder/`.
 
 | Domain | Routes | Notes |
-|---|---|---|
-| `wilayas` | 2 | Pilot endpoint |
-| `activity-logs` | 2 | Admin-only |
-| `delivery-companies` | 13 | CRUD + stop-desks + webhook config |
-| `reviews` | 3 | Moderation, RBAC |
+|--------|--------|-------|
+| `abandoned-orders` | 6 | Dashboard CRUD/stats + storefront upsert/convert |
+| `activity-logs` | 2 | Admin-only read |
+| `analytics` | 1 | Dashboard status-count stats |
 | `customer-groups` | 7 | Segments + member management |
 | `customer-tags` | 7 | Tags + assignment management |
-| `product-groups` | 5 | Category tree CRUD; delete blocked with `422 PRODUCT_GROUP_HAS_PRODUCTS`; completed 2026-08-21 |
-| `customers` | 8 | CRUD + orders/groups/tags lookups; granular scopes (`customers:read/create/update/delete`); completed 2026-08-21 |
-| `shipping-profiles` | 10 | Rate cards + wilaya rules + commune overrides; delete guards (`PROFILE_IN_USE`, `DEFAULT_PROFILE_REQUIRED`); completed 2026-08-21 |
-| `drivers` | 8 | Driver CRUD + status + per-wilaya compensations; delete guard (`409 DRIVER_HAS_ACTIVE_ORDERS`); completed 2026-08-21 |
-| `users` | 8 | Team management + scopes + API-key rotation; admin-only (`requireAdmin`); one-time key reveals; completed 2026-08-21 |
-| `stores` | 4 | Store settings + Meta pixel config; admin-only; completed 2026-08-21 |
-| `products` | 15 | Product CRUD + nested images (R2 association, full-set reorder) + variants; `409 DUPLICATE_SKU`, `422 PRODUCT_HAS_ORDERS`; SKU required for simple products; completed 2026-08-21 |
+| `customers` | 8 | CRUD + orders/groups/tags lookups |
+| `delivery-companies` | 13 | CRUD + stop-desks + webhook config |
+| `driver-payments` | 3 | Payment create + history + pending settlement |
+| `drivers` | 8 | Driver CRUD + status + per-wilaya compensations |
+| `images` | 3 | Upload + presign + public serve (plain-Hono exception, see below) |
+| `offers` | 5 | Promotional offer CRUD |
+| `product-groups` | 5 | Category tree CRUD |
+| `reviews` | 3 | Moderation + RBAC |
+| `shipping-profiles` | 10 | Rate cards + wilaya rules + commune overrides |
+| `stock` | 7 | Inventory adjustments, history, thresholds (two sub-routers) |
+| `store` | 9 | Public storefront surface behind X-Store-API-Key |
+| `stores` | 4 | Store settings + Meta pixel config |
+| `users` | 8 | Team management + scopes + API-key rotation |
+| `webhooks` | 3 | Public receivers — no body validation (raw-byte signature contract) |
 
-| `driver-payments` | 3 | Payment create + history + pending settlement; `422 ORDER_NOT_FOUND` / `PAYMENT_ALREADY_SETTLED`; completed 2026-08-21 |
-| `images` | 2+1 | Upload + presign generated (`products:manage`, multipart); public `/images/{key}` serve stays plain-Hono + legacy stub (regex param) — exception documented; completed 2026-08-21 |
-| `orders` | 17 | Full COD lifecycle CRUD + driver/company dispatch (single+bulk) + shipment ops; transition guard (`INVALID_STATUS_TRANSITION`); 11-status enum now typed in cod-shared; completed 2026-08-21 |
-| `webhooks` | 3 | Public receivers (Yalidine CRC/events, ZR Svix); no body validation — raw-byte signature contract documented; completed 2026-08-21 |
-| `abandoned-orders` | 6 | Dashboard recovery CRUD/stats + storefront upsert/convert (StoreAuth); previously undocumented entirely — now fully specified; completed 2026-08-21 |
-| `store` | 9 | Public storefront catalog/order/review surface behind X-Store-API-Key; list-vs-detail product shapes; completed 2026-08-21 |
+---
 
-| `analytics` | 1 | Dashboard status-count stats (`dashboard:view`); previously undocumented — now specified; completed 2026-08-21 |
+## Special cases
 
-## Pending migration ⏳
+- `variants/` — no `routes.ts`; handlers are mounted directly inside `products/routes.ts`.
+- `mcp/` — MCP server surface, not part of the REST API.
+- `images/{key}` public serve — stays plain-Hono (regex param); the `createRoute` documentation stub for it is intentional.
 
-**None.** 🎉 The @hono/zod-openapi migration is complete (2026-08-21).
-Legacy `generator.ts` + `paths.ts` are retired; `/api/openapi.json` is purely
-generated from route definitions. The only hand-written entry left in the spec
-is the `/images/{key}` documentation stub (plain-Hono regex-param exception).
+---
 
-Next up: nothing to migrate. New endpoints are born migrated — define routes
-with `@hono/zod-openapi` and their docs generate themselves.
+## Summary
 
-## Special
-
-- `mcp` — MCP server surface, not part of the REST API migration.
-
-## Progress
-
-**23/23 endpoints migrated (100%)** · legacy generator + paths aggregation retired
+**3 / 22 domains on `defineRoute()` (14%)**
+19 domains still on `createRoute()` — fully functional, pending conversion.

--- a/cod-server/src/endpoints/products/routes.ts
+++ b/cod-server/src/endpoints/products/routes.ts
@@ -1,18 +1,6 @@
-/**
- * Products Routes
- *
- * Product CRUD + nested image management + variant management under
- * /api/products. Image and variant handlers live in their own domain
- * directories and are mounted here because they share the path prefix.
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
- */
-
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import * as h from "./handlers";
 import * as vh from "../variants/handlers";
@@ -28,18 +16,12 @@ import {
   ProductSchema,
   ProductImageSchema,
   ProductVariantSchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
   ListResponseSchema,
 } from "@/openapi/schemas";
 
 const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
-});
-
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
 });
 
 const idParams = z.object({
@@ -60,183 +42,56 @@ const imageIdParams = idParams.extend({
 
 // ─── Products ─────────────────────────────────────────────────────────────────
 
-const listProductsRoute = createRoute({
+const listProductsRoute = defineRoute({
   method: "get",
   path: "/",
-  middleware: [requireScope(SCOPES.PRODUCTS_READ)],
+  auth: { scope: SCOPES.PRODUCTS_READ },
   tags: ["Products"],
   summary: "List products",
   description:
     "Returns a paginated list of products. Soft-deleted products are never returned. Each item includes `variantsCount`, `totalInventory`, `primaryImageSrc`, and `variants` array.",
   operationId: "listProducts",
-  request: {
-    query: productFiltersSchema,
-  },
+  query: productFiltersSchema,
   responses: {
     200: {
       description: "List of products",
       content: jsonContent(ListResponseSchema(ProductSchema)),
     },
-    400: errorResponse("Invalid filter value e.g. unknown status (VALIDATION_FAILED)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.listProducts,
 });
 
-const createProductRoute = createRoute({
+const createProductRoute = defineRoute({
   method: "post",
   path: "/",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
   tags: ["Products"],
   summary: "Create product",
   description:
     "Creates a product. SKU rules: simple products (`hasVariants=false`, the default) must include `sku`. Variant products (`hasVariants=true`) must omit `sku` here — set it on each variant instead. Returns the full product record including empty `variants` and `images` arrays.",
   operationId: "createProduct",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(createProductSchema),
-    },
-  },
+  body: createProductSchema,
   responses: {
     201: {
       description: "Product created",
       content: jsonContent(SuccessResponseSchema(ProductSchema)),
     },
-    400: errorResponse("Validation error"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:manage scope"),
-    409: errorResponse("Duplicate SKU (DUPLICATE_SKU)"),
+    409: { description: "Duplicate SKU (DUPLICATE_SKU)" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.createProduct,
 });
 
-const getProductRoute = createRoute({
-  method: "get",
-  path: "/{id}",
-  middleware: [requireScope(SCOPES.PRODUCTS_READ)],
-  tags: ["Products"],
-  summary: "Get product",
-  description:
-    "Returns full product detail including `category`, `variants`, and `images`.",
-  operationId: "getProduct",
-  request: {
-    params: idParams,
-  },
-  responses: {
-    200: {
-      description: "Product detail",
-      content: jsonContent(SuccessResponseSchema(ProductSchema)),
-    },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:read scope"),
-    404: errorResponse("Product not found (PRODUCT_NOT_FOUND)"),
-  },
-  security: [{ ApiKeyAuth: [] }],
-});
+// ─── Product images (registered before /{id} to avoid param capture) ──────────
 
-const updateProductRoute = createRoute({
-  method: "patch",
-  path: "/{id}",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
-  tags: ["Products"],
-  summary: "Update product",
-  description:
-    "Partial update — only include fields you want to change. Setting `status` to `ACTIVE` auto-sets `publishedAt`. Send `variantOptions: null` to clear all variant options when converting a variant product to simple.",
-  operationId: "updateProduct",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: jsonContent(updateProductSchema),
-    },
-  },
-  responses: {
-    200: {
-      description: "Product updated. Returns full updated product record.",
-      content: jsonContent(SuccessResponseSchema(ProductSchema)),
-    },
-    400: errorResponse("Validation error"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:manage scope"),
-    404: errorResponse("Product not found (PRODUCT_NOT_FOUND)"),
-  },
-  security: [{ ApiKeyAuth: [] }],
-});
-
-const updateProductStatusRoute = createRoute({
-  method: "patch",
-  path: "/{id}/status",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
-  tags: ["Products"],
-  summary: "Update product status",
-  description:
-    "Dedicated endpoint for status-only updates. Setting `ACTIVE` auto-sets `publishedAt`.",
-  operationId: "updateProductStatus",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: jsonContent(updateStatusSchema),
-    },
-  },
-  responses: {
-    200: {
-      description: "Status updated. Returns full updated product record.",
-      content: jsonContent(SuccessResponseSchema(ProductSchema)),
-    },
-    400: errorResponse("Validation error (invalid status value)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:manage scope"),
-    404: errorResponse("Product not found (PRODUCT_NOT_FOUND)"),
-  },
-  security: [{ ApiKeyAuth: [] }],
-});
-
-const deleteProductRoute = createRoute({
-  method: "delete",
-  path: "/{id}",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
-  tags: ["Products"],
-  summary: "Delete product",
-  description:
-    "Soft-deletes the product by setting `deletedAt`. The product is excluded from all list and detail responses. Returns 422 if the product has existing orders (PRODUCT_HAS_ORDERS).",
-  operationId: "deleteProduct",
-  request: {
-    params: idParams,
-  },
-  responses: {
-    200: {
-      description: "Product deleted",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          message: z.string().openapi({ example: "Product deleted" }),
-        })
-      ),
-    },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:manage scope"),
-    404: errorResponse("Product not found (PRODUCT_NOT_FOUND)"),
-    422: errorResponse("Cannot delete product with existing orders (PRODUCT_HAS_ORDERS)"),
-  },
-  security: [{ ApiKeyAuth: [] }],
-});
-
-// ─── Product images ───────────────────────────────────────────────────────────
-
-const listProductImagesRoute = createRoute({
+const listProductImagesRoute = defineRoute({
   method: "get",
   path: "/{id}/images",
-  middleware: [requireScope(SCOPES.PRODUCTS_READ)],
+  auth: { scope: SCOPES.PRODUCTS_READ },
   tags: ["Products"],
   summary: "List product images",
   description: "Returns all images for a product ordered by position.",
   operationId: "listProductImages",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "List of product images ordered by position",
@@ -247,82 +102,63 @@ const listProductImagesRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: ih.listProductImages,
 });
 
-const saveProductImageRoute = createRoute({
+const saveProductImageRoute = defineRoute({
   method: "post",
   path: "/{id}/images",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
   tags: ["Products"],
   summary: "Save product image",
   description:
     "Associates an already-uploaded R2 image with a product. Upload the file first via POST /api/images/upload, then call this endpoint with the returned `key` and `url`.",
   operationId: "saveProductImage",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          key: z.string().min(1).openapi({
-            description: "R2 object key returned by the upload endpoint",
-            example: "products/abc123def456.jpg",
-          }),
-          src: z.string().min(1).openapi({
-            format: "uri",
-            description: "Public URL of the image",
-            example: "https://cdn.example.com/products/abc123.jpg",
-          }),
-          altText: z.string().nullable().optional().openapi({
-            description: "Alt text for accessibility",
-          }),
-          position: z.number().int().min(1).optional().openapi({
-            description: "Display order (auto-appended at end if not provided)",
-          }),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: z.object({
+    key: z.string().min(1).openapi({
+      description: "R2 object key returned by the upload endpoint",
+      example: "products/abc123def456.jpg",
+    }),
+    src: z.string().min(1).openapi({
+      format: "uri",
+      description: "Public URL of the image",
+      example: "https://cdn.example.com/products/abc123.jpg",
+    }),
+    altText: z.string().nullable().optional().openapi({
+      description: "Alt text for accessibility",
+    }),
+    position: z.number().int().min(1).optional().openapi({
+      description: "Display order (auto-appended at end if not provided)",
+    }),
+  }),
   responses: {
     201: {
       description: "Image record created",
       content: jsonContent(SuccessResponseSchema(ProductImageSchema)),
     },
-    400: errorResponse("Missing key or src"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:manage scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: ih.saveProductImage,
 });
 
-const reorderProductImagesRoute = createRoute({
+const reorderProductImagesRoute = defineRoute({
   method: "patch",
   path: "/{id}/images/reorder",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
   tags: ["Products"],
   summary: "Reorder product images",
   description:
     "Sets the display order of a product's images. Send the complete ordered array of image IDs — every existing image ID must be included exactly once. The server assigns position 1, 2, 3… based on the array order. Returns the full reordered image list.",
   operationId: "reorderProductImages",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          imageIds: z.array(z.string()).min(1).openapi({
-            description:
-              "Complete ordered list of all image IDs for this product. All existing image IDs must be included — no duplicates, no omissions.",
-            example: ["uuid-b", "uuid-a", "uuid-c"],
-          }),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: z.object({
+    imageIds: z.array(z.string()).min(1).openapi({
+      description:
+        "Complete ordered list of all image IDs for this product. All existing image IDs must be included — no duplicates, no omissions.",
+      example: ["uuid-b", "uuid-a", "uuid-c"],
+    }),
+  }),
   responses: {
     200: {
       description: "Images reordered successfully. Returns updated image list in new order.",
@@ -333,181 +169,232 @@ const reorderProductImagesRoute = createRoute({
         })
       ),
     },
-    400: errorResponse(
-      "Validation error — empty array, duplicate IDs, image IDs that don't belong to this product, or incomplete set"
-    ),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:manage scope"),
+    422: { description: "Duplicate IDs, image IDs that don't belong to this product, or incomplete set" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: ih.reorderProductImages,
 });
 
-const deleteProductImageRoute = createRoute({
+const deleteProductImageRoute = defineRoute({
   method: "delete",
   path: "/{id}/images/{imageId}",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
   tags: ["Products"],
   summary: "Delete product image",
-  description:
-    "Deletes the image record from the database and removes the object from R2.",
+  description: "Deletes the image record from the database and removes the object from R2.",
   operationId: "deleteProductImage",
-  request: {
-    params: imageIdParams,
-  },
+  params: imageIdParams,
   responses: {
     200: {
       description: "Image deleted",
       content: jsonContent(z.object({ success: z.boolean().openapi({ example: true }) })),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:manage scope"),
-    404: errorResponse("Image not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: ih.deleteProductImage,
+});
+
+// ─── PATCH /{id}/status (registered before /{id} to avoid param capture) ──────
+
+const updateProductStatusRoute = defineRoute({
+  method: "patch",
+  path: "/{id}/status",
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
+  tags: ["Products"],
+  summary: "Update product status",
+  description: "Dedicated endpoint for status-only updates. Setting `ACTIVE` auto-sets `publishedAt`.",
+  operationId: "updateProductStatus",
+  params: idParams,
+  body: updateStatusSchema,
+  responses: {
+    200: {
+      description: "Status updated. Returns full updated product record.",
+      content: jsonContent(SuccessResponseSchema(ProductSchema)),
+    },
+  },
+  handler: h.updateProductStatus,
+});
+
+// ─── /{id} param routes ────────────────────────────────────────────────────────
+
+const getProductRoute = defineRoute({
+  method: "get",
+  path: "/{id}",
+  auth: { scope: SCOPES.PRODUCTS_READ },
+  tags: ["Products"],
+  summary: "Get product",
+  description: "Returns full product detail including `category`, `variants`, and `images`.",
+  operationId: "getProduct",
+  params: idParams,
+  responses: {
+    200: {
+      description: "Product detail",
+      content: jsonContent(SuccessResponseSchema(ProductSchema)),
+    },
+  },
+  handler: h.getProduct,
+});
+
+const updateProductRoute = defineRoute({
+  method: "patch",
+  path: "/{id}",
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
+  tags: ["Products"],
+  summary: "Update product",
+  description:
+    "Partial update — only include fields you want to change. Setting `status` to `ACTIVE` auto-sets `publishedAt`. Send `variantOptions: null` to clear all variant options when converting a variant product to simple.",
+  operationId: "updateProduct",
+  params: idParams,
+  body: updateProductSchema,
+  responses: {
+    200: {
+      description: "Product updated. Returns full updated product record.",
+      content: jsonContent(SuccessResponseSchema(ProductSchema)),
+    },
+  },
+  handler: h.updateProduct,
+});
+
+const deleteProductRoute = defineRoute({
+  method: "delete",
+  path: "/{id}",
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
+  tags: ["Products"],
+  summary: "Delete product",
+  description:
+    "Soft-deletes the product by setting `deletedAt`. The product is excluded from all list and detail responses. Returns 422 if the product has existing orders (PRODUCT_HAS_ORDERS).",
+  operationId: "deleteProduct",
+  params: idParams,
+  responses: {
+    200: {
+      description: "Product deleted",
+      content: jsonContent(
+        z.object({
+          success: z.boolean().openapi({ example: true }),
+          message: z.string().openapi({ example: "Product deleted" }),
+        })
+      ),
+    },
+    422: { description: "Cannot delete product with existing orders (PRODUCT_HAS_ORDERS)" },
+  },
+  handler: h.deleteProduct,
 });
 
 // ─── Variants (nested under product) ──────────────────────────────────────────
 
-const listVariantsRoute = createRoute({
+const listVariantsRoute = defineRoute({
   method: "get",
   path: "/{productId}/variants",
-  middleware: [requireScope(SCOPES.PRODUCTS_READ)],
+  auth: { scope: SCOPES.PRODUCTS_READ },
   tags: ["Products"],
   summary: "List product variants",
   description: "Returns variants ordered by position, with parsed `variations` objects.",
   operationId: "listVariants",
-  request: {
-    params: productIdParams,
-  },
+  params: productIdParams,
   responses: {
     200: {
       description: "List of variants ordered by position",
       content: jsonContent(ListResponseSchema(ProductVariantSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: vh.listVariants,
 });
 
-const createVariantRoute = createRoute({
+const createVariantRoute = defineRoute({
   method: "post",
   path: "/{productId}/variants",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
   tags: ["Products"],
   summary: "Create product variant",
   operationId: "createVariant",
-  request: {
-    params: productIdParams,
-    body: {
-      required: true,
-      content: jsonContent(createVariantSchema),
-    },
-  },
+  params: productIdParams,
+  body: createVariantSchema,
   responses: {
     201: {
       description: "Variant created",
       content: jsonContent(SuccessResponseSchema(ProductVariantSchema)),
     },
-    400: errorResponse("Validation error"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:manage scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: vh.createVariant,
 });
 
-const getVariantRoute = createRoute({
+const getVariantRoute = defineRoute({
   method: "get",
   path: "/{productId}/variants/{variantId}",
-  middleware: [requireScope(SCOPES.PRODUCTS_READ)],
+  auth: { scope: SCOPES.PRODUCTS_READ },
   tags: ["Products"],
   summary: "Get product variant",
   operationId: "getVariant",
-  request: {
-    params: variantIdParams,
-  },
+  params: variantIdParams,
   responses: {
     200: {
       description: "Variant detail",
       content: jsonContent(SuccessResponseSchema(ProductVariantSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:read scope"),
-    404: errorResponse("Variant not found (VARIANT_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: vh.getVariant,
 });
 
-const updateVariantRoute = createRoute({
+const updateVariantRoute = defineRoute({
   method: "patch",
   path: "/{productId}/variants/{variantId}",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
   tags: ["Products"],
   summary: "Update product variant",
   description: "Partial update — only include fields you want to change.",
   operationId: "updateVariant",
-  request: {
-    params: variantIdParams,
-    body: {
-      required: true,
-      content: jsonContent(updateVariantSchema),
-    },
-  },
+  params: variantIdParams,
+  body: updateVariantSchema,
   responses: {
     200: {
       description: "Variant updated",
       content: jsonContent(SuccessResponseSchema(ProductVariantSchema)),
     },
-    400: errorResponse("Validation error"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:manage scope"),
-    404: errorResponse("Variant not found (VARIANT_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: vh.updateVariant,
 });
 
-const deleteVariantRoute = createRoute({
+const deleteVariantRoute = defineRoute({
   method: "delete",
   path: "/{productId}/variants/{variantId}",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
   tags: ["Products"],
   summary: "Delete product variant",
   description:
     "Permanently deletes the variant. Any order line items referencing this variant will have their `variantId` set to null — order history is fully preserved.",
   operationId: "deleteVariant",
-  request: {
-    params: variantIdParams,
-  },
+  params: variantIdParams,
   responses: {
     200: {
       description: "Variant deleted",
       content: jsonContent(z.object({ success: z.boolean().openapi({ example: true }) })),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:manage scope"),
-    404: errorResponse("Variant not found (VARIANT_NOT_FOUND)"),
+    422: { description: "Cannot delete variant referenced by existing orders (VARIANT_HAS_ORDERS)" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: vh.deleteVariant,
 });
+
+// ─── Router ────────────────────────────────────────────────────────────────────
+// Registration order: specific paths before param-based /{id} paths
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(listProductsRoute, h.listProducts);
-router.openapi(createProductRoute, h.createProduct);
-router.openapi(getProductRoute, h.getProduct);
-router.openapi(updateProductRoute, h.updateProduct);
-router.openapi(updateProductStatusRoute, h.updateProductStatus);
-router.openapi(deleteProductRoute, h.deleteProduct);
+router.openapi(listProductsRoute.route, listProductsRoute.handler);
+router.openapi(createProductRoute.route, createProductRoute.handler);
 
-router.openapi(listProductImagesRoute, ih.listProductImages);
-router.openapi(saveProductImageRoute, ih.saveProductImage);
-router.openapi(reorderProductImagesRoute, ih.reorderProductImages);
-router.openapi(deleteProductImageRoute, ih.deleteProductImage);
+// /{id}/images and /{id}/status must come before /{id}
+router.openapi(listProductImagesRoute.route, listProductImagesRoute.handler);
+router.openapi(saveProductImageRoute.route, saveProductImageRoute.handler);
+router.openapi(reorderProductImagesRoute.route, reorderProductImagesRoute.handler);
+router.openapi(deleteProductImageRoute.route, deleteProductImageRoute.handler);
+router.openapi(updateProductStatusRoute.route, updateProductStatusRoute.handler);
 
-router.openapi(listVariantsRoute, vh.listVariants);
-router.openapi(createVariantRoute, vh.createVariant);
-router.openapi(getVariantRoute, vh.getVariant);
-router.openapi(updateVariantRoute, vh.updateVariant);
-router.openapi(deleteVariantRoute, vh.deleteVariant);
+router.openapi(getProductRoute.route, getProductRoute.handler);
+router.openapi(updateProductRoute.route, updateProductRoute.handler);
+router.openapi(deleteProductRoute.route, deleteProductRoute.handler);
+
+router.openapi(listVariantsRoute.route, listVariantsRoute.handler);
+router.openapi(createVariantRoute.route, createVariantRoute.handler);
+router.openapi(getVariantRoute.route, getVariantRoute.handler);
+router.openapi(updateVariantRoute.route, updateVariantRoute.handler);
+router.openapi(deleteVariantRoute.route, deleteVariantRoute.handler);
 
 export default router;


### PR DESCRIPTION
## Changes

- Converts all 15 product routes from `createRoute()` to `defineRoute()`
- Fixes route registration order: `/{id}/images`, `/{id}/images/reorder`, `/{id}/images/{imageId}`, and `/{id}/status` now registered before `/{id}`
- Updates `endpoints/README.md` to accurately reflect which domains have been migrated to `defineRoute()` and which are still pending

## Tests

1104 tests pass, typecheck clean.