### PR TITLE
chore: gitignore wrangler.toml, add examples, update setup skill

### DIFF
--- a/.agents/skills/codflow-setup/SKILL.md
+++ b/.agents/skills/codflow-setup/SKILL.md
@@ -114,6 +114,11 @@ Rules:
 
 ## Step 3 — Bind Real IDs into BOTH wrangler.toml Files
 
+```bash
+cp cod-server/wrangler.toml.example cod-server/wrangler.toml
+cp cod-client/wrangler.toml.example cod-client/wrangler.toml
+```
+
 Files: `cod-server/wrangler.toml` **and** `cod-client/wrangler.toml`.
 
 - `[[d1_databases]]`: set `database_id` (same database in both files).
@@ -144,6 +149,16 @@ name remain:
 grep -r "codflow-db" --exclude-dir=node_modules --exclude-dir=.git
 # expected: only documentation files, zero script/config hits
 ```
+
+Confirm the filled `wrangler.toml` files are not tracked by git:
+
+```bash
+git status cod-server/wrangler.toml cod-client/wrangler.toml
+# expected: nothing listed (both ignored)
+```
+
+If either file appears in `git status`, stop — the `.gitignore` is not applied
+correctly. Do not continue until both are untracked.
 
 While editing, also replace the example domains in `[vars]` /
 `[env.production.vars]` (`WORKER_URL`, `BETTER_AUTH_URL`, `WORKER_SELF_URL`,

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ cod-shared/node_modules/
 # Wrangler
 .wrangler/
 .wrangler-shared/
+# Real wrangler configs contain live resource IDs — never commit them.
+# Copy wrangler.toml.example → wrangler.toml and fill in your own IDs.
+cod-server/wrangler.toml
+cod-client/wrangler.toml
 
 # OS
 .DS_Store

--- a/cod-client/wrangler.toml.example
+++ b/cod-client/wrangler.toml.example
@@ -1,0 +1,52 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# CodFlow dashboard (cod-client) — Cloudflare Worker configuration
+#
+# Every value below is a placeholder you must replace with your own resources.
+# Nothing in this repo depends on a specific Cloudflare account or domain.
+# See README.md → Quick Start.
+#
+#   wrangler d1 create codflow-db            → database_id
+#   wrangler kv namespace create RATE_LIMIT_KV → id
+#   wrangler secret put BETTER_AUTH_SECRET
+#   wrangler deploy
+# ─────────────────────────────────────────────────────────────────────────────
+
+name = "codflow-main"
+main = ".open-next/worker.js"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat", "global_fetch_strictly_public"]
+keep_names = false
+
+assets = { directory = ".open-next/assets", binding = "ASSETS" }
+
+[[d1_databases]]
+binding           = "DB"
+database_name     = "codflow-db"
+# Replace with the id from `wrangler d1 create codflow-db` (shared with cod-server).
+database_id       = "00000000-0000-0000-0000-000000000000"
+# Migrations are single-sourced in cod-server/src/db/migrations — this Worker
+# binds the same database but owns no migrations (see cod-client README).
+
+[[send_email]]
+name = "SEND_EMAIL"
+
+[[kv_namespaces]]
+binding = "RATE_LIMIT_KV"
+# Replace with the id from `wrangler kv namespace create RATE_LIMIT_KV`.
+id = "00000000000000000000000000000000"
+
+[vars]
+# Public URL of this dashboard app. Used as Better Auth's base URL and as the
+# sender domain for transactional email (no-reply@{your-domain}).
+#   Local: http://localhost:3000
+#   Prod:  https://app.yourdomain.com
+NEXT_PUBLIC_APP_URL = "http://localhost:3000"
+# Public URL of the cod-server API Worker (used as the MCP audience claim).
+#   Local: http://localhost:8787
+#   Prod:  https://api.yourdomain.com
+NEXT_PUBLIC_WORKER_URL = "http://localhost:8787"
+# BETTER_AUTH_SECRET is a secret — set it via:
+#   wrangler secret put BETTER_AUTH_SECRET
+
+[dev]
+port = 8788

--- a/cod-server/wrangler.toml.example
+++ b/cod-server/wrangler.toml.example
@@ -1,0 +1,116 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# CodFlow server — Cloudflare Worker configuration
+#
+# EVERY value below is a placeholder you must replace with your own resources.
+# Nothing in this repo depends on a specific Cloudflare account, domain, or
+# database. See README.md → "Getting Started" for step-by-step setup.
+#
+#   wrangler d1 create codflow-db      → gives you a database_id
+#   wrangler r2 bucket create codflow-images
+#   wrangler deploy
+# ─────────────────────────────────────────────────────────────────────────────
+
+name = "codflow-server"
+main = "src/index.ts"
+compatibility_date = "2024-11-27"
+compatibility_flags = ["nodejs_compat"]
+
+# D1 database binding.
+[[d1_databases]]
+binding = "DB"
+database_name = "codflow-db"
+# Replace with the id from `wrangler d1 create codflow-db`.
+database_id = "00000000-0000-0000-0000-000000000000"
+migrations_dir = "src/db/migrations"
+
+# R2 bucket for product images (serve + presigned uploads).
+# Replace with the name from `wrangler r2 bucket create codflow-images`.
+[[r2_buckets]]
+binding = "IMAGES"
+bucket_name = "codflow-images"
+
+# KV namespace for rate limiting.
+# Create with: wrangler kv:namespace create "RATE_LIMIT"
+[[kv_namespaces]]
+binding = "RATE_LIMIT"
+id = "00000000000000000000000000000000"
+
+# MCP remote server — one Durable Object per active MCP session holds
+# transport state (streamable-HTTP connection, pending elicitations, etc.).
+# Binding name MCP_SESSIONS is referenced by CodMcpAgent.serve("/mcp", { binding: "MCP_SESSIONS" }).
+[[durable_objects.bindings]]
+name       = "MCP_SESSIONS"
+class_name = "CodMcpAgent"
+
+[[migrations]]
+tag                = "mcp-v1"
+new_sqlite_classes = ["CodMcpAgent"]
+
+# CodCapiWorkflow — fires Meta CAPI Purchase events at order delivery.
+[[workflows]]
+name       = "capi-workflow"
+binding    = "CAPI_WORKFLOW"
+class_name = "CodCapiWorkflow"
+
+# The `agents` package statically imports `cloudflare:email`. Declaring this
+# satisfies the module resolver even though this Worker never sends email.
+# (Cloudflare's local dev runtime fails to load the Worker without it.)
+[[send_email]]
+name = "SEND_EMAIL_UNUSED"
+
+# Cron Triggers
+# Sweeps pending abandoned orders → abandoned status every hour.
+# Maximum lag from "true abandonment" to "marked abandoned" is ~90 min (pending > 30 min).
+[triggers]
+crons = ["0 * * * *"]
+
+# Environment variables (non-secret).
+#
+# Local dev defaults work out of the box. For a deployed worker, replace the
+# URLs with your own public domains:
+#   WORKER_URL       → https://api.yourdomain.com      (your Worker's public URL)
+#   MEDIA_DOMAIN     → media.yourdomain.com            (domain fronting your R2 bucket)
+#   BETTER_AUTH_URL  → https://app.yourdomain.com/api/auth (the dashboard Worker's
+#                       Better Auth origin — issuer used to verify MCP tokens)
+#   WORKER_SELF_URL  → https://api.yourdomain.com/     (this Worker's own origin;
+#                       required `aud` claim for MCP bearer tokens)
+[vars]
+ENVIRONMENT = "development"
+WORKER_URL = "http://localhost:8787"
+MEDIA_DOMAIN = "media.example.com"
+R2_BUCKET_NAME = "codflow-images"
+BETTER_AUTH_URL = "http://localhost:3000/api/auth"
+WORKER_SELF_URL = "http://localhost:8787/"
+# Development allows all origins for easier testing. Production uses ALLOWED_ORIGINS.
+ALLOWED_ORIGINS = "*"
+
+# Production environment.
+# Deploy with `wrangler deploy --env production` after editing the values.
+# IMPORTANT: Set ALLOWED_ORIGINS to your actual client and storefront domains.
+[env.production]
+vars = { ENVIRONMENT = "production", WORKER_URL = "https://api.example.com", MEDIA_DOMAIN = "media.example.com", R2_BUCKET_NAME = "codflow-images", BETTER_AUTH_URL = "https://app.example.com/api/auth", WORKER_SELF_URL = "https://api.example.com/", ALLOWED_ORIGINS = "https://app.example.com,https://store.example.com" }
+
+[[env.production.r2_buckets]]
+binding = "IMAGES"
+bucket_name = "codflow-images"
+
+[[env.production.durable_objects.bindings]]
+name       = "MCP_SESSIONS"
+class_name = "CodMcpAgent"
+
+[[env.production.workflows]]
+name       = "capi-workflow"
+binding    = "CAPI_WORKFLOW"
+class_name = "CodCapiWorkflow"
+
+# Share local D1 state with cod-client so both read the same SQLite file in dev.
+# Without this, each project gets its own .wrangler/state dir and their D1s diverge.
+# `persist_to` under [dev] is not a wrangler 3.x field (hence the old warning);
+# the shared path is wired in via --persist-to in package.json dev + migration
+# scripts, plus initOpenNextCloudflareForDev({ persist: { path } }) on the client.
+# Shared path resolves to <repo-root>/.wrangler-shared.
+[dev]
+port = 8787
+
+[observability]
+enabled = false


### PR DESCRIPTION
## Changes

- Adds `cod-server/wrangler.toml` and `cod-client/wrangler.toml` to `.gitignore` — real resource IDs are never committed
- Adds `wrangler.toml.example` in both packages with all-zero placeholder values as the committed template
- Updates setup skill Step 3: agent copies example → `wrangler.toml` before binding real IDs, then verifies both files are gitignored

## How it works

Developers copy the example file and fill in their own resource IDs. The real `wrangler.toml` stays local only.