### PR TITLE
fix(theme01): use passthroughImageService and add media domain preconnect

### DIFF
--- a/cod-astro/theme01/astro.config.mjs
+++ b/cod-astro/theme01/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig, envField } from "astro/config";
+import { defineConfig, envField, passthroughImageService } from "astro/config";
 import cloudflare from "@astrojs/cloudflare";
 import tailwindcss from "@tailwindcss/vite";
 import compress from "@playform/compress";
@@ -9,7 +9,7 @@ export default defineConfig({
   compressHTML: true,
   session: false,
   adapter: cloudflare({
-    imageService: "cloudflare",
+    imageService: "passthrough",
   }),
   env: {
     schema: {
@@ -34,7 +34,7 @@ export default defineConfig({
   },
   prefetch: true,
   image: {
-    // Allow any remote image (R2, CDN)
+    service: passthroughImageService(),
     remotePatterns: [{ protocol: "https" }],
   },
   build: {

--- a/cod-astro/theme01/src/theme/components/layout/BaseHead.astro
+++ b/cod-astro/theme01/src/theme/components/layout/BaseHead.astro
@@ -21,6 +21,8 @@ interface Props {
 }
 
 const { title, description, ogImage, noindex, config, primary, fontHref, font, bg, accent } = Astro.props;
+
+import { MEDIA_DOMAIN } from "astro:env/server";
 ---
 
 <head>
@@ -59,6 +61,9 @@ const { title, description, ogImage, noindex, config, primary, fontHref, font, b
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href={fontHref} rel="stylesheet" media="print" onload="this.media='all'" />
   <noscript><link href={fontHref} rel="stylesheet" /></noscript>
+
+  <!-- R2 media domain — early connection for product images -->
+  {MEDIA_DOMAIN && <link rel="preconnect" href={`https://${MEDIA_DOMAIN}`} />}
 
   <!-- Meta Pixel — deferred after window.load so fbevents.js (101 KiB) does
        not compete with the LCP image for bandwidth. A lightweight queue stub


### PR DESCRIPTION
## Changes

- Replaces `imageService: "cloudflare"` adapter option with Astro's `passthroughImageService()` — the correct approach for SSR on free Cloudflare accounts where Image Resizing is not available
- Adds `<link rel="preconnect">` for the R2 media domain in `BaseHead.astro`, read dynamically from the `MEDIA_DOMAIN` secret — only rendered when the secret is set, no-op otherwise

## Result

- Product images load correctly on the storefront
- Browser pre-warms the connection to the media domain early in the page lifecycle
- No broken `/cdn-cgi/image/` URLs