### PR TITLE
refactor(server): migrate 8 endpoint domains to defineRoute() route-builder

### DIFF
--- a/cod-server/src/endpoints/activity-logs/routes.test.ts
+++ b/cod-server/src/endpoints/activity-logs/routes.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Route-level integration tests for the Activity Logs defineRoute() router.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import type { AppContext } from "@/types";
+import { errorHandler } from "@/middleware/error";
+import { openApiValidationHook } from "@/openapi/validation-hook";
+import { ERROR_CODES, ERROR_CATEGORIES } from "../../../../cod-shared/errors/codes";
+import activityLogsRouter from "./routes";
+import {
+  listActivityLogs as queryActivityLogs,
+  getUserActivityLogs as queryUserActivityLogs,
+} from "../../../../cod-shared/queries/activity-logs";
+
+const mockDb = { select: vi.fn() } as any;
+
+vi.mock("@/db", () => ({
+  getDb: vi.fn(() => mockDb),
+}));
+vi.mock("../../../../cod-shared/queries/activity-logs", () => ({
+  listActivityLogs: vi.fn(),
+  getUserActivityLogs: vi.fn(),
+}));
+
+const admin = { id: "user_admin_001", name: "Admin User", role: "admin", scopes: [] };
+const staff = { id: "user_staff_001", name: "Amira Khalil", role: "staff", scopes: [] };
+
+function makeApp(user: any) {
+  const app = new OpenAPIHono<AppContext>({ defaultHook: openApiValidationHook });
+  app.use("*", async (c, next) => {
+    c.env = { DB: mockDb } as any;
+    if (user) c.set("user", user);
+    await next();
+  });
+  app.onError(errorHandler);
+  app.route("/api/activity-logs", activityLogsRouter);
+  return app;
+}
+
+describe("Activity Logs routes (defineRoute)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /api/activity-logs", () => {
+    it("returns 200 with logs for an admin", async () => {
+      const rows = [{ id: "log_001" }];
+      vi.mocked(queryActivityLogs).mockResolvedValue(rows as any);
+      const app = makeApp(admin);
+
+      const res = await app.request("/api/activity-logs?actorId=u1&entityType=order&limit=10&offset=5");
+
+      expect(res.status).toBe(200);
+      const body: any = await res.json();
+      expect(body).toEqual({ success: true, data: rows, count: 1 });
+      expect(queryActivityLogs).toHaveBeenCalledWith(mockDb, {
+        actorId: "u1",
+        entityType: "order",
+        limit: 10,
+        offset: 5,
+      });
+    });
+
+    it("returns 400 for invalid query parameter (limit > 100)", async () => {
+      const app = makeApp(admin);
+
+      const res = await app.request("/api/activity-logs?limit=200");
+
+      expect(res.status).toBe(400);
+      const body: any = await res.json();
+      expect(body).toMatchObject({
+        code: ERROR_CODES.VALIDATION_FAILED,
+        category: ERROR_CATEGORIES.VALIDATION,
+      });
+    });
+
+    it("returns 403 with the PERMISSION_DENIED envelope for non-admin", async () => {
+      const app = makeApp(staff);
+
+      const res = await app.request("/api/activity-logs");
+
+      expect(res.status).toBe(403);
+      const body: any = await res.json();
+      expect(body).toMatchObject({
+        code: ERROR_CODES.PERMISSION_DENIED,
+        category: ERROR_CATEGORIES.AUTHENTICATION,
+      });
+      expect(queryActivityLogs).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /api/activity-logs/users/:userId", () => {
+    it("returns 200 with user logs for an admin", async () => {
+      const rows = [{ id: "log_002" }];
+      vi.mocked(queryUserActivityLogs).mockResolvedValue(rows as any);
+      const app = makeApp(admin);
+
+      const res = await app.request("/api/activity-logs/users/u1?limit=5&offset=1");
+
+      expect(res.status).toBe(200);
+      const body: any = await res.json();
+      expect(body).toEqual({ success: true, data: rows, count: 1 });
+      expect(queryUserActivityLogs).toHaveBeenCalledWith(mockDb, "u1", { limit: 5, offset: 1 });
+    });
+
+    it("returns 403 with the PERMISSION_DENIED envelope for non-admin", async () => {
+      const app = makeApp(staff);
+
+      const res = await app.request("/api/activity-logs/users/u1");
+
+      expect(res.status).toBe(403);
+      const body: any = await res.json();
+      expect(body).toMatchObject({
+        code: ERROR_CODES.PERMISSION_DENIED,
+        category: ERROR_CATEGORIES.AUTHENTICATION,
+      });
+      expect(queryUserActivityLogs).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/cod-server/src/endpoints/activity-logs/routes.ts
+++ b/cod-server/src/endpoints/activity-logs/routes.ts
@@ -2,31 +2,21 @@
  * Activity Logs Routes
  *
  * All routes are admin-only — activity logs are never visible to staff.
+ * Built with defineRoute() — the standard route-builder pattern.
  *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * Admin enforcement stays on the router-level adminOnly middleware so
+ * denials keep the standard error envelope (PERMISSION_DENIED) that the
+ * README documents; the platform's requireAdmin() middleware returns a
+ * plain-JSON 403 instead.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { Context, Next } from "hono";
 import type { AppContext } from "@/types";
-import {
-  ActivityLogSchema,
-  ErrorResponseSchema,
-  ListResponseSchema,
-} from "@/openapi/schemas";
+import { defineRoute } from "@/lib/route-builder";
+import { ActivityLogSchema, ListResponseSchema } from "@/openapi/schemas";
 import { listActivityLogs, getUserActivityLogs } from "./handlers";
 import { PermissionError } from "@/lib/errors/classes";
-
-const jsonContent = (schema: z.ZodType) => ({
-  "application/json": { schema },
-});
-
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
-});
 
 async function adminOnly(c: Context<AppContext>, next: Next) {
   if (c.get("user").role !== "admin") {
@@ -34,6 +24,8 @@ async function adminOnly(c: Context<AppContext>, next: Next) {
   }
   await next();
 }
+
+// ─── Request schemas ──────────────────────────────────────────────────────────
 
 const activityLogsQuerySchema = z.object({
   actorId: z.string().optional().openapi({
@@ -77,57 +69,61 @@ const userLogsQuerySchema = z.object({
     .openapi({ description: "Number of logs to skip" }),
 });
 
-const listActivityLogsRoute = createRoute({
+const userIdParams = z.object({
+  userId: z.string().openapi({ description: "User ID to filter logs for" }),
+});
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const listActivityLogsRoute = defineRoute({
   method: "get",
   path: "/",
+  auth: "api-key",
   tags: ["Activity Logs"],
   summary: "List activity logs",
   description: "Get audit trail of all system actions (admin only)",
   operationId: "listActivityLogs",
-  request: {
-    query: activityLogsQuerySchema,
-  },
+  query: activityLogsQuerySchema,
   responses: {
     200: {
       description: "List of activity logs",
-      content: jsonContent(ListResponseSchema(ActivityLogSchema)),
+      content: {
+        "application/json": { schema: ListResponseSchema(ActivityLogSchema) },
+      },
     },
-    400: errorResponse("Validation error - invalid query parameters"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin access required"),
+    403: { description: "Admin access required" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: listActivityLogs,
 });
 
-const getUserActivityLogsRoute = createRoute({
+const getUserActivityLogsRoute = defineRoute({
   method: "get",
   path: "/users/{userId}",
+  auth: "api-key",
   tags: ["Activity Logs"],
   summary: "Get user activity logs",
   description: "Get activity logs for a specific user (admin only)",
   operationId: "getUserActivityLogs",
-  request: {
-    params: z.object({
-      userId: z.string().openapi({ description: "User ID to filter logs for" }),
-    }),
-    query: userLogsQuerySchema,
-  },
+  params: userIdParams,
+  query: userLogsQuerySchema,
   responses: {
     200: {
       description: "User activity logs",
-      content: jsonContent(ListResponseSchema(ActivityLogSchema)),
+      content: {
+        "application/json": { schema: ListResponseSchema(ActivityLogSchema) },
+      },
     },
-    400: errorResponse("Validation error - invalid query parameters"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin access required"),
+    403: { description: "Admin access required" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: getUserActivityLogs,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
 router.use("*", adminOnly);
-router.openapi(listActivityLogsRoute, listActivityLogs);
-router.openapi(getUserActivityLogsRoute, getUserActivityLogs);
+router.openapi(listActivityLogsRoute.route, listActivityLogsRoute.handler);
+router.openapi(getUserActivityLogsRoute.route, getUserActivityLogsRoute.handler);
 
 export default router;

--- a/cod-server/src/endpoints/analytics/routes.test.ts
+++ b/cod-server/src/endpoints/analytics/routes.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Route-level integration tests for the Analytics OpenAPIHono router.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import type { AppContext } from "@/types";
+import { errorHandler } from "@/middleware/error";
+import { openApiValidationHook } from "@/openapi/validation-hook";
+import analyticsRouter from "./routes";
+import { getOrderStatusStats } from "../../../../cod-shared/queries/analytics";
+
+const mockDb = {
+  select: vi.fn(),
+} as any;
+
+vi.mock("@/db", () => ({
+  getDb: vi.fn(() => mockDb),
+}));
+vi.mock("../../../../cod-shared/queries/analytics", () => ({
+  getOrderStatusStats: vi.fn(),
+}));
+
+function makeApp(user: any) {
+  const app = new OpenAPIHono<AppContext>({ defaultHook: openApiValidationHook });
+  app.use("*", async (c, next) => {
+    c.env = { DB: mockDb } as any;
+    if (user) c.set("user", user);
+    await next();
+  });
+  app.onError(errorHandler);
+  app.route("/api/analytics", analyticsRouter);
+  return app;
+}
+
+describe("Analytics routes (defineRoute)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with status breakdown for a user holding dashboard:view", async () => {
+    vi.mocked(getOrderStatusStats).mockResolvedValue([
+      { status: "new", count: 12 },
+      { status: "delivered", count: 5 },
+    ]);
+    const app = makeApp({ id: "u1", name: "Viewer", role: "viewer", scopes: ["dashboard:view"] });
+
+    const res = await app.request("/api/analytics/dashboard-stats");
+
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body).toEqual({
+      success: true,
+      data: [
+        { status: "new", count: 12 },
+        { status: "delivered", count: 5 },
+      ],
+    });
+    expect(getOrderStatusStats).toHaveBeenCalledWith(mockDb);
+  });
+
+  it("allows admin without explicit dashboard:view scope", async () => {
+    vi.mocked(getOrderStatusStats).mockResolvedValue([]);
+    const app = makeApp({ id: "u1", name: "Admin", role: "admin", scopes: [] });
+
+    const res = await app.request("/api/analytics/dashboard-stats");
+
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 when the user lacks dashboard:view", async () => {
+    const app = makeApp({ id: "u1", name: "Viewer", role: "viewer", scopes: ["orders:read"] });
+
+    const res = await app.request("/api/analytics/dashboard-stats");
+
+    expect(res.status).toBe(403);
+    expect(getOrderStatusStats).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const app = makeApp(null);
+
+    const res = await app.request("/api/analytics/dashboard-stats");
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/cod-server/src/endpoints/analytics/routes.ts
+++ b/cod-server/src/endpoints/analytics/routes.ts
@@ -3,22 +3,20 @@
  *
  * Read-only endpoints that serve aggregated stats for the dashboard and
  * any future reporting features. Protected by DASHBOARD_VIEW scope.
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import { getDashboardStats } from "./handlers";
-import { OrderStatusEnum, ErrorResponseSchema } from "@/openapi/schemas";
+import { OrderStatusEnum } from "@/openapi/schemas";
 
-const dashboardStatsRoute = createRoute({
+const dashboardStatsRoute = defineRoute({
   method: "get",
   path: "/dashboard-stats",
-  middleware: [requireScope(SCOPES.DASHBOARD_VIEW)],
+  auth: { scope: SCOPES.DASHBOARD_VIEW },
   tags: ["Analytics"],
   summary: "Order status statistics",
   description:
@@ -41,24 +39,12 @@ const dashboardStatsRoute = createRoute({
         },
       },
     },
-    401: {
-      description: "Missing or invalid API key",
-      content: {
-        "application/json": { schema: ErrorResponseSchema },
-      },
-    },
-    403: {
-      description: "Missing dashboard:view scope",
-      content: {
-        "application/json": { schema: ErrorResponseSchema },
-      },
-    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: getDashboardStats,
 });
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(dashboardStatsRoute, getDashboardStats);
+router.openapi(dashboardStatsRoute.route, dashboardStatsRoute.handler);
 
 export default router;

--- a/cod-server/src/endpoints/customer-groups/routes.ts
+++ b/cod-server/src/endpoints/customer-groups/routes.ts
@@ -3,304 +3,234 @@
  *
  * CRUD and member management endpoints for customer segmentation groups.
  * All routes require an API key with the appropriate customer_groups scope.
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import * as h from "./handlers";
 import {
   CustomerGroupSchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
+  SuccessWithMessageSchema,
+  MessageResponseSchema,
   ListResponseSchema,
+  IdParamSchema,
 } from "@/openapi/schemas";
 
 const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
 
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
+// ─── Request schemas ─────────────────────────────────────────────────────────
+
+const listQuerySchema = z.object({
+  search: z.string().optional().openapi({
+    description: "Search by name",
+  }),
+  limit: z.coerce.number().int().positive().max(100).default(50).openapi({
+    description: "Maximum number of groups to return",
+    example: 50,
+  }),
+  offset: z.coerce.number().int().min(0).default(0).openapi({
+    description: "Number of groups to skip",
+    example: 0,
+  }),
 });
 
-const listGroupsRoute = createRoute({
+const createBodySchema = z.object({
+  name: z.string().min(1, "Name is required").max(100).openapi({
+    example: "Wholesale Customers",
+  }),
+  description: z.string().max(500).nullable().optional().openapi({
+    example: "High volume buyers",
+  }),
+  color: z
+    .string()
+    .regex(/^#[0-9a-fA-F]{6}$/, "Invalid hex color")
+    .default("#6366f1")
+    .optional()
+    .openapi({
+      example: "#3B82F6",
+    }),
+});
+
+const membersQuerySchema = z.object({
+  members: z.enum(["true", "false"]).optional().openapi({
+    description: "Set to `true` to include the `members` array in the response",
+  }),
+});
+
+const updateBodySchema = z.object({
+  name: z.string().min(1).max(100).optional().openapi({ example: "VIP Customers" }),
+  description: z.string().max(500).nullable().optional().openapi({ example: "Updated description" }),
+  color: z
+    .string()
+    .regex(/^#[0-9a-fA-F]{6}$/, "Invalid hex color")
+    .optional()
+    .openapi({ example: "#10B981" }),
+});
+
+const addMemberBodySchema = z.object({
+  customerId: z.string().min(1, "Customer ID is required").openapi({ example: "cust_123" }),
+});
+
+const removeMemberParamsSchema = IdParamSchema.extend({
+  customerId: z.string().openapi({ description: "Customer ID", example: "cust_123" }),
+});
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const listGroupsRoute = defineRoute({
   method: "get",
   path: "/",
-  middleware: [requireScope(SCOPES.CUSTOMER_GROUPS_READ)],
+  auth: { scope: SCOPES.CUSTOMER_GROUPS_READ },
   tags: ["Customer Groups"],
   summary: "List customer groups",
   description: "Get all customer groups with optional search filter and pagination",
   operationId: "listCustomerGroups",
-  request: {
-    query: z.object({
-      search: z.string().optional().openapi({
-        description: "Search by name",
-      }),
-      limit: z.coerce.number().int().positive().max(100).default(50).openapi({
-        description: "Maximum number of groups to return",
-        example: 50,
-      }),
-      offset: z.coerce.number().int().min(0).default(0).openapi({
-        description: "Number of groups to skip",
-        example: 0,
-      }),
-    }),
-  },
+  query: listQuerySchema,
   responses: {
     200: {
       description: "List of customer groups",
       content: jsonContent(ListResponseSchema(CustomerGroupSchema)),
     },
-    400: errorResponse("Validation error - invalid query parameters"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_groups:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.listGroups,
 });
 
-const createGroupRoute = createRoute({
+const createGroupRoute = defineRoute({
   method: "post",
   path: "/",
-  middleware: [requireScope(SCOPES.CUSTOMER_GROUPS_MANAGE)],
+  auth: { scope: SCOPES.CUSTOMER_GROUPS_MANAGE },
   tags: ["Customer Groups"],
   summary: "Create customer group",
   description: "Create a new customer segment group",
   operationId: "createCustomerGroup",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          name: z.string().min(1, "Name is required").max(100).openapi({
-            example: "Wholesale Customers",
-          }),
-          description: z.string().max(500).nullable().optional().openapi({
-            example: "High volume buyers",
-          }),
-          color: z
-            .string()
-            .regex(/^#[0-9a-fA-F]{6}$/, "Invalid hex color")
-            .default("#6366f1")
-            .optional()
-            .openapi({
-              example: "#3B82F6",
-            }),
-        })
-      ),
-    },
-  },
+  body: createBodySchema,
   responses: {
     201: {
       description: "Group created",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          data: CustomerGroupSchema,
-          message: z.string().openapi({ example: "Group created" }),
-        })
-      ),
+      content: jsonContent(SuccessWithMessageSchema(CustomerGroupSchema)),
     },
-    400: errorResponse("Validation error (missing name, invalid hex color)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_groups:manage scope"),
-    409: errorResponse("Duplicate group name"),
+    409: { description: "Duplicate group name" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.createGroup,
 });
 
-const getGroupRoute = createRoute({
+const getGroupRoute = defineRoute({
   method: "get",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.CUSTOMER_GROUPS_READ)],
+  auth: { scope: SCOPES.CUSTOMER_GROUPS_READ },
   tags: ["Customer Groups"],
   summary: "Get customer group",
   description:
     "Returns the group. Pass `?members=true` to include the full member list (each with `assignedAt` timestamp).",
   operationId: "getCustomerGroup",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Customer group ID", example: "grp_123" }),
-    }),
-    query: z.object({
-      members: z.enum(["true", "false"]).optional().openapi({
-        description: "Set to `true` to include the `members` array in the response",
-      }),
-    }),
-  },
+  params: IdParamSchema,
+  query: membersQuerySchema,
   responses: {
     200: {
       description:
         "Group detail. When `?members=true`, includes a `members` array of customer summaries.",
       content: jsonContent(SuccessResponseSchema(CustomerGroupSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_groups:read scope"),
-    404: errorResponse("Group not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.getGroup,
 });
 
-const updateGroupRoute = createRoute({
+const updateGroupRoute = defineRoute({
   method: "patch",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.CUSTOMER_GROUPS_MANAGE)],
+  auth: { scope: SCOPES.CUSTOMER_GROUPS_MANAGE },
   tags: ["Customer Groups"],
   summary: "Update customer group",
   description:
     "Partial update — only include fields you want to change. Set `description` to `null` to clear it.",
   operationId: "updateCustomerGroup",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Customer group ID", example: "grp_123" }),
-    }),
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          name: z.string().min(1).max(100).optional().openapi({ example: "VIP Customers" }),
-          description: z.string().max(500).nullable().optional().openapi({ example: "Updated description" }),
-          color: z
-            .string()
-            .regex(/^#[0-9a-fA-F]{6}$/, "Invalid hex color")
-            .optional()
-            .openapi({ example: "#10B981" }),
-        })
-      ),
-    },
-  },
+  params: IdParamSchema,
+  body: updateBodySchema,
   responses: {
     200: {
       description: "Group updated",
       content: jsonContent(SuccessResponseSchema(CustomerGroupSchema)),
     },
-    400: errorResponse("Validation error (invalid hex color)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_groups:manage scope"),
-    404: errorResponse("Group not found"),
-    409: errorResponse("Duplicate group name"),
+    409: { description: "Duplicate group name" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.updateGroup,
 });
 
-const deleteGroupRoute = createRoute({
+const deleteGroupRoute = defineRoute({
   method: "delete",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.CUSTOMER_GROUPS_MANAGE)],
+  auth: { scope: SCOPES.CUSTOMER_GROUPS_MANAGE },
   tags: ["Customer Groups"],
   summary: "Delete customer group",
   description:
     "Deletes the group and all its member associations. Customers themselves are not affected.",
   operationId: "deleteCustomerGroup",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Customer group ID", example: "grp_123" }),
-    }),
-  },
+  params: IdParamSchema,
   responses: {
     200: {
       description: "Group deleted",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          message: z.string().openapi({ example: "Group deleted" }),
-        })
-      ),
+      content: jsonContent(MessageResponseSchema),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_groups:manage scope"),
-    404: errorResponse("Group not found"),
-    422: errorResponse("Group has members - cannot delete"),
+    422: { description: "Group has members - cannot delete" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.deleteGroup,
 });
 
-const addMemberRoute = createRoute({
+const addMemberRoute = defineRoute({
   method: "post",
   path: "/{id}/members",
-  middleware: [requireScope(SCOPES.CUSTOMER_GROUPS_MANAGE)],
+  auth: { scope: SCOPES.CUSTOMER_GROUPS_MANAGE },
   tags: ["Customer Groups"],
   summary: "Add member to group",
   description:
     "Adds a customer to the group. Idempotent — silently succeeds if already a member. Increments `memberCount`.",
   operationId: "addMember",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Customer group ID", example: "grp_123" }),
-    }),
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          customerId: z.string().min(1, "Customer ID is required").openapi({ example: "cust_123" }),
-        })
-      ),
-    },
-  },
+  params: IdParamSchema,
+  body: addMemberBodySchema,
   responses: {
     200: {
       description: "Member added",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          message: z.string().openapi({ example: "Member added" }),
-        })
-      ),
+      content: jsonContent(MessageResponseSchema),
     },
-    400: errorResponse("Validation error (missing customerId)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_groups:manage scope"),
-    404: errorResponse("Group or customer not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.addMember,
 });
 
-const removeMemberRoute = createRoute({
+const removeMemberRoute = defineRoute({
   method: "delete",
   path: "/{id}/members/{customerId}",
-  middleware: [requireScope(SCOPES.CUSTOMER_GROUPS_MANAGE)],
+  auth: { scope: SCOPES.CUSTOMER_GROUPS_MANAGE },
   tags: ["Customer Groups"],
   summary: "Remove member from group",
   description:
     "Removes a customer from the group. Idempotent — succeeds silently if not a member. Decrements `memberCount`.",
   operationId: "removeMember",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Customer group ID", example: "grp_123" }),
-      customerId: z.string().openapi({ description: "Customer ID", example: "cust_123" }),
-    }),
-  },
+  params: removeMemberParamsSchema,
   responses: {
     200: {
       description: "Member removed",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          message: z.string().openapi({ example: "Member removed" }),
-        })
-      ),
+      content: jsonContent(MessageResponseSchema),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_groups:manage scope"),
-    404: errorResponse("Group not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.removeMember,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(listGroupsRoute, h.listGroups);
-router.openapi(createGroupRoute, h.createGroup);
-router.openapi(getGroupRoute, h.getGroup);
-router.openapi(updateGroupRoute, h.updateGroup);
-router.openapi(deleteGroupRoute, h.deleteGroup);
-router.openapi(addMemberRoute, h.addMember);
-router.openapi(removeMemberRoute, h.removeMember);
+router.openapi(listGroupsRoute.route, listGroupsRoute.handler);
+router.openapi(createGroupRoute.route, createGroupRoute.handler);
+router.openapi(getGroupRoute.route, getGroupRoute.handler);
+router.openapi(updateGroupRoute.route, updateGroupRoute.handler);
+router.openapi(deleteGroupRoute.route, deleteGroupRoute.handler);
+router.openapi(addMemberRoute.route, addMemberRoute.handler);
+router.openapi(removeMemberRoute.route, removeMemberRoute.handler);
 
 export default router;

--- a/cod-server/src/endpoints/customer-tags/routes.ts
+++ b/cod-server/src/endpoints/customer-tags/routes.ts
@@ -3,300 +3,229 @@
  *
  * CRUD and assignment endpoints for customer tags.
  * All routes require an API key with the appropriate customer_tags scope.
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import * as h from "./handlers";
 import {
   CustomerTagSchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
+  SuccessWithMessageSchema,
+  MessageResponseSchema,
   ListResponseSchema,
+  IdParamSchema,
 } from "@/openapi/schemas";
 
 const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
 
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
+// ─── Request schemas ──────────────────────────────────────────────────────────
+
+const listQuerySchema = z.object({
+  search: z.string().optional().openapi({
+    description: "Search by name",
+  }),
+  limit: z.coerce.number().int().positive().max(100).default(50).openapi({
+    description: "Maximum number of tags to return",
+    example: 50,
+  }),
+  offset: z.coerce.number().int().min(0).default(0).openapi({
+    description: "Number of tags to skip",
+    example: 0,
+  }),
 });
 
-const listTagsRoute = createRoute({
+const createBodySchema = z.object({
+  name: z.string().min(1, "Name is required").max(50).openapi({
+    example: "VIP",
+  }),
+  color: z
+    .string()
+    .regex(/^#[0-9a-fA-F]{6}$/, "Invalid hex color")
+    .default("#64748b")
+    .optional()
+    .openapi({
+      example: "#FF5733",
+    }),
+});
+
+const customersQuerySchema = z.object({
+  customers: z.enum(["true", "false"]).optional().openapi({
+    description: "Set to `true` to include the `customers` array in the response",
+  }),
+});
+
+const updateBodySchema = z.object({
+  name: z.string().min(1).max(50).optional().openapi({ example: "VIP" }),
+  color: z
+    .string()
+    .regex(/^#[0-9a-fA-F]{6}$/, "Invalid hex color")
+    .optional()
+    .openapi({ example: "#FF5733" }),
+});
+
+const assignBodySchema = z.object({
+  customerId: z.string().min(1, "Customer ID is required").openapi({ example: "cust_123" }),
+});
+
+const unassignParamsSchema = IdParamSchema.extend({
+  customerId: z.string().openapi({ description: "Customer ID", example: "cust_123" }),
+});
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const listTagsRoute = defineRoute({
   method: "get",
   path: "/",
-  middleware: [requireScope(SCOPES.CUSTOMER_TAGS_READ)],
+  auth: { scope: SCOPES.CUSTOMER_TAGS_READ },
   tags: ["Customer Tags"],
   summary: "List customer tags",
   description: "Get all customer tags with optional search filter and pagination",
   operationId: "listCustomerTags",
-  request: {
-    query: z.object({
-      search: z.string().optional().openapi({
-        description: "Search by name",
-      }),
-      limit: z.coerce.number().int().positive().max(100).default(50).openapi({
-        description: "Maximum number of tags to return",
-        example: 50,
-      }),
-      offset: z.coerce.number().int().min(0).default(0).openapi({
-        description: "Number of tags to skip",
-        example: 0,
-      }),
-    }),
-  },
+  query: listQuerySchema,
   responses: {
     200: {
       description: "List of customer tags",
       content: jsonContent(ListResponseSchema(CustomerTagSchema)),
     },
-    400: errorResponse("Validation error - invalid query parameters"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_tags:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.listTags,
 });
 
-const createTagRoute = createRoute({
+const createTagRoute = defineRoute({
   method: "post",
   path: "/",
-  middleware: [requireScope(SCOPES.CUSTOMER_TAGS_MANAGE)],
+  auth: { scope: SCOPES.CUSTOMER_TAGS_MANAGE },
   tags: ["Customer Tags"],
   summary: "Create customer tag",
   description: "Create a new customer tag",
   operationId: "createCustomerTag",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          name: z.string().min(1, "Name is required").max(50).openapi({
-            example: "VIP",
-          }),
-          color: z
-            .string()
-            .regex(/^#[0-9a-fA-F]{6}$/, "Invalid hex color")
-            .default("#64748b")
-            .optional()
-            .openapi({
-              example: "#FF5733",
-            }),
-        })
-      ),
-    },
-  },
+  body: createBodySchema,
   responses: {
     201: {
       description: "Tag created",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          data: CustomerTagSchema,
-          message: z.string().openapi({ example: "Tag created" }),
-        })
-      ),
+      content: jsonContent(SuccessWithMessageSchema(CustomerTagSchema)),
     },
-    400: errorResponse("Validation error (missing name, invalid hex color)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_tags:manage scope"),
-    409: errorResponse("Duplicate tag name"),
+    409: { description: "Duplicate tag name" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.createTag,
 });
 
-const getTagRoute = createRoute({
+const getTagRoute = defineRoute({
   method: "get",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.CUSTOMER_TAGS_READ)],
+  auth: { scope: SCOPES.CUSTOMER_TAGS_READ },
   tags: ["Customer Tags"],
   summary: "Get customer tag",
   description:
     "Returns the tag. Pass `?customers=true` to include the full list of assigned customers (each with `assignedAt` timestamp).",
   operationId: "getCustomerTag",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Customer tag ID", example: "tag_123" }),
-    }),
-    query: z.object({
-      customers: z.enum(["true", "false"]).optional().openapi({
-        description: "Set to `true` to include the `customers` array in the response",
-      }),
-    }),
-  },
+  params: IdParamSchema,
+  query: customersQuerySchema,
   responses: {
     200: {
       description:
         "Tag detail. When `?customers=true`, includes a `customers` array of customer summaries.",
       content: jsonContent(SuccessResponseSchema(CustomerTagSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_tags:read scope"),
-    404: errorResponse("Tag not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.getTag,
 });
 
-const updateTagRoute = createRoute({
+const updateTagRoute = defineRoute({
   method: "patch",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.CUSTOMER_TAGS_MANAGE)],
+  auth: { scope: SCOPES.CUSTOMER_TAGS_MANAGE },
   tags: ["Customer Tags"],
   summary: "Update customer tag",
   description: "Partial update — only include fields you want to change.",
   operationId: "updateCustomerTag",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Customer tag ID", example: "tag_123" }),
-    }),
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          name: z.string().min(1).max(50).optional().openapi({ example: "VIP" }),
-          color: z
-            .string()
-            .regex(/^#[0-9a-fA-F]{6}$/, "Invalid hex color")
-            .optional()
-            .openapi({ example: "#FF5733" }),
-        })
-      ),
-    },
-  },
+  params: IdParamSchema,
+  body: updateBodySchema,
   responses: {
     200: {
       description: "Tag updated",
       content: jsonContent(SuccessResponseSchema(CustomerTagSchema)),
     },
-    400: errorResponse("Validation error (invalid hex color)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_tags:manage scope"),
-    404: errorResponse("Tag not found"),
-    409: errorResponse("Duplicate tag name"),
+    409: { description: "Duplicate tag name" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.updateTag,
 });
 
-const deleteTagRoute = createRoute({
+const deleteTagRoute = defineRoute({
   method: "delete",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.CUSTOMER_TAGS_MANAGE)],
+  auth: { scope: SCOPES.CUSTOMER_TAGS_MANAGE },
   tags: ["Customer Tags"],
   summary: "Delete customer tag",
   description:
     "Deletes the tag and all its customer assignments. Customers themselves are not affected.",
   operationId: "deleteCustomerTag",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Customer tag ID", example: "tag_123" }),
-    }),
-  },
+  params: IdParamSchema,
   responses: {
     200: {
       description: "Tag deleted",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          message: z.string().openapi({ example: "Tag deleted" }),
-        })
-      ),
+      content: jsonContent(MessageResponseSchema),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_tags:manage scope"),
-    404: errorResponse("Tag not found"),
-    422: errorResponse("Tag has assignments - cannot delete"),
+    422: { description: "Tag has assignments - cannot delete" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.deleteTag,
 });
 
-const assignTagRoute = createRoute({
+const assignTagRoute = defineRoute({
   method: "post",
   path: "/{id}/assignments",
-  middleware: [requireScope(SCOPES.CUSTOMER_TAGS_MANAGE)],
+  auth: { scope: SCOPES.CUSTOMER_TAGS_MANAGE },
   tags: ["Customer Tags"],
   summary: "Assign tag to customer",
   description:
     "Assigns the tag to a customer. Idempotent — silently succeeds if already assigned. Increments `assignmentCount`.",
   operationId: "assignTag",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Customer tag ID", example: "tag_123" }),
-    }),
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          customerId: z.string().min(1, "Customer ID is required").openapi({ example: "cust_123" }),
-        })
-      ),
-    },
-  },
+  params: IdParamSchema,
+  body: assignBodySchema,
   responses: {
     200: {
       description: "Tag assigned",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          message: z.string().openapi({ example: "Tag assigned" }),
-        })
-      ),
+      content: jsonContent(MessageResponseSchema),
     },
-    400: errorResponse("Validation error (missing customerId)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_tags:manage scope"),
-    404: errorResponse("Tag or customer not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.assignTag,
 });
 
-const unassignTagRoute = createRoute({
+const unassignTagRoute = defineRoute({
   method: "delete",
   path: "/{id}/assignments/{customerId}",
-  middleware: [requireScope(SCOPES.CUSTOMER_TAGS_MANAGE)],
+  auth: { scope: SCOPES.CUSTOMER_TAGS_MANAGE },
   tags: ["Customer Tags"],
   summary: "Unassign tag from customer",
   description:
     "Removes the tag from a customer. Idempotent — succeeds silently if not assigned. Decrements `assignmentCount`.",
   operationId: "unassignTag",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Customer tag ID", example: "tag_123" }),
-      customerId: z.string().openapi({ description: "Customer ID", example: "cust_123" }),
-    }),
-  },
+  params: unassignParamsSchema,
   responses: {
     200: {
       description: "Tag unassigned",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          message: z.string().openapi({ example: "Tag unassigned" }),
-        })
-      ),
+      content: jsonContent(MessageResponseSchema),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_tags:manage scope"),
-    404: errorResponse("Tag not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.unassignTag,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(listTagsRoute, h.listTags);
-router.openapi(createTagRoute, h.createTag);
-router.openapi(getTagRoute, h.getTag);
-router.openapi(updateTagRoute, h.updateTag);
-router.openapi(deleteTagRoute, h.deleteTag);
-router.openapi(assignTagRoute, h.assignTag);
-router.openapi(unassignTagRoute, h.unassignTag);
+router.openapi(listTagsRoute.route, listTagsRoute.handler);
+router.openapi(createTagRoute.route, createTagRoute.handler);
+router.openapi(getTagRoute.route, getTagRoute.handler);
+router.openapi(updateTagRoute.route, updateTagRoute.handler);
+router.openapi(deleteTagRoute.route, deleteTagRoute.handler);
+router.openapi(assignTagRoute.route, assignTagRoute.handler);
+router.openapi(unassignTagRoute.route, unassignTagRoute.handler);
 
 export default router;
-

--- a/cod-server/src/endpoints/customers/routes.ts
+++ b/cod-server/src/endpoints/customers/routes.ts
@@ -5,15 +5,12 @@
  * membership lookups. All routes require an API key with the appropriate
  * scope (customers:* for profile access, customer_groups:read /
  * customer_tags:read for membership lookups).
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import * as handlers from "./handlers";
 import {
@@ -21,18 +18,14 @@ import {
   CustomerOrderSummarySchema,
   CustomerGroupMembershipSchema,
   CustomerTagMembershipSchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
+  SuccessWithMessageSchema,
+  MessageResponseSchema,
   ListResponseSchema,
 } from "@/openapi/schemas";
 
 const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
-});
-
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
 });
 
 const phoneRegex = /^0[5-7]\d{8}$/;
@@ -48,245 +41,203 @@ const idParams = z.object({
   id: z.string().openapi({ description: "Customer ID", example: "550e8400-e29b-41d4-a716-446655440000" }),
 });
 
-const listCustomersRoute = createRoute({
+// ─── Request schemas ──────────────────────────────────────────────────────────
+
+const listQuerySchema = z.object({
+  wilayaId: z.coerce.number().int().min(1).max(58).optional().openapi({
+    description: "Filter by wilaya ID (1–58)",
+  }),
+  search: z.string().optional().openapi({ description: "Search by customer name or phone" }),
+  groupId: z.string().optional().openapi({
+    description: "Filter to customers in a specific customer group",
+  }),
+  tagId: z.string().optional().openapi({
+    description: "Filter to customers with a specific tag",
+  }),
+  limit: z.coerce.number().int().positive().max(100).default(50).openapi({
+    description: "Maximum number of results to return",
+  }),
+  offset: z.coerce.number().int().min(0).default(0).openapi({
+    description: "Number of results to skip for pagination",
+  }),
+});
+
+const createBodySchema = z.object({
+  name: z.string().min(1, "Name is required").openapi({ example: "Ahmed Benali" }),
+  phone: phoneField(),
+  phone2: z.preprocess(
+    (v) => (v === "" || v == null ? undefined : v),
+    z.string().regex(phoneRegex, "Invalid Algerian phone number").optional()
+  ).openapi({ description: "Secondary phone number (optional)" }),
+  wilayaId: z.number().int().min(1).max(58).openapi({
+    description: "Official wilaya number (1–58)",
+    example: 16,
+  }),
+  communeId: z.string().min(1, "Commune is required").openapi({
+    description: "Commune UUID from /api/wilayas/{id}/communes",
+    example: "550e8400-e29b-41d4-a716-446655440000",
+  }),
+  address: z.string().optional().openapi({ example: "12 Rue Didouche Mourad" }),
+});
+
+const updateBodySchema = z.object({
+  name: z.string().min(1, "Name is required").optional().openapi({ example: "Ahmed Benali" }),
+  phone: phoneField().optional(),
+  phone2: z.preprocess(
+    (v) => (v === "" ? null : v),
+    z.string().regex(phoneRegex, "Invalid Algerian phone number").nullable().optional()
+  ).openapi({ description: "Secondary phone. Set to null to clear it." }),
+  wilayaId: z.number().int().min(1).max(58).optional().openapi({
+    description: "Official wilaya number (1–58)",
+    example: 16,
+  }),
+  communeId: z.string().min(1, "Commune is required").nullable().optional().openapi({
+    description: "Commune UUID. Set to null to clear.",
+  }),
+  address: z.string().nullable().optional().openapi({
+    description: "Street address. Set to null to clear it.",
+  }),
+});
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const listCustomersRoute = defineRoute({
   method: "get",
   path: "/",
-  middleware: [requireScope(SCOPES.CUSTOMERS_READ)],
+  auth: { scope: SCOPES.CUSTOMERS_READ },
   tags: ["Customers"],
   summary: "List customers",
   description:
     "Returns a paginated list of customers. Use `groupId` or `tagId` to filter by segment. Use `wilayaId` to filter by wilaya.",
   operationId: "listCustomers",
-  request: {
-    query: z.object({
-      wilayaId: z.coerce.number().int().min(1).max(58).optional().openapi({
-        description: "Filter by wilaya ID (1–58)",
-      }),
-      search: z.string().optional().openapi({ description: "Search by customer name or phone" }),
-      groupId: z.string().optional().openapi({
-        description: "Filter to customers in a specific customer group",
-      }),
-      tagId: z.string().optional().openapi({
-        description: "Filter to customers with a specific tag",
-      }),
-      limit: z.coerce.number().int().positive().max(100).default(50).openapi({
-        description: "Maximum number of results to return",
-      }),
-      offset: z.coerce.number().int().min(0).default(0).openapi({
-        description: "Number of results to skip for pagination",
-      }),
-    }),
-  },
+  query: listQuerySchema,
   responses: {
     200: {
       description: "List of customers",
       content: jsonContent(ListResponseSchema(CustomerSchema)),
     },
-    400: errorResponse("Validation error - invalid query parameters"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customers:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.listCustomers,
 });
 
-const createCustomerRoute = createRoute({
+const createCustomerRoute = defineRoute({
   method: "post",
   path: "/",
-  middleware: [requireScope(SCOPES.CUSTOMERS_CREATE)],
+  auth: { scope: SCOPES.CUSTOMERS_CREATE },
   tags: ["Customers"],
   summary: "Create customer",
   description:
     "Register a new customer profile. Resolves wilayaId/communeId to their Arabic display names automatically.",
   operationId: "createCustomer",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          name: z.string().min(1, "Name is required").openapi({ example: "Ahmed Benali" }),
-          phone: phoneField(),
-          phone2: z.preprocess(
-            (v) => (v === "" || v == null ? undefined : v),
-            z.string().regex(phoneRegex, "Invalid Algerian phone number").optional()
-          ).openapi({ description: "Secondary phone number (optional)" }),
-          wilayaId: z.number().int().min(1).max(58).openapi({
-            description: "Official wilaya number (1–58)",
-            example: 16,
-          }),
-          communeId: z.string().min(1, "Commune is required").openapi({
-            description: "Commune UUID from /api/wilayas/{id}/communes",
-            example: "550e8400-e29b-41d4-a716-446655440000",
-          }),
-          address: z.string().optional().openapi({ example: "12 Rue Didouche Mourad" }),
-        })
-      ),
-    },
-  },
+  body: createBodySchema,
   responses: {
     201: {
       description:
         "Customer created. Response includes the full customer record with recentOrders (empty array for new customers).",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          data: CustomerSchema,
-          message: z.string().openapi({ example: "Customer created successfully" }),
-        })
-      ),
+      content: jsonContent(SuccessWithMessageSchema(CustomerSchema)),
     },
-    400: errorResponse("Validation error (invalid phone format, missing required fields)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customers:create scope"),
-    409: errorResponse("Duplicate phone number - a customer with this phone already exists (code: DUPLICATE_PHONE)"),
+    409: {
+      description:
+        "Duplicate phone number - a customer with this phone already exists (code: DUPLICATE_PHONE)",
+    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.createCustomer,
 });
 
-const getCustomerRoute = createRoute({
+const getCustomerRoute = defineRoute({
   method: "get",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.CUSTOMERS_READ)],
+  auth: { scope: SCOPES.CUSTOMERS_READ },
   tags: ["Customers"],
   summary: "Get customer",
   description: "Returns the full customer record plus `recentOrders` (up to 10 most recent orders).",
   operationId: "getCustomer",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Customer detail including recentOrders",
       content: jsonContent(SuccessResponseSchema(CustomerSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customers:read scope"),
-    404: errorResponse("Customer not found (code: CUSTOMER_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.getCustomer,
 });
 
-const updateCustomerRoute = createRoute({
+const updateCustomerRoute = defineRoute({
   method: "patch",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.CUSTOMERS_UPDATE)],
+  auth: { scope: SCOPES.CUSTOMERS_UPDATE },
   tags: ["Customers"],
   summary: "Update customer",
   description:
     "Partial update — only include fields you want to change. Set `phone2`, `communeId`, or `address` to null to clear them.",
   operationId: "updateCustomer",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          name: z.string().min(1, "Name is required").optional().openapi({ example: "Ahmed Benali" }),
-          phone: phoneField().optional(),
-          phone2: z.preprocess(
-            (v) => (v === "" ? null : v),
-            z.string().regex(phoneRegex, "Invalid Algerian phone number").nullable().optional()
-          ).openapi({ description: "Secondary phone. Set to null to clear it." }),
-          wilayaId: z.number().int().min(1).max(58).optional().openapi({
-            description: "Official wilaya number (1–58)",
-            example: 16,
-          }),
-          communeId: z.string().min(1, "Commune is required").nullable().optional().openapi({
-            description: "Commune UUID. Set to null to clear.",
-          }),
-          address: z.string().nullable().optional().openapi({
-            description: "Street address. Set to null to clear it.",
-          }),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: updateBodySchema,
   responses: {
     200: {
       description: "Customer updated. Returns the full updated customer record.",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          data: CustomerSchema,
-          message: z.string().openapi({ example: "Customer updated successfully" }),
-        })
-      ),
+      content: jsonContent(SuccessWithMessageSchema(CustomerSchema)),
     },
-    400: errorResponse("Validation error (invalid phone format)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customers:update scope"),
-    404: errorResponse("Customer not found (code: CUSTOMER_NOT_FOUND)"),
-    409: errorResponse("Duplicate phone number - a customer with this phone already exists (code: DUPLICATE_PHONE)"),
+    409: {
+      description:
+        "Duplicate phone number - a customer with this phone already exists (code: DUPLICATE_PHONE)",
+    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.updateCustomer,
 });
 
-const deleteCustomerRoute = createRoute({
+const deleteCustomerRoute = defineRoute({
   method: "delete",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.CUSTOMERS_DELETE)],
+  auth: { scope: SCOPES.CUSTOMERS_DELETE },
   tags: ["Customers"],
   summary: "Delete customer",
   description:
     "Permanently deletes the customer. **Blocked with 422 if the customer has any orders** — remove or reassign the orders first.",
   operationId: "deleteCustomer",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Customer permanently deleted",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          message: z.string().openapi({ example: "Customer deleted successfully" }),
-        })
-      ),
+      content: jsonContent(MessageResponseSchema),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customers:delete scope"),
-    404: errorResponse("Customer not found (code: CUSTOMER_NOT_FOUND)"),
-    422: errorResponse(
-      "Cannot delete customer with existing orders (code: CUSTOMER_HAS_ORDERS). The context includes orderCount."
-    ),
+    422: {
+      description:
+        "Cannot delete customer with existing orders (code: CUSTOMER_HAS_ORDERS). The context includes orderCount.",
+    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.deleteCustomer,
 });
 
-const listCustomerOrdersRoute = createRoute({
+const listCustomerOrdersRoute = defineRoute({
   method: "get",
   path: "/{id}/orders",
-  middleware: [requireScope(SCOPES.CUSTOMERS_READ)],
+  auth: { scope: SCOPES.CUSTOMERS_READ },
   tags: ["Customers"],
   summary: "Get customer orders",
   description:
     "Returns all orders for a customer in reverse chronological order, each with `statusHistory` included.",
   operationId: "getCustomerOrders",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "List of customer orders (each includes statusHistory)",
       content: jsonContent(ListResponseSchema(CustomerOrderSummarySchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customers:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.listCustomerOrders,
 });
 
-const listCustomerGroupsRoute = createRoute({
+const listCustomerGroupsRoute = defineRoute({
   method: "get",
   path: "/{id}/groups",
-  middleware: [requireScope(SCOPES.CUSTOMER_GROUPS_READ)],
+  auth: { scope: SCOPES.CUSTOMER_GROUPS_READ },
   tags: ["Customers"],
   summary: "Get customer groups",
   description:
     "Returns all customer groups the customer belongs to, including the `assignedAt` timestamp for each membership.",
   operationId: "getCustomerGroups",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "List of groups the customer belongs to",
@@ -297,24 +248,20 @@ const listCustomerGroupsRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_groups:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.listCustomerGroups,
 });
 
-const listCustomerTagsRoute = createRoute({
+const listCustomerTagsRoute = defineRoute({
   method: "get",
   path: "/{id}/tags",
-  middleware: [requireScope(SCOPES.CUSTOMER_TAGS_READ)],
+  auth: { scope: SCOPES.CUSTOMER_TAGS_READ },
   tags: ["Customers"],
   summary: "Get customer tags",
   description:
     "Returns all tags assigned to the customer, including the `assignedAt` timestamp for each assignment.",
   operationId: "getCustomerTags",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "List of tags assigned to the customer",
@@ -325,21 +272,21 @@ const listCustomerTagsRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing customer_tags:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.listCustomerTags,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(listCustomersRoute, handlers.listCustomers);
-router.openapi(createCustomerRoute, handlers.createCustomer);
-router.openapi(getCustomerRoute, handlers.getCustomer);
-router.openapi(updateCustomerRoute, handlers.updateCustomer);
-router.openapi(deleteCustomerRoute, handlers.deleteCustomer);
-router.openapi(listCustomerOrdersRoute, handlers.listCustomerOrders);
-router.openapi(listCustomerGroupsRoute, handlers.listCustomerGroups);
-router.openapi(listCustomerTagsRoute, handlers.listCustomerTags);
+router.openapi(listCustomersRoute.route, listCustomersRoute.handler);
+router.openapi(createCustomerRoute.route, createCustomerRoute.handler);
+router.openapi(getCustomerRoute.route, getCustomerRoute.handler);
+router.openapi(updateCustomerRoute.route, updateCustomerRoute.handler);
+router.openapi(deleteCustomerRoute.route, deleteCustomerRoute.handler);
+router.openapi(listCustomerOrdersRoute.route, listCustomerOrdersRoute.handler);
+router.openapi(listCustomerGroupsRoute.route, listCustomerGroupsRoute.handler);
+router.openapi(listCustomerTagsRoute.route, listCustomerTagsRoute.handler);
 
 export default router;

--- a/cod-server/src/endpoints/driver-payments/routes.ts
+++ b/cod-server/src/endpoints/driver-payments/routes.ts
@@ -4,40 +4,34 @@
  * Records payment events that settle batches of delivered orders for a
  * driver (COD remittance, fee payment, or net settlement) and exposes the
  * data needed for pre-settlement review.
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import * as handlers from "./handlers";
 import { createPaymentSchema } from "./validation";
 import {
   DriverPaymentSchema,
-  ErrorResponseSchema,
+  SuccessWithMessageSchema,
 } from "@/openapi/schemas";
 
 const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
 
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
-});
-
 const driverIdParams = z.object({
   driverId: z.string().openapi({ description: "UUID of the driver" }),
 });
 
-const createPaymentRoute = createRoute({
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const createPaymentRoute = defineRoute({
   method: "post",
   path: "/",
-  middleware: [requireScope(SCOPES.DELIVERY_MANAGE)],
+  auth: { scope: SCOPES.DELIVERY_MANAGE },
   tags: ["Driver Payments"],
   summary: "Create driver payment",
   description: `Record a payment event that settles a batch of delivered orders for a driver.
@@ -63,45 +57,31 @@ const createPaymentRoute = createRoute({
 
 \`createdBy\` and \`createdByName\` are derived from the authenticated user and cannot be overridden.`,
   operationId: "createDriverPayment",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(createPaymentSchema),
-    },
-  },
+  body: createPaymentSchema,
   responses: {
     201: {
       description: "Payment created and orders settled. Returns the new payment record.",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          data: DriverPaymentSchema,
-          message: z.string().openapi({ example: "Payment recorded successfully" }),
-        })
-      ),
+      content: jsonContent(SuccessWithMessageSchema(DriverPaymentSchema)),
     },
-    400: errorResponse("Validation error — missing required fields, empty orderIds array, or invalid payment type"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:manage scope"),
-    422: errorResponse(`Business rule violation. Distinguish via the \`code\` field:
+    422: {
+      description: `Business rule violation. Distinguish via the \`code\` field:
 - \`ORDER_NOT_FOUND\` — one or more orders do not exist, are not in \`delivered\` status, or do not belong to this driver
-- \`PAYMENT_ALREADY_SETTLED\` — one or more orders are already settled for the requested payment type. \`context.kind\` is \`"cod"\` (when \`codPaymentId\` is already set) or \`"fee"\` (when \`feePaymentId\` is already set).`),
+- \`PAYMENT_ALREADY_SETTLED\` — one or more orders are already settled for the requested payment type. \`context.kind\` is \`"cod"\` (when \`codPaymentId\` is already set) or \`"fee"\` (when \`feePaymentId\` is already set).`,
+    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.createPayment,
 });
 
-const listPaymentsRoute = createRoute({
+const listPaymentsRoute = defineRoute({
   method: "get",
   path: "/{driverId}",
-  middleware: [requireScope(SCOPES.DELIVERY_READ)],
+  auth: { scope: SCOPES.DELIVERY_READ },
   tags: ["Driver Payments"],
   summary: "List driver payment history",
   description:
     "Returns all payment records for a driver, most recent first. Returns an empty array if the driver has no payments or the driver ID does not exist.",
   operationId: "listDriverPayments",
-  request: {
-    params: driverIdParams,
-  },
+  params: driverIdParams,
   responses: {
     200: {
       description: "Payment history (empty array if driver has no payments)",
@@ -112,16 +92,14 @@ const listPaymentsRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.listPayments,
 });
 
-const listPendingOrdersRoute = createRoute({
+const listPendingOrdersRoute = defineRoute({
   method: "get",
   path: "/{driverId}/pending",
-  middleware: [requireScope(SCOPES.DELIVERY_READ)],
+  auth: { scope: SCOPES.DELIVERY_READ },
   tags: ["Driver Payments"],
   summary: "List pending settlement orders",
   description: `Returns delivered orders that still have unsettled COD for a driver.
@@ -130,9 +108,7 @@ Specifically: orders where \`driverId\` matches, \`status = 'delivered'\`, and \
 
 Use this before creating a \`cod_remittance\` or \`net_settlement\` payment to see which orders are eligible and calculate the total. Returns an empty array if the driver has no pending orders or does not exist.`,
   operationId: "listPendingSettlementOrders",
-  request: {
-    params: driverIdParams,
-  },
+  params: driverIdParams,
   responses: {
     200: {
       description:
@@ -150,16 +126,16 @@ Use this before creating a \`cod_remittance\` or \`net_settlement\` payment to s
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.listPendingOrders,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(createPaymentRoute, handlers.createPayment);
-router.openapi(listPaymentsRoute, handlers.listPayments);
-router.openapi(listPendingOrdersRoute, handlers.listPendingOrders);
+router.openapi(createPaymentRoute.route, createPaymentRoute.handler);
+router.openapi(listPaymentsRoute.route, listPaymentsRoute.handler);
+router.openapi(listPendingOrdersRoute.route, listPendingOrdersRoute.handler);
 
 export default router;

--- a/cod-server/src/endpoints/reviews/routes.ts
+++ b/cod-server/src/endpoints/reviews/routes.ts
@@ -3,20 +3,16 @@
  *
  * CRM endpoints for moderation of product reviews submitted via the storefront.
  * All routes require an API key with the appropriate reviews scope.
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import * as h from "./handlers";
 import {
   ReviewSchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
 } from "@/openapi/schemas";
 
@@ -24,10 +20,7 @@ const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
 
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
-});
+// ─── Response schemas ─────────────────────────────────────────────────────────
 
 const reviewListResponseSchema = z.object({
   success: z.boolean().openapi({ example: true }),
@@ -39,87 +32,81 @@ const reviewListResponseSchema = z.object({
   }),
 });
 
-const listReviewsRoute = createRoute({
+// ─── Request schemas ──────────────────────────────────────────────────────────
+
+const listQuerySchema = z.object({
+  status: z.enum(["pending", "approved", "rejected"]).optional().openapi({
+    description: "Filter by moderation status",
+  }),
+  productId: z.string().optional().openapi({
+    description: "Filter by product ID",
+  }),
+  limit: z.coerce.number().int().min(1).max(100).default(20).openapi({
+    description: "Maximum number of reviews to return",
+  }),
+  offset: z.coerce.number().int().min(0).default(0).openapi({
+    description: "Number of reviews to skip",
+  }),
+});
+
+const idParams = z.object({
+  id: z.string().openapi({ description: "Review ID", example: "rev_123" }),
+});
+
+const updateBodySchema = z.object({
+  status: z.enum(["pending", "approved", "rejected"]).openapi({
+    description: "New moderation status",
+  }),
+});
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const listReviewsRoute = defineRoute({
   method: "get",
   path: "/",
+  auth: { scope: SCOPES.REVIEWS_READ },
   tags: ["Reviews"],
   summary: "List reviews",
   description: "Get all product reviews with optional status and product filters. Requires `reviews:read` scope.",
   operationId: "listReviews",
-  request: {
-    query: z.object({
-      status: z.enum(["pending", "approved", "rejected"]).optional().openapi({
-        description: "Filter by moderation status",
-      }),
-      productId: z.string().optional().openapi({
-        description: "Filter by product ID",
-      }),
-      limit: z.coerce.number().int().min(1).max(100).default(20).openapi({
-        description: "Maximum number of reviews to return",
-      }),
-      offset: z.coerce.number().int().min(0).default(0).openapi({
-        description: "Number of reviews to skip",
-      }),
-    }),
-  },
+  query: listQuerySchema,
   responses: {
     200: {
       description: "List of reviews",
       content: jsonContent(reviewListResponseSchema),
     },
-    400: errorResponse("Invalid filter value (VALIDATION_FAILED)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires reviews:read"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.listReviews,
 });
 
-const updateReviewRoute = createRoute({
+const updateReviewRoute = defineRoute({
   method: "patch",
   path: "/{id}",
+  auth: { scope: SCOPES.REVIEWS_MANAGE },
   tags: ["Reviews"],
   summary: "Update review status",
   description: "Approve or reject a review. Requires `reviews:manage` scope.",
   operationId: "updateReview",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Review ID", example: "rev_123" }),
-    }),
-    body: {
-      content: jsonContent(
-        z.object({
-          status: z.enum(["pending", "approved", "rejected"]).openapi({
-            description: "New moderation status",
-          }),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: updateBodySchema,
   responses: {
     200: {
       description: "Updated review",
       content: jsonContent(SuccessResponseSchema(ReviewSchema)),
     },
-    400: errorResponse("Validation error — invalid or missing status (VALIDATION_FAILED)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires reviews:manage"),
-    404: errorResponse("Review not found (REVIEW_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.updateReview,
 });
 
-const deleteReviewRoute = createRoute({
+const deleteReviewRoute = defineRoute({
   method: "delete",
   path: "/{id}",
+  auth: { scope: SCOPES.REVIEWS_MANAGE },
   tags: ["Reviews"],
   summary: "Delete review",
   description: "Permanently delete a review. Requires `reviews:manage` scope.",
   operationId: "deleteReview",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Review ID", example: "rev_123" }),
-    }),
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Review deleted",
@@ -129,21 +116,16 @@ const deleteReviewRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires reviews:manage"),
-    404: errorResponse("Review not found (REVIEW_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.deleteReview,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
-router.use("/", requireScope(SCOPES.REVIEWS_READ));
-router.use("/:id", requireScope(SCOPES.REVIEWS_MANAGE));
-
-router.openapi(listReviewsRoute, h.listReviews);
-router.openapi(updateReviewRoute, h.updateReview);
-router.openapi(deleteReviewRoute, h.deleteReview);
+router.openapi(listReviewsRoute.route, listReviewsRoute.handler);
+router.openapi(updateReviewRoute.route, updateReviewRoute.handler);
+router.openapi(deleteReviewRoute.route, deleteReviewRoute.handler);
 
 export default router;
-

--- a/cod-server/src/endpoints/webhooks/routes.ts
+++ b/cod-server/src/endpoints/webhooks/routes.ts
@@ -8,16 +8,18 @@
  * Mount order in index.ts:
  *   app.route("/webhooks", webhooksRouter)  ← BEFORE app.use("/api/*", authMiddleware)
  *
- * Migrated to @hono/zod-openapi for the OpenAPI spec. Deliberately NO
- * request-body validation on the event-delivery routes: handlers must read
- * the RAW body (c.req.text()) before any JSON parsing because Svix
- * signatures verify raw bytes — framework parsing here would break that
- * contract. Payload shapes are documented in the route descriptions and the
- * handlers enforce their own specific error codes.
+ * Built with defineRoute() — the standard route-builder pattern.
+ *
+ * Deliberately NO request-body validation on the event-delivery routes:
+ * handlers must read the RAW body (c.req.text()) before any JSON parsing
+ * because Svix signatures verify raw bytes — framework parsing here would
+ * break that contract. Payload shapes are documented in the route
+ * descriptions and the handlers enforce their own specific error codes.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
+import { defineRoute } from "@/lib/route-builder";
 import {
   handleYalidineChallenge,
   handleYalidineWebhook,
@@ -28,6 +30,8 @@ const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
 
+// ─── Response schemas ─────────────────────────────────────────────────────────
+
 const receivedResponse = {
   description: "Event received (always 200 — carriers retry on non-200)",
   content: jsonContent(
@@ -37,9 +41,24 @@ const receivedResponse = {
   ),
 };
 
-const yalidineChallengeRoute = createRoute({
+const webhookErrorResponse = (code: string, category: string, description: string) => ({
+  description,
+  content: jsonContent(
+    z.object({
+      error: z.string(),
+      code: z.string().openapi({ example: code }),
+      category: z.string().openapi({ example: category }),
+      context: z.record(z.string(), z.unknown()).optional(),
+    })
+  ),
+});
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const yalidineChallengeRoute = defineRoute({
   method: "get",
   path: "/yalidine",
+  auth: "public",
   tags: ["Webhooks"],
   summary: "Yalidine CRC challenge",
   description:
@@ -47,20 +66,18 @@ const yalidineChallengeRoute = createRoute({
     "at creation, edit, and periodically. The endpoint echoes the crc_token as plain text. " +
     "If this fails, Yalidine disables the webhook automatically.",
   operationId: "yalidineChallenge",
-  request: {
-    query: z.object({
-      subscribe: z.string().optional().openapi({
-        description: "Sent by Yalidine to initiate the CRC challenge",
-      }),
-      crc_token: z.string().optional().openapi({
-        description: "Token echoed back in the (plain-text) response body",
-      }),
+  query: z.object({
+    subscribe: z.string().optional().openapi({
+      description: "Sent by Yalidine to initiate the CRC challenge",
     }),
-  },
+    crc_token: z.string().optional().openapi({
+      description: "Token echoed back in the (plain-text) response body",
+    }),
+  }),
   responses: {
     // Documented contract: crc_token echoed as text/plain. Without challenge
     // params the legacy handler answers a tiny {ok:true} JSON ack instead —
-    // the dual return predates typed routes, hence the registration cast below.
+    // the dual return predates typed routes.
     200: {
       description: "CRC token echoed as plain text",
       content: {
@@ -70,11 +87,13 @@ const yalidineChallengeRoute = createRoute({
       },
     },
   },
+  handler: handleYalidineChallenge,
 });
 
-const yalidineWebhookRoute = createRoute({
+const yalidineWebhookRoute = defineRoute({
   method: "post",
   path: "/yalidine",
+  auth: "public",
   tags: ["Webhooks"],
   summary: "Yalidine event delivery",
   description: `Receives webhook event batches from Yalidine. One event type per request, multiple events per batch. Each event carries its own idempotency key (\`event_id\`). Always returns 200 — errors are logged internally.
@@ -85,34 +104,24 @@ Invalid payloads are rejected with \`400 INVALID_WEBHOOK_PAYLOAD\`; processing f
   operationId: "yalidineWebhook",
   responses: {
     200: receivedResponse,
-    400: {
-      description: "Invalid webhook payload (INVALID_WEBHOOK_PAYLOAD)",
-      content: jsonContent(
-        z.object({
-          error: z.string(),
-          code: z.string().openapi({ example: "INVALID_WEBHOOK_PAYLOAD" }),
-          category: z.string().openapi({ example: "VALIDATION" }),
-          context: z.record(z.string(), z.unknown()).optional(),
-        })
-      ),
-    },
-    502: {
-      description: "Webhook processing failed (EXTERNAL_API_FAILURE)",
-      content: jsonContent(
-        z.object({
-          error: z.string(),
-          code: z.string().openapi({ example: "EXTERNAL_API_FAILURE" }),
-          category: z.string().openapi({ example: "SYSTEM" }),
-          context: z.record(z.string(), z.unknown()).optional(),
-        })
-      ),
-    },
+    400: webhookErrorResponse(
+      "INVALID_WEBHOOK_PAYLOAD",
+      "VALIDATION",
+      "Invalid webhook payload (INVALID_WEBHOOK_PAYLOAD)"
+    ),
+    502: webhookErrorResponse(
+      "EXTERNAL_API_FAILURE",
+      "SYSTEM",
+      "Webhook processing failed (EXTERNAL_API_FAILURE)"
+    ),
   },
+  handler: handleYalidineWebhook,
 });
 
-const zrWebhookRoute = createRoute({
+const zrWebhookRoute = defineRoute({
   method: "post",
   path: "/zr_express",
+  auth: "public",
   tags: ["Webhooks"],
   summary: "ZR Express event delivery",
   description: `Receives webhook events from ZR Express via Svix. Signature is verified using HMAC-SHA256 with the stored whsec_ secret over the RAW request bytes. Idempotency key is the \`svix-id\` header. Always returns 200.
@@ -121,47 +130,33 @@ const zrWebhookRoute = createRoute({
 
 Signature/payload failures are rejected with \`400 INVALID_WEBHOOK_PAYLOAD\`; processing failures surface as \`502 EXTERNAL_API_FAILURE\`.`,
   operationId: "zrExpressWebhook",
-  request: {
-    headers: z.object({
-      "svix-id": z.string().openapi({ description: "Svix idempotency key" }),
-      "svix-timestamp": z.string().openapi({ description: "Svix signed timestamp" }),
-      "svix-signature": z.string().openapi({ description: "Svix HMAC-SHA256 signature" }),
-    }),
-  },
+  headers: z.object({
+    "svix-id": z.string().openapi({ description: "Svix idempotency key" }),
+    "svix-timestamp": z.string().openapi({ description: "Svix signed timestamp" }),
+    "svix-signature": z.string().openapi({ description: "Svix HMAC-SHA256 signature" }),
+  }),
   responses: {
     200: receivedResponse,
-    400: {
-      description: "Invalid webhook payload or signature (INVALID_WEBHOOK_PAYLOAD)",
-      content: jsonContent(
-        z.object({
-          error: z.string(),
-          code: z.string().openapi({ example: "INVALID_WEBHOOK_PAYLOAD" }),
-          category: z.string().openapi({ example: "VALIDATION" }),
-          context: z.record(z.string(), z.unknown()).optional(),
-        })
-      ),
-    },
-    502: {
-      description: "Webhook processing failed (EXTERNAL_API_FAILURE)",
-      content: jsonContent(
-        z.object({
-          error: z.string(),
-          code: z.string().openapi({ example: "EXTERNAL_API_FAILURE" }),
-          category: z.string().openapi({ example: "SYSTEM" }),
-          context: z.record(z.string(), z.unknown()).optional(),
-        })
-      ),
-    },
+    400: webhookErrorResponse(
+      "INVALID_WEBHOOK_PAYLOAD",
+      "VALIDATION",
+      "Invalid webhook payload or signature (INVALID_WEBHOOK_PAYLOAD)"
+    ),
+    502: webhookErrorResponse(
+      "EXTERNAL_API_FAILURE",
+      "SYSTEM",
+      "Webhook processing failed (EXTERNAL_API_FAILURE)"
+    ),
   },
+  handler: handleZrWebhook,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const webhooksRouter = new OpenAPIHono<AppContext>();
 
-// Dual-protocol endpoint (text/plain challenge ack vs JSON ack when params
-// are absent) — the union return predates typed routes, so registration
-// widens the handler type. Runtime behavior is unchanged.
-webhooksRouter.openapi(yalidineChallengeRoute, handleYalidineChallenge as never);
-webhooksRouter.openapi(yalidineWebhookRoute, handleYalidineWebhook);
-webhooksRouter.openapi(zrWebhookRoute, handleZrWebhook);
+webhooksRouter.openapi(yalidineChallengeRoute.route, yalidineChallengeRoute.handler);
+webhooksRouter.openapi(yalidineWebhookRoute.route, yalidineWebhookRoute.handler);
+webhooksRouter.openapi(zrWebhookRoute.route, zrWebhookRoute.handler);
 
 export default webhooksRouter;

--- a/cod-server/src/lib/ROUTE-BUILDER-CHANGELOG.md
+++ b/cod-server/src/lib/ROUTE-BUILDER-CHANGELOG.md
@@ -1,5 +1,46 @@
 # Route Builder - Change Log
 
+## [Unreleased] - 2026-08-31
+
+### ✅ Added: Public Routes and Header Schemas (webhooks migration)
+
+**Problem:**
+- `auth` was mandatory with no way to express an unauthenticated endpoint
+- Webhook receivers (Yalidine, ZR Express) are public — signature-verified
+  inside their handlers, no API key, no `security` block in the spec
+- `defineRoute()` had no `headers` support; the ZR receiver documents its
+  required `svix-*` headers via `request.headers`
+
+**Added:**
+
+```typescript
+// 1. "public" auth strategy — no middleware, security omitted from the spec
+const webhookRoute = defineRoute({
+  method: "post",
+  path: "/zr_express",
+  auth: "public",
+  headers: z.object({ "svix-id": z.string(), ... }),  // 2. new
+  responses: { ... },
+  handler: handlers.handleZrWebhook,
+});
+
+// 2. headers?: ZodType — passed through to request.headers
+```
+
+**Behavior details:**
+- `auth: "public"` omits the `security` key entirely (NOT `security: []`) —
+  matches raw `createRoute()` routes without a security block, verified by
+  `serve.test.ts` asserting `post.security` is `undefined` on `/webhooks/zr_express`
+- Public routes get no auto-generated 401 and never get 403
+- Backward compatible — existing strategies unchanged
+
+**Testing:**
+- ✅ Typecheck passes
+- ✅ Webhooks route tests pass side-by-side against old and new routers
+- ✅ Full suite green (spec assertions included)
+
+---
+
 ## [Unreleased] - 2026-08-23
 
 ### ✅ Fixed: Type Safety (Issue #1 from Code Review)

--- a/cod-server/src/lib/route-builder.ts
+++ b/cod-server/src/lib/route-builder.ts
@@ -33,6 +33,8 @@ import { ErrorResponseSchema } from "@/openapi/schemas";
 /**
  * Authentication strategy for the route.
  * 
+ * - "public": No auth middleware, no security requirement (signature-verified
+ *   receivers, health checks, etc.)
  * - "api-key": Requires X-API-Key header (any authenticated user)
  * - "admin": Requires X-API-Key + admin role
  * - "store": Requires X-Store-API-Key header
@@ -41,6 +43,7 @@ import { ErrorResponseSchema } from "@/openapi/schemas";
  * - { allOf: ["orders:read", "products:read"] }: Requires all scopes
  */
 export type AuthStrategy =
+  | "public"
   | "api-key"
   | "admin"
   | "store"
@@ -62,6 +65,7 @@ export interface RouteDefinition {
   query?: ZodType;                            // Query parameters (GET /users?role=admin)
   params?: ZodType;                           // Path parameters (GET /users/:id)
   body?: ZodType;                             // Request body (POST /users)
+  headers?: ZodType;                          // Request headers (POST /webhooks with svix-*)
   handler: (c: Context<AppContext>) => any;   // Your handler function
   
   /**
@@ -125,8 +129,10 @@ const standardErrors: Record<number, any> = {
  * Convert auth strategy to Hono middleware array.
  */
 function resolveAuthMiddleware(auth: AuthStrategy) {
-  if (auth === "api-key") {
-    // Just authMiddleware (loaded at app level) — no additional middleware
+  if (auth === "public" || auth === "api-key") {
+    // No additional middleware — public routes are unprotected (handlers
+    // verify signatures themselves when needed); api-key routes rely on the
+    // app-level authMiddleware.
     return [];
   }
   if (auth === "admin") {
@@ -149,6 +155,13 @@ function resolveAuthMiddleware(auth: AuthStrategy) {
  * Convert auth strategy to OpenAPI security requirement.
  */
 function resolveSecurity(auth: AuthStrategy) {
+  if (auth === "public") {
+    // Omit the security requirement entirely — matches routes that declare
+    // no security (public receivers). `security: []` would also render, so
+    // undefined is what keeps the generated spec identical to raw
+    // createRoute() calls without a security block.
+    return undefined;
+  }
   if (auth === "store") {
     return [{ StoreAuth: [] }];
   }
@@ -182,16 +195,19 @@ function generateSuccessResponse(method: string): Record<number, any> {
  */
 function generateErrorResponses(method: string, auth: AuthStrategy) {
   const errors: Record<number, any> = { ...standardErrors };
-  
-  // Add 403 for endpoints that might have permission checks
-  if (method !== "get" || auth === "admin" || (typeof auth === "object" && "scope" in auth)) {
+
+  if (auth === "public") {
+    // Public routes have no auth to fail — drop 401, never add 403
+    delete errors[401];
+  } else if (method !== "get" || auth === "admin" || (typeof auth === "object" && "scope" in auth)) {
+    // Add 403 for endpoints that might have permission checks
     errors[403] = errorResponse("Permission denied");
   }
-  
+
   // Add 404 for routes with params (/:id endpoints)
   // Note: This is a heuristic — callers can override by passing custom responses
   errors[404] = errorResponse("Resource not found");
-  
+
   return errors;
 }
 
@@ -231,6 +247,7 @@ export function defineRoute(def: RouteDefinition): BuiltRoute {
   const request: any = {};
   if (def.query) request.query = def.query;
   if (def.params) request.params = def.params;
+  if (def.headers) request.headers = def.headers;
   if (def.body) request.body = { content: jsonContent(def.body) };
   
   // Use custom responses if provided, otherwise generate standard ones


### PR DESCRIPTION
## What

Migrates 8 endpoint domains from raw `createRoute()` ceremony to the standard `defineRoute()` route-builder pattern:

- customer-groups
- customer-tags
- customers
- analytics
- activity-logs
- reviews
- driver-payments
- webhooks

Also extends `route-builder` with two capabilities the webhooks domain needed:

- `auth: "public"` — no middleware, `security` omitted from the spec (signature-verified receivers)
- `headers` — request header schemas (svix-\* on the ZR Express receiver)

## What's preserved (zero behavior change)

- Same paths, scopes, validation schemas, response contracts, and registration order
- activity-logs keeps its throw-based `adminOnly` middleware so 403s stay the documented `PERMISSION_DENIED` envelope (`requireAdmin()` returns plain JSON instead)
- Webhook receivers stay fully public with raw-body reads for Svix verification

## New coverage

- `analytics/routes.test.ts` — 4 tests (domain had no route tests)
- `activity-logs/routes.test.ts` — 5 tests, including the 403 envelope contract

## Verification

- Each domain validated side-by-side: prototype tested against the same suite as the original before graduating
- `npm run typecheck` clean
- Full suite: 70 files, 1154 tests passing