### PR TITLE
fix: correct order totals math and show COD total in orders views

### DIFF
--- a/cod-client/components/orders/order-detail-view.tsx
+++ b/cod-client/components/orders/order-detail-view.tsx
@@ -22,6 +22,7 @@ import {
   getShipmentTracking,
 } from "@/actions/orders";
 import { formatPrice, formatDateTime } from "@/lib/format";
+import { computeOrderTotals } from "@/lib/order-totals";
 import { ErrorModal } from "@/components/errors/error-modal";
 import { useErrorLocale } from "@/lib/errors/use-locale";
 import type { Order, OrderStatus, Driver, DeliveryCompany } from "@/types";
@@ -534,7 +535,7 @@ export function OrderDetailView({ order: initialOrder, drivers, companies }: Pro
             <div className="mt-5 pt-5 border-t border-border/10 space-y-2">
               <div className="flex items-center justify-between text-[12px]">
                 <span className="font-bold text-muted-foreground/60">{t.detail?.subtotal ?? "Subtotal"}</span>
-                <span className="font-black text-foreground/70 tabular-nums">{formatPrice(displayPrice - initialOrder.deliveryFee, common.currency.symbol)}</span>
+                <span className="font-black text-foreground/70 tabular-nums">{formatPrice(computeOrderTotals({ price: displayPrice, deliveryFee: initialOrder.deliveryFee }).subtotal, common.currency.symbol)}</span>
               </div>
               <div className="flex items-center justify-between text-[12px]">
                 <span className="font-bold text-muted-foreground/60">{t.detail?.delivery_fee ?? "Delivery"}</span>
@@ -547,7 +548,7 @@ export function OrderDetailView({ order: initialOrder, drivers, companies }: Pro
               <div className="flex items-center justify-between pt-3 border-t border-border/10">
                 <span className="text-[10px] font-black text-primary/60 uppercase tracking-widest">{t.detail?.total_price ?? "Total"}</span>
                 <span className="text-2xl sm:text-3xl font-black text-primary tabular-nums tracking-tight font-display">
-                  {formatPrice(displayPrice, common.currency.symbol)}
+                  {formatPrice(computeOrderTotals({ price: displayPrice, deliveryFee: initialOrder.deliveryFee }).total, common.currency.symbol)}
                 </span>
               </div>
             </div>

--- a/cod-client/components/orders/orders-table.tsx
+++ b/cod-client/components/orders/orders-table.tsx
@@ -36,6 +36,7 @@ import { useErrorLocale } from "@/lib/errors/use-locale";
 import { useOrders, useCommon } from "@/lib/translations";
 import { useLanguage } from "@/lib/i18n-context";
 import { formatPrice, formatDate, formatRelativeTime } from "@/lib/format";
+import { computeOrderTotals } from "@/lib/order-totals";
 import { cn } from "@/lib/utils";
 import { updateOrderStatus, assignDriverToOrder, dispatchOrder, deleteOrder } from "@/actions/orders";
 import { fetchCompanyStopDesks } from "@/actions/delivery-companies";
@@ -834,11 +835,11 @@ export function OrdersTable({
 
     {
       key: "price",
-      label: t.table.price,
+      label: t.table.total,
       sortable: true,
-      render: (value) => (
+      render: (_value, row) => (
         <span className="font-black text-sm text-primary tabular-nums">
-          {formatPrice(value, common.currency.symbol)}
+          {formatPrice(computeOrderTotals({ price: row.price, deliveryFee: row.deliveryFee }).total, common.currency.symbol)}
         </span>
       ),
       className: "text-right",
@@ -1030,7 +1031,7 @@ export function OrdersTable({
               {/* Row 3: price + delivery type + date */}
               <div className="flex items-center justify-between gap-2 pt-2 pb-2.5 border-b border-border/10">
                 <p className="text-[22px] font-black text-primary tabular-nums tracking-tight leading-none" dir="ltr">
-                  {formatPrice(order.price, common.currency.symbol)}
+                  {formatPrice(computeOrderTotals({ price: order.price, deliveryFee: order.deliveryFee }).total, common.currency.symbol)}
                 </p>
                 <div className="flex items-center gap-2 shrink-0">
                   <span className={cn(

--- a/cod-client/lib/order-totals.ts
+++ b/cod-client/lib/order-totals.ts
@@ -1,0 +1,27 @@
+/**
+ * Order money math — single source of truth for dashboard displays.
+ *
+ * orders.price is the ITEMS-ONLY subtotal (both creation paths store it that
+ * way; see cod-server/src/endpoints/orders/handlers.ts where
+ * codAmount = price + deliveryFee). Never subtract shipping from it.
+ */
+export interface OrderTotalsInput {
+  /** Items-only price as stored in orders.price */
+  price: number;
+  /** Delivery fee charged to the customer (orders.deliveryFee) */
+  deliveryFee: number;
+}
+
+export interface OrderTotals {
+  subtotal: number;
+  deliveryFee: number;
+  total: number;
+}
+
+export function computeOrderTotals({ price, deliveryFee }: OrderTotalsInput): OrderTotals {
+  return {
+    subtotal: price,
+    deliveryFee,
+    total: price + deliveryFee,
+  };
+}

--- a/cod-client/locales/ar/orders.json
+++ b/cod-client/locales/ar/orders.json
@@ -15,7 +15,8 @@
     "delivery": "التوصيل",
     "driver": "السائق",
     "date": "التاريخ",
-    "not_assigned": "غير معين"
+    "not_assigned": "غير معين",
+    "total": "الإجمالي"
   },
   "actions": {
     "view": "عرض",

--- a/cod-client/locales/en/orders.json
+++ b/cod-client/locales/en/orders.json
@@ -15,7 +15,8 @@
     "delivery": "Delivery",
     "driver": "Driver",
     "date": "Date",
-    "not_assigned": "Not Assigned"
+    "not_assigned": "Not Assigned",
+    "total": "Total"
   },
   "actions": {
     "view": "View",

--- a/cod-client/locales/fr/orders.json
+++ b/cod-client/locales/fr/orders.json
@@ -15,7 +15,8 @@
     "delivery": "Livraison",
     "driver": "Livreur",
     "date": "Date",
-    "not_assigned": "Non assigné"
+    "not_assigned": "Non assigné",
+    "total": "Total"
   },
   "actions": {
     "view": "Voir",

--- a/cod-client/tests/unit/order-totals.test.ts
+++ b/cod-client/tests/unit/order-totals.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { computeOrderTotals } from "@/lib/order-totals";
+
+/**
+ * Regression guard for the order-details money math.
+ *
+ * orders.price stores ITEMS-ONLY price (never includes shipping);
+ * codAmount = price + deliveryFee is what the customer pays (handlers.ts:182).
+ *
+ * Bug context: the detail view computed subtotal = price - deliveryFee,
+ * showing 2400 for a 2800 basket with 400 shipping.
+ */
+describe("computeOrderTotals", () => {
+  it("user-reported case: 2800 goods + 400 shipping", () => {
+    const t = computeOrderTotals({ price: 2800, deliveryFee: 400 });
+    expect(t.subtotal).toBe(2800);
+    expect(t.total).toBe(3200);
+  });
+
+  it("free shipping: total equals subtotal", () => {
+    const t = computeOrderTotals({ price: 1500, deliveryFee: 0 });
+    expect(t.subtotal).toBe(1500);
+    expect(t.deliveryFee).toBe(0);
+    expect(t.total).toBe(1500);
+  });
+
+  it("multi-line baskets keep price as-is (already summed server-side)", () => {
+    const t = computeOrderTotals({ price: 999, deliveryFee: 500 });
+    expect(t.subtotal).toBe(999);
+    expect(t.total).toBe(1499);
+  });
+});

--- a/cod-shared/db/schema.ts
+++ b/cod-shared/db/schema.ts
@@ -461,7 +461,7 @@ export const orders = sqliteTable("orders", {
   driverFee: real("driver_fee").notNull().default(0),
   /**
    * Cash-on-delivery amount the driver must collect from the customer.
-   * Set to order.price on creation. Added to driver.pendingCash when delivered.
+   * Set to order.price + delivery_fee on creation. Added to driver.pendingCash when delivered.
    */
   codAmount: real("cod_amount").notNull().default(0),
 


### PR DESCRIPTION
## Problem

Order money figures were inconsistent across dashboard surfaces:

- **Order detail** computed `Subtotal = price − deliveryFee` and `Total = price`. For a 2 800 DZD basket with 400 DZD shipping it displayed Subtotal 2 400 / Total 2 800, while the storefront checkout correctly showed 3 200.
- **Orders list** (desktop column and mobile card) displayed the raw items-only `price`, which does not match the COD amount actually collected from the customer.

`orders.price` is stored items-only on every creation path (storefront and manual); the amount collected is `codAmount = price + deliveryFee`.

## Fix

- Add `lib/order-totals.ts` with `computeOrderTotals({ price, deliveryFee })` as the single source for displayed money figures: `subtotal = price`, `total = price + deliveryFee`.
- Order detail breakdown now renders subtotal and total through it.
- Orders table column and mobile card now show the COD total under a new localized `table.total` label (`ar`, `en`, `fr`).
- Correct the stale `cod_amount` schema comment (it is set to `price + delivery_fee`, not `price`).

No backend, schema, or data changes — stored order records were already consistent.

## Verification

- New unit test locks the reported case: 2 800 + 400 → subtotal 2 800, total 3 200.
- `npm test` in cod-client: 144 passed (10 files).
- `tsc --noEmit` clean.