### PR TITLE
refactor(server): migrate all remaining endpoint domains to defineRoute() route-builder

### DIFF
--- a/cod-server/src/endpoints/abandoned-orders/routes.ts
+++ b/cod-server/src/endpoints/abandoned-orders/routes.ts
@@ -7,15 +7,14 @@
  * PATCH  /api/abandoned-orders/:id/status → update status
  * DELETE /api/abandoned-orders/:id      → delete record
  *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are inline
- * (thin query wrappers) and unchanged apart from the validated-data
- * fallback pattern.
+ * Built with defineRoute() — the standard route-builder pattern.
+ * Handlers are inline (thin query wrappers).
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
+import type { Context } from "hono";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import { getDb } from "@/db";
 import {
@@ -28,37 +27,79 @@ import {
   AbandonedOrderSchema,
   AbandonedOrderStatsSchema,
   AbandonedOrderStatusEnum,
-  ErrorResponseSchema,
 } from "@/openapi/schemas";
 
 const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
 
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
+// ─── Request schemas ──────────────────────────────────────────────────────────
+
+const listQuerySchema = z.object({
+  status: AbandonedOrderStatusEnum.optional().openapi({
+    description: "Filter by recovery status",
+  }),
+  search: z.string().optional(),
+  limit: z.coerce.number().int().positive().max(200).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
 });
 
-const listRoute = createRoute({
+const idParams = z.object({ id: z.string().openapi({ description: "Abandoned order ID" }) });
+
+const updateStatusBodySchema = z.object({
+  status: AbandonedOrderStatusEnum,
+});
+
+// ─── Inline handlers (thin query wrappers) ────────────────────────────────────
+
+async function listHandler(c: Context<AppContext>) {
+  const db = getDb(c.env.DB);
+  const { status, search, limit, offset } = (c.req as any).valid("query");
+
+  const { rows, total } = await listAbandonedOrders(db, {
+    status,
+    search,
+    limit,
+    offset,
+  });
+
+  return c.json({ success: true, data: rows, total, limit, offset }, 200);
+}
+
+async function statsHandler(c: Context<AppContext>) {
+  const db = getDb(c.env.DB);
+  const stats = await getAbandonedOrderStats(db);
+  return c.json({ success: true, data: stats }, 200);
+}
+
+async function updateStatusHandler(c: Context<AppContext>) {
+  const db = getDb(c.env.DB);
+  const id = c.req.param("id")!;
+  const { status } = (c.req as any).valid("json");
+
+  await updateAbandonedOrderStatus(db, id, status);
+  return c.json({ success: true }, 200);
+}
+
+async function deleteHandler(c: Context<AppContext>) {
+  const db = getDb(c.env.DB);
+  const id = c.req.param("id")!;
+  await deleteAbandonedOrder(db, id);
+  return c.json({ success: true }, 200);
+}
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const listRoute = defineRoute({
   method: "get",
   path: "/",
-  middleware: [requireScope(SCOPES.ABANDONED_ORDERS_READ)],
+  auth: { scope: SCOPES.ABANDONED_ORDERS_READ },
   tags: ["Abandoned Orders"],
   summary: "List abandoned orders",
   description:
     "Paginated list of abandoned checkouts, newest first. Filter by recovery status or search by customer name / phone / session.",
   operationId: "listAbandonedOrders",
-  request: {
-    query: z.object({
-      status: AbandonedOrderStatusEnum.optional().openapi({
-        description: "Filter by recovery status",
-      }),
-      search: z.string().optional(),
-      limit: z.coerce.number().int().positive().max(200).default(50),
-      offset: z.coerce.number().int().min(0).default(0),
-    }),
-  },
+  query: listQuerySchema,
   responses: {
     200: {
       description: "Paginated abandoned orders",
@@ -75,16 +116,14 @@ const listRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing abandoned_orders:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: listHandler,
 });
 
-const statsRoute = createRoute({
+const statsRoute = defineRoute({
   method: "get",
   path: "/stats",
-  middleware: [requireScope(SCOPES.ABANDONED_ORDERS_READ)],
+  auth: { scope: SCOPES.ABANDONED_ORDERS_READ },
   tags: ["Abandoned Orders"],
   summary: "Abandoned order statistics",
   description:
@@ -100,102 +139,55 @@ const statsRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing abandoned_orders:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: statsHandler,
 });
 
-const updateStatusRoute = createRoute({
+const updateStatusRoute = defineRoute({
   method: "patch",
   path: "/{id}/status",
-  middleware: [requireScope(SCOPES.ABANDONED_ORDERS_MANAGE)],
+  auth: { scope: SCOPES.ABANDONED_ORDERS_MANAGE },
   tags: ["Abandoned Orders"],
   summary: "Update abandoned order status",
   description:
     "Advances the recovery status of an abandoned checkout (pending → contacted → converted, or mark as abandoned).",
   operationId: "updateAbandonedOrderStatus",
-  request: {
-    params: z.object({ id: z.string().openapi({ description: "Abandoned order ID" }) }),
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          status: AbandonedOrderStatusEnum,
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: updateStatusBodySchema,
   responses: {
     200: {
       description: "Status updated",
       content: jsonContent(z.object({ success: z.boolean().openapi({ example: true }) })),
     },
-    400: errorResponse("Invalid status value"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing abandoned_orders:manage scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: updateStatusHandler,
 });
 
-const deleteRoute = createRoute({
+const deleteRoute = defineRoute({
   method: "delete",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.ABANDONED_ORDERS_MANAGE)],
+  auth: { scope: SCOPES.ABANDONED_ORDERS_MANAGE },
   tags: ["Abandoned Orders"],
   summary: "Delete abandoned order",
   description: "Permanently removes an abandoned checkout record.",
   operationId: "deleteAbandonedOrder",
-  request: {
-    params: z.object({ id: z.string().openapi({ description: "Abandoned order ID" }) }),
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Record deleted",
       content: jsonContent(z.object({ success: z.boolean().openapi({ example: true }) })),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing abandoned_orders:manage scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: deleteHandler,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(listRoute, async (c) => {
-  const db = getDb(c.env.DB);
-  const { status, search, limit, offset } = c.req.valid("query");
-
-  const { rows, total } = await listAbandonedOrders(db, {
-    status,
-    search,
-    limit,
-    offset,
-  });
-
-  return c.json({ success: true, data: rows, total, limit, offset }, 200);
-});
-
-router.openapi(statsRoute, async (c) => {
-  const db = getDb(c.env.DB);
-  const stats = await getAbandonedOrderStats(db);
-  return c.json({ success: true, data: stats }, 200);
-});
-
-router.openapi(updateStatusRoute, async (c) => {
-  const db = getDb(c.env.DB);
-  const id = c.req.param("id");
-  const { status } = c.req.valid("json");
-
-  await updateAbandonedOrderStatus(db, id, status);
-  return c.json({ success: true }, 200);
-});
-
-router.openapi(deleteRoute, async (c) => {
-  const db = getDb(c.env.DB);
-  const id = c.req.param("id");
-  await deleteAbandonedOrder(db, id);
-  return c.json({ success: true }, 200);
-});
+router.openapi(listRoute.route, listRoute.handler);
+router.openapi(statsRoute.route, statsRoute.handler);
+router.openapi(updateStatusRoute.route, updateStatusRoute.handler);
+router.openapi(deleteRoute.route, deleteRoute.handler);
 
 export default router;

--- a/cod-server/src/endpoints/abandoned-orders/store-routes.ts
+++ b/cod-server/src/endpoints/abandoned-orders/store-routes.ts
@@ -6,13 +6,13 @@
  * POST  /store/abandoned               → upsert (create or update) an abandoned record
  * PATCH /store/abandoned/:sessionId/convert → mark as converted after successful order
  *
- * Migrated to @hono/zod-openapi: route definitions are the single source of
- * truth for validation and the OpenAPI spec. These endpoints were previously
- * undocumented entirely.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
+import type { Context } from "hono";
 import type { AppContext } from "@/types";
+import { defineRoute } from "@/lib/route-builder";
 import { getDb } from "@/db";
 import {
   upsertAbandonedOrder,
@@ -22,6 +22,8 @@ import {
 const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
+
+// ─── Request schemas ──────────────────────────────────────────────────────────
 
 const upsertSchema = z.object({
   sessionId: z.string().uuid(),
@@ -50,65 +52,15 @@ const convertSchema = z.object({
   orderNumber: z.string().min(1),
 });
 
-const upsertAbandonedRoute = createRoute({
-  method: "post",
-  path: "/abandoned",
-  tags: ["Storefront"],
-  summary: "Track an abandoned checkout",
-  description:
-    "Called silently by the storefront as the customer types contact details. Upserts the abandoned-checkout record keyed by sessionId and captures Meta attribution (_fbc/_fbp) plus client IP/User-Agent for CAPI recovery events.",
-  operationId: "upsertAbandonedOrder",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(upsertSchema),
-    },
-  },
-  responses: {
-    200: {
-      description: "Record stored (new or updated)",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          id: z.string().openapi({ description: "Abandoned order record ID" }),
-        })
-      ),
-    },
-  },
-  security: [{ StoreAuth: [] }],
+const sessionIdParams = z.object({
+  sessionId: z.string().openapi({ description: "Storefront session ID from the upsert call" }),
 });
 
-const convertAbandonedRoute = createRoute({
-  method: "patch",
-  path: "/abandoned/{sessionId}/convert",
-  tags: ["Storefront"],
-  summary: "Mark abandoned checkout as converted",
-  description:
-    "Links a completed order back to the original abandoned session (recovery attribution). Intentionally returns 200 even if the session is unknown — conversion tracking is fire-and-forget and must never break checkout.",
-  operationId: "markAbandonedOrderConverted",
-  request: {
-    params: z.object({
-      sessionId: z.string().openapi({ description: "Storefront session ID from the upsert call" }),
-    }),
-    body: {
-      required: true,
-      content: jsonContent(convertSchema),
-    },
-  },
-  responses: {
-    200: {
-      description: "Conversion recorded (fire-and-forget)",
-      content: jsonContent(z.object({ success: z.boolean().openapi({ example: true }) })),
-    },
-  },
-  security: [{ StoreAuth: [] }],
-});
+// ─── Inline handlers ──────────────────────────────────────────────────────────
 
-const router = new OpenAPIHono<AppContext>();
-
-router.openapi(upsertAbandonedRoute, async (c) => {
+async function upsertHandler(c: Context<AppContext>) {
   const db = getDb(c.env.DB);
-  const data = c.req.valid("json");
+  const data = (c.req as any).valid("json");
 
   const ipAddress =
     c.req.header("CF-Connecting-IP") ??
@@ -123,12 +75,12 @@ router.openapi(upsertAbandonedRoute, async (c) => {
   });
 
   return c.json({ success: true, id }, 200);
-});
+}
 
-router.openapi(convertAbandonedRoute, async (c) => {
+async function convertHandler(c: Context<AppContext>) {
   const db = getDb(c.env.DB);
-  const sessionId = c.req.param("sessionId");
-  const { orderId, orderNumber } = c.req.valid("json");
+  const sessionId = c.req.param("sessionId")!;
+  const { orderId, orderNumber } = (c.req as any).valid("json");
 
   // Intentionally returns 200 even if session not found — convert is fire-and-forget
   await markAbandonedOrderConverted(db, sessionId, orderId, orderNumber).catch(
@@ -136,6 +88,59 @@ router.openapi(convertAbandonedRoute, async (c) => {
   );
 
   return c.json({ success: true }, 200);
+}
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const upsertAbandonedRoute = defineRoute({
+  method: "post",
+  path: "/abandoned",
+  auth: "store",
+  tags: ["Storefront"],
+  summary: "Track an abandoned checkout",
+  description:
+    "Called silently by the storefront as the customer types contact details. Upserts the abandoned-checkout record keyed by sessionId and captures Meta attribution (_fbc/_fbp) plus client IP/User-Agent for CAPI recovery events.",
+  operationId: "upsertAbandonedOrder",
+  body: upsertSchema,
+  responses: {
+    200: {
+      description: "Record stored (new or updated)",
+      content: jsonContent(
+        z.object({
+          success: z.boolean().openapi({ example: true }),
+          id: z.string().openapi({ description: "Abandoned order record ID" }),
+        })
+      ),
+    },
+  },
+  handler: upsertHandler,
 });
+
+const convertAbandonedRoute = defineRoute({
+  method: "patch",
+  path: "/abandoned/{sessionId}/convert",
+  auth: "store",
+  tags: ["Storefront"],
+  summary: "Mark abandoned checkout as converted",
+  description:
+    "Links a completed order back to the original abandoned session (recovery attribution). Intentionally returns 200 even if the session is unknown — conversion tracking is fire-and-forget and must never break checkout.",
+  operationId: "markAbandonedOrderConverted",
+  params: sessionIdParams,
+  body: convertSchema,
+  responses: {
+    200: {
+      description: "Conversion recorded (fire-and-forget)",
+      content: jsonContent(z.object({ success: z.boolean().openapi({ example: true }) })),
+    },
+  },
+  handler: convertHandler,
+});
+
+// ─── Router ───────────────────────────────────────────────────────────────────
+
+const router = new OpenAPIHono<AppContext>();
+
+router.openapi(upsertAbandonedRoute.route, upsertAbandonedRoute.handler);
+router.openapi(convertAbandonedRoute.route, convertAbandonedRoute.handler);
 
 export default router;

--- a/cod-server/src/endpoints/delivery-companies/routes.ts
+++ b/cod-server/src/endpoints/delivery-companies/routes.ts
@@ -2,18 +2,24 @@
  * Delivery Companies Routes
  *
  * CRUD endpoints for third-party delivery company management.
+ * Built with defineRoute() — the standard route-builder pattern.
+ *
+ * RBAC stays on router.use() path patterns (not per-route auth) to preserve
+ * the existing gating exactly — including the long-standing quirk that
+ * POST / and PATCH/DELETE /:id are gated by delivery:read via the "/"
+ * and "/:id" patterns rather than delivery:manage.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
 import * as handlers from "./handlers";
 import * as webhookHandlers from "./webhook-handlers";
+import { defineRoute } from "@/lib/route-builder";
 import { requireScope } from "@/rbac/middleware";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import {
   DeliveryCompanySchema,
   StopDeskSchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
   ListResponseSchema,
 } from "@/openapi/schemas";
@@ -24,207 +30,205 @@ const jsonContent = <T extends z.ZodType>(schema: T) => ({
 
 const deliveryCompaniesRouter = new OpenAPIHono<AppContext>();
 
-// ── Route Definitions ─────────────────────────────────────────────────────────
+// ─── Params & request schemas ────────────────────────────────────────────────
 
-const listRoute = createRoute({
+const idParams = z.object({
+  id: z.string().openapi({ description: "Delivery company ID", example: "comp_abc123" }),
+});
+
+const listQuerySchema = z.object({
+  active: z.enum(["true", "false"]).optional().openapi({
+    description: "Filter by active status",
+    example: "true",
+  }),
+  search: z.string().optional().openapi({
+    description: "Search in company name (EN/AR) and code",
+  }),
+  limit: z.coerce.number().int().positive().max(100).default(50).openapi({
+    description: "Maximum number of results",
+    example: 50,
+  }),
+  offset: z.coerce.number().int().min(0).default(0).openapi({
+    description: "Pagination offset",
+    example: 0,
+  }),
+});
+
+const createBodySchema = z.object({
+  name: z.string().min(1).openapi({ example: "Yalidine" }),
+  nameAr: z.string().min(1).openapi({ example: "ياليدين" }),
+  code: z
+    .string()
+    .min(1)
+    .regex(/^[a-z0-9_]+$/)
+    .openapi({ example: "yalidine", description: "Lowercase alphanumeric with underscores" }),
+  website: z.string().url().optional().nullable().openapi({ example: "https://www.yalidine.com" }),
+  active: z.boolean().default(true).openapi({ example: true }),
+  apiEndpoint: z.string().url().optional().nullable().openapi({ example: "https://api.yalidine.app/v1" }),
+  apiToken: z.string().optional().nullable().openapi({ description: "API authentication token" }),
+  apiUserGuid: z.string().optional().nullable().openapi({ description: "Tenant/user GUID for ZR Express" }),
+  supportsHomeDelivery: z.boolean().default(true),
+  supportsStopDesk: z.boolean().default(true),
+  supportsTracking: z.boolean().default(false),
+  autoValidate: z.boolean().optional().openapi({
+    description:
+      "When true, orders are auto-validated on dispatch (locked at carrier). " +
+      "When false, orders stay editable. If omitted, a safe default is derived per provider.",
+  }),
+  notes: z.string().optional().nullable(),
+});
+
+const updateBodySchema = z.object({
+  name: z.string().min(1).optional(),
+  nameAr: z.string().min(1).optional(),
+  code: z
+    .string()
+    .min(1)
+    .regex(/^[a-z0-9_]+$/)
+    .optional(),
+  website: z.string().url().optional().nullable(),
+  active: z.boolean().optional(),
+  apiEndpoint: z.string().url().optional().nullable(),
+  apiToken: z.string().optional().nullable(),
+  apiUserGuid: z.string().optional().nullable(),
+  supportsHomeDelivery: z.boolean().optional(),
+  supportsStopDesk: z.boolean().optional(),
+  supportsTracking: z.boolean().optional(),
+  autoValidate: z.boolean().optional(),
+  notes: z.string().optional().nullable(),
+});
+
+const stopDesksQuerySchema = z.object({
+  wilayaId: z.coerce.number().int().optional().openapi({
+    description: "Filter by wilaya ID",
+    example: 16,
+  }),
+  activeOnly: z.enum(["true", "false"]).default("true").openapi({
+    description: "Filter by active flag (default true)",
+    example: "true",
+  }),
+});
+
+const toggleParams = z.object({
+  id: z.string().openapi({ description: "Delivery company ID", example: "comp_abc123" }),
+  code: z.string().openapi({ description: "Stop desk code", example: "16A" }),
+});
+
+const saveSecretBodySchema = z.object({
+  secret: z.string().min(1).openapi({ description: "Webhook secret key from Yalidine dashboard" }),
+});
+
+const saveMappingBodySchema = z.object({
+  mapping: z.record(z.string(), z.array(z.string())).openapi({
+    description:
+      "Keys must be valid our-status strings (new, preparing, assigned, out_for_delivery, delivered, returned, cancelled). " +
+      "Values are arrays of ZR state names.",
+    example: {
+      delivered: ["Livré", "Delivered"],
+      returned: ["Retourné", "Returned"],
+    },
+  }),
+});
+
+// ─── Route Definitions ─────────────────────────────────────────────────────────
+
+const listRoute = defineRoute({
   method: "get",
   path: "/",
+  auth: "api-key",
   tags: ["Delivery Companies"],
   summary: "List delivery companies",
   description: "List all delivery companies with optional filters",
-  request: {
-    query: z.object({
-      active: z.enum(["true", "false"]).optional().openapi({
-        description: "Filter by active status",
-        example: "true",
-      }),
-      search: z.string().optional().openapi({
-        description: "Search in company name (EN/AR) and code",
-      }),
-      limit: z.coerce.number().int().positive().max(100).default(50).openapi({
-        description: "Maximum number of results",
-        example: 50,
-      }),
-      offset: z.coerce.number().int().min(0).default(0).openapi({
-        description: "Pagination offset",
-        example: 0,
-      }),
-    }),
-  },
+  query: listQuerySchema,
   responses: {
     200: {
       description: "List of delivery companies",
       content: jsonContent(ListResponseSchema(DeliveryCompanySchema)),
     },
-    401: { description: "Not authenticated", content: jsonContent(ErrorResponseSchema) },
-    403: { description: "Insufficient permissions", content: jsonContent(ErrorResponseSchema) },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.listDeliveryCompanies,
 });
 
-const getRoute = createRoute({
+const getRoute = defineRoute({
   method: "get",
   path: "/{id}",
+  auth: "api-key",
   tags: ["Delivery Companies"],
   summary: "Get delivery company",
   description: "Get a single delivery company by ID",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Delivery company ID", example: "comp_abc123" }),
-    }),
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Delivery company details",
       content: jsonContent(SuccessResponseSchema(DeliveryCompanySchema)),
     },
-    401: { description: "Not authenticated", content: jsonContent(ErrorResponseSchema) },
-    403: { description: "Insufficient permissions", content: jsonContent(ErrorResponseSchema) },
-    404: { description: "Company not found", content: jsonContent(ErrorResponseSchema) },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.getDeliveryCompany,
 });
 
-const createRoute_definition = createRoute({
+const createCompanyRoute = defineRoute({
   method: "post",
   path: "/",
+  auth: "api-key",
   tags: ["Delivery Companies"],
   summary: "Create delivery company",
   description: "Create a new delivery company integration",
-  request: {
-    body: {
-      content: jsonContent(
-        z.object({
-          name: z.string().min(1).openapi({ example: "Yalidine" }),
-          nameAr: z.string().min(1).openapi({ example: "ياليدين" }),
-          code: z
-            .string()
-            .min(1)
-            .regex(/^[a-z0-9_]+$/)
-            .openapi({ example: "yalidine", description: "Lowercase alphanumeric with underscores" }),
-          website: z.string().url().optional().nullable().openapi({ example: "https://www.yalidine.com" }),
-          active: z.boolean().default(true).openapi({ example: true }),
-          apiEndpoint: z.string().url().optional().nullable().openapi({ example: "https://api.yalidine.app/v1" }),
-          apiToken: z.string().optional().nullable().openapi({ description: "API authentication token" }),
-          apiUserGuid: z.string().optional().nullable().openapi({ description: "Tenant/user GUID for ZR Express" }),
-          supportsHomeDelivery: z.boolean().default(true),
-          supportsStopDesk: z.boolean().default(true),
-          supportsTracking: z.boolean().default(false),
-          autoValidate: z.boolean().optional().openapi({
-            description:
-              "When true, orders are auto-validated on dispatch (locked at carrier). " +
-              "When false, orders stay editable. If omitted, a safe default is derived per provider.",
-          }),
-          notes: z.string().optional().nullable(),
-        })
-      ),
-    },
-  },
+  body: createBodySchema,
   responses: {
     201: {
       description: "Delivery company created",
       content: jsonContent(SuccessResponseSchema(DeliveryCompanySchema)),
     },
-    400: { description: "Validation error", content: jsonContent(ErrorResponseSchema) },
-    401: { description: "Not authenticated", content: jsonContent(ErrorResponseSchema) },
-    403: { description: "Insufficient permissions", content: jsonContent(ErrorResponseSchema) },
-    409: { description: "Duplicate company code", content: jsonContent(ErrorResponseSchema) },
+    409: { description: "Duplicate company code" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.createDeliveryCompany,
 });
 
-const updateRoute = createRoute({
+const updateRoute = defineRoute({
   method: "patch",
   path: "/{id}",
+  auth: "api-key",
   tags: ["Delivery Companies"],
   summary: "Update delivery company",
   description: "Update an existing delivery company",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Delivery company ID", example: "comp_abc123" }),
-    }),
-    body: {
-      content: jsonContent(
-        z.object({
-          name: z.string().min(1).optional(),
-          nameAr: z.string().min(1).optional(),
-          code: z
-            .string()
-            .min(1)
-            .regex(/^[a-z0-9_]+$/)
-            .optional(),
-          website: z.string().url().optional().nullable(),
-          active: z.boolean().optional(),
-          apiEndpoint: z.string().url().optional().nullable(),
-          apiToken: z.string().optional().nullable(),
-          apiUserGuid: z.string().optional().nullable(),
-          supportsHomeDelivery: z.boolean().optional(),
-          supportsStopDesk: z.boolean().optional(),
-          supportsTracking: z.boolean().optional(),
-          autoValidate: z.boolean().optional(),
-          notes: z.string().optional().nullable(),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: updateBodySchema,
   responses: {
     200: {
       description: "Delivery company updated",
       content: jsonContent(SuccessResponseSchema(DeliveryCompanySchema)),
     },
-    400: { description: "Validation error", content: jsonContent(ErrorResponseSchema) },
-    401: { description: "Not authenticated", content: jsonContent(ErrorResponseSchema) },
-    403: { description: "Insufficient permissions", content: jsonContent(ErrorResponseSchema) },
-    404: { description: "Company not found", content: jsonContent(ErrorResponseSchema) },
-    409: { description: "Duplicate company code", content: jsonContent(ErrorResponseSchema) },
+    409: { description: "Duplicate company code" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.updateDeliveryCompany,
 });
 
-const deleteRoute = createRoute({
+const deleteRoute = defineRoute({
   method: "delete",
   path: "/{id}",
+  auth: "api-key",
   tags: ["Delivery Companies"],
   summary: "Delete delivery company",
   description: "Delete a delivery company",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Delivery company ID", example: "comp_abc123" }),
-    }),
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Delivery company deleted",
       content: jsonContent(z.object({ success: z.boolean() })),
     },
-    401: { description: "Not authenticated", content: jsonContent(ErrorResponseSchema) },
-    403: { description: "Insufficient permissions", content: jsonContent(ErrorResponseSchema) },
-    404: { description: "Company not found", content: jsonContent(ErrorResponseSchema) },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.deleteDeliveryCompany,
 });
 
-const getStopDesksRoute = createRoute({
+const getStopDesksRoute = defineRoute({
   method: "get",
   path: "/{id}/stop-desks",
+  auth: "api-key",
   tags: ["Delivery Companies"],
   summary: "Get company stop desks",
   description: "Read stop desks from DB (no live API call). Admin must sync first via POST .../sync-stop-desks",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Delivery company ID", example: "comp_abc123" }),
-    }),
-    query: z.object({
-      wilayaId: z.coerce.number().int().optional().openapi({
-        description: "Filter by wilaya ID",
-        example: 16,
-      }),
-      activeOnly: z.enum(["true", "false"]).default("true").openapi({
-        description: "Filter by active flag (default true)",
-        example: "true",
-      }),
-    }),
-  },
+  params: idParams,
+  query: stopDesksQuerySchema,
   responses: {
     200: {
       description: "Stop desks list",
@@ -243,24 +247,18 @@ const getStopDesksRoute = createRoute({
         })
       ),
     },
-    401: { description: "Not authenticated", content: jsonContent(ErrorResponseSchema) },
-    403: { description: "Insufficient permissions", content: jsonContent(ErrorResponseSchema) },
-    404: { description: "Company not found", content: jsonContent(ErrorResponseSchema) },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.fetchCompanyStopDesks,
 });
 
-const syncStopDesksRoute = createRoute({
+const syncStopDesksRoute = defineRoute({
   method: "post",
   path: "/{id}/sync-stop-desks",
+  auth: "api-key",
   tags: ["Delivery Companies"],
   summary: "Sync stop desks",
   description: "Fetch stop desks from carrier API and upsert into DB. Active flag is preserved.",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Delivery company ID", example: "comp_abc123" }),
-    }),
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Stop desks synced",
@@ -275,30 +273,20 @@ const syncStopDesksRoute = createRoute({
         })
       ),
     },
-    401: { description: "Not authenticated", content: jsonContent(ErrorResponseSchema) },
-    403: { description: "Insufficient permissions", content: jsonContent(ErrorResponseSchema) },
-    404: { description: "Company not found", content: jsonContent(ErrorResponseSchema) },
-    422: {
-      description: "Company not connected or provider does not support stop desks",
-      content: jsonContent(ErrorResponseSchema),
-    },
-    502: { description: "External API failure", content: jsonContent(ErrorResponseSchema) },
+    422: { description: "Company not connected or provider does not support stop desks" },
+    502: { description: "External API failure" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.syncCompanyStopDesks,
 });
 
-const toggleStopDeskRoute = createRoute({
+const toggleStopDeskRoute = defineRoute({
   method: "patch",
   path: "/{id}/stop-desks/{code}/toggle",
+  auth: "api-key",
   tags: ["Delivery Companies"],
   summary: "Toggle stop desk active flag",
   description: "Toggle the active flag on a single stop desk. Admin can deactivate stop desks that can't be serviced.",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Delivery company ID", example: "comp_abc123" }),
-      code: z.string().openapi({ description: "Stop desk code", example: "16A" }),
-    }),
-  },
+  params: toggleParams,
   responses: {
     200: {
       description: "Stop desk toggled",
@@ -312,24 +300,18 @@ const toggleStopDeskRoute = createRoute({
         })
       ),
     },
-    401: { description: "Not authenticated", content: jsonContent(ErrorResponseSchema) },
-    403: { description: "Insufficient permissions", content: jsonContent(ErrorResponseSchema) },
-    404: { description: "Stop desk not found", content: jsonContent(ErrorResponseSchema) },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.toggleCompanyStopDesk,
 });
 
-const registerWebhookRoute = createRoute({
+const registerWebhookRoute = defineRoute({
   method: "post",
   path: "/{id}/webhook/register",
+  auth: "api-key",
   tags: ["Delivery Companies"],
   summary: "Register ZR Express webhook",
   description: "Registers a webhook endpoint with ZR Express via their API. Stores the endpointId and signing secret.",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Delivery company ID", example: "comp_abc123" }),
-    }),
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Webhook registered",
@@ -341,109 +323,64 @@ const registerWebhookRoute = createRoute({
         })
       ),
     },
-    400: { description: "Invalid configuration or ZR API error", content: jsonContent(ErrorResponseSchema) },
-    401: { description: "Not authenticated", content: jsonContent(ErrorResponseSchema) },
-    403: { description: "Insufficient permissions", content: jsonContent(ErrorResponseSchema) },
-    404: { description: "Company not found", content: jsonContent(ErrorResponseSchema) },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: webhookHandlers.registerZrWebhook,
 });
 
-const unregisterWebhookRoute = createRoute({
+const unregisterWebhookRoute = defineRoute({
   method: "delete",
   path: "/{id}/webhook/register",
+  auth: "api-key",
   tags: ["Delivery Companies"],
   summary: "Unregister ZR Express webhook",
   description: "Deletes the registered webhook endpoint from ZR Express and clears the DB fields.",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Delivery company ID", example: "comp_abc123" }),
-    }),
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Webhook unregistered",
       content: jsonContent(z.object({ success: z.boolean() })),
     },
-    400: { description: "Invalid configuration or ZR API error", content: jsonContent(ErrorResponseSchema) },
-    401: { description: "Not authenticated", content: jsonContent(ErrorResponseSchema) },
-    403: { description: "Insufficient permissions", content: jsonContent(ErrorResponseSchema) },
-    404: { description: "Company not found or no webhook registered", content: jsonContent(ErrorResponseSchema) },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: webhookHandlers.unregisterZrWebhook,
 });
 
-const saveYalidineSecretRoute = createRoute({
+const saveYalidineSecretRoute = defineRoute({
   method: "patch",
   path: "/{id}/webhook/secret",
+  auth: "api-key",
   tags: ["Delivery Companies"],
   summary: "Save Yalidine webhook secret",
   description: "Stores the Yalidine webhook secret key (entered manually after setting up webhook in Yalidine dashboard).",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Delivery company ID", example: "comp_abc123" }),
-    }),
-    body: {
-      content: jsonContent(
-        z.object({
-          secret: z.string().min(1).openapi({ description: "Webhook secret key from Yalidine dashboard" }),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: saveSecretBodySchema,
   responses: {
     200: {
       description: "Secret saved",
       content: jsonContent(z.object({ success: z.boolean() })),
     },
-    400: { description: "Invalid request or wrong company type", content: jsonContent(ErrorResponseSchema) },
-    401: { description: "Not authenticated", content: jsonContent(ErrorResponseSchema) },
-    403: { description: "Insufficient permissions", content: jsonContent(ErrorResponseSchema) },
-    404: { description: "Company not found", content: jsonContent(ErrorResponseSchema) },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: webhookHandlers.saveYalidineSecret,
 });
 
-const saveZrMappingRoute = createRoute({
+const saveZrMappingRoute = defineRoute({
   method: "patch",
   path: "/{id}/webhook/mapping",
+  auth: "api-key",
   tags: ["Delivery Companies"],
   summary: "Save ZR status mapping",
   description: "Saves the custom ZR state name → our status mapping for this company.",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Delivery company ID", example: "comp_abc123" }),
-    }),
-    body: {
-      content: jsonContent(
-        z.object({
-          mapping: z.record(z.string(), z.array(z.string())).openapi({
-            description:
-              "Keys must be valid our-status strings (new, preparing, assigned, out_for_delivery, delivered, returned, cancelled). " +
-              "Values are arrays of ZR state names.",
-            example: {
-              delivered: ["Livré", "Delivered"],
-              returned: ["Retourné", "Returned"],
-            },
-          }),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: saveMappingBodySchema,
   responses: {
     200: {
       description: "Mapping saved",
       content: jsonContent(z.object({ success: z.boolean() })),
     },
-    400: { description: "Invalid mapping or wrong company type", content: jsonContent(ErrorResponseSchema) },
-    401: { description: "Not authenticated", content: jsonContent(ErrorResponseSchema) },
-    403: { description: "Insufficient permissions", content: jsonContent(ErrorResponseSchema) },
-    404: { description: "Company not found", content: jsonContent(ErrorResponseSchema) },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: webhookHandlers.saveZrStatusMapping,
 });
 
-// ── Route Registrations ───────────────────────────────────────────────────────
+// ─── Route Registrations ───────────────────────────────────────────────────────
 
 // Apply RBAC middleware to all routes
 deliveryCompaniesRouter.use("/", requireScope(SCOPES.DELIVERY_READ));
@@ -456,41 +393,41 @@ deliveryCompaniesRouter.use("/:id/webhook/secret", requireScope(SCOPES.DELIVERY_
 deliveryCompaniesRouter.use("/:id/webhook/mapping", requireScope(SCOPES.DELIVERY_MANAGE));
 
 // GET /delivery-companies — list all companies
-deliveryCompaniesRouter.openapi(listRoute, handlers.listDeliveryCompanies);
+deliveryCompaniesRouter.openapi(listRoute.route, listRoute.handler);
 
 // GET /delivery-companies/:id — get single company
-deliveryCompaniesRouter.openapi(getRoute, handlers.getDeliveryCompany);
+deliveryCompaniesRouter.openapi(getRoute.route, getRoute.handler);
 
 // GET /delivery-companies/:id/stop-desks — read from company_stop_desks DB (no live API)
-deliveryCompaniesRouter.openapi(getStopDesksRoute, handlers.fetchCompanyStopDesks);
+deliveryCompaniesRouter.openapi(getStopDesksRoute.route, getStopDesksRoute.handler);
 
 // POST /delivery-companies/:id/sync-stop-desks — fetch from carrier API and upsert into DB
-deliveryCompaniesRouter.openapi(syncStopDesksRoute, handlers.syncCompanyStopDesks);
+deliveryCompaniesRouter.openapi(syncStopDesksRoute.route, syncStopDesksRoute.handler);
 
 // PATCH /delivery-companies/:id/stop-desks/:code/toggle — toggle admin active flag
-deliveryCompaniesRouter.openapi(toggleStopDeskRoute, handlers.toggleCompanyStopDesk);
+deliveryCompaniesRouter.openapi(toggleStopDeskRoute.route, toggleStopDeskRoute.handler);
 
 // POST /delivery-companies — create company
-deliveryCompaniesRouter.openapi(createRoute_definition, handlers.createDeliveryCompany);
+deliveryCompaniesRouter.openapi(createCompanyRoute.route, createCompanyRoute.handler);
 
 // PATCH /delivery-companies/:id — update company
-deliveryCompaniesRouter.openapi(updateRoute, handlers.updateDeliveryCompany);
+deliveryCompaniesRouter.openapi(updateRoute.route, updateRoute.handler);
 
 // DELETE /delivery-companies/:id — delete company
-deliveryCompaniesRouter.openapi(deleteRoute, handlers.deleteDeliveryCompany);
+deliveryCompaniesRouter.openapi(deleteRoute.route, deleteRoute.handler);
 
 // ── Webhook Management ────────────────────────────────────────────────────────
 
 // POST /delivery-companies/:id/webhook/register — register ZR Express webhook endpoint
-deliveryCompaniesRouter.openapi(registerWebhookRoute, webhookHandlers.registerZrWebhook);
+deliveryCompaniesRouter.openapi(registerWebhookRoute.route, registerWebhookRoute.handler);
 
 // DELETE /delivery-companies/:id/webhook/register — unregister ZR Express webhook endpoint
-deliveryCompaniesRouter.openapi(unregisterWebhookRoute, webhookHandlers.unregisterZrWebhook);
+deliveryCompaniesRouter.openapi(unregisterWebhookRoute.route, unregisterWebhookRoute.handler);
 
 // PATCH /delivery-companies/:id/webhook/secret — save Yalidine webhook secret
-deliveryCompaniesRouter.openapi(saveYalidineSecretRoute, webhookHandlers.saveYalidineSecret);
+deliveryCompaniesRouter.openapi(saveYalidineSecretRoute.route, saveYalidineSecretRoute.handler);
 
 // PATCH /delivery-companies/:id/webhook/mapping — save ZR custom state name mapping
-deliveryCompaniesRouter.openapi(saveZrMappingRoute, webhookHandlers.saveZrStatusMapping);
+deliveryCompaniesRouter.openapi(saveZrMappingRoute.route, saveZrMappingRoute.handler);
 
 export default deliveryCompaniesRouter;

--- a/cod-server/src/endpoints/drivers/routes.ts
+++ b/cod-server/src/endpoints/drivers/routes.ts
@@ -4,32 +4,24 @@
  * Driver management CRUD, availability status toggle, and per-wilaya
  * compensation management. All routes require an API key with the
  * appropriate delivery scope.
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import * as handlers from "./handlers";
 import {
   DriverSchema,
   DriverCompensationRowSchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
+  SuccessWithMessageSchema,
   ListResponseSchema,
 } from "@/openapi/schemas";
 
 const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
-});
-
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
 });
 
 const phoneRegex = /^0[5-7]\d{8}$/;
@@ -53,234 +45,195 @@ const compensationParams = z.object({
   }),
 });
 
-const listDriversRoute = createRoute({
+// ─── Request schemas ──────────────────────────────────────────────────────────
+
+const listQuerySchema = z.object({
+  wilayaId: z.coerce.number().int().min(1).max(58).optional().openapi({
+    description: "Filter to drivers with a configured compensation row for this wilaya (1–58)",
+  }),
+  status: z.enum(["available", "busy", "inactive"]).optional().openapi({
+    description: "Filter by availability status",
+  }),
+  vehicleType: z.enum(["motorcycle", "car", "van"]).optional().openapi({
+    description: "Filter by vehicle type",
+  }),
+  search: z.string().optional().openapi({
+    description: "Search by first name, last name, or phone",
+  }),
+  limit: z.coerce.number().int().positive().max(100).default(50).openapi({
+    description: "Maximum number of results to return",
+  }),
+  offset: z.coerce.number().int().min(0).default(0).openapi({
+    description: "Number of results to skip for pagination",
+  }),
+});
+
+const createBodySchema = z.object({
+  firstName: z.string().min(1, "First name is required").openapi({ example: "Mohamed" }),
+  lastName: z.string().min(1, "Last name is required").openapi({ example: "Amiri" }),
+  phone: phoneField(),
+  phone2: z.preprocess(
+    (v) => (v === "" || v == null ? undefined : v),
+    z.string().regex(phoneRegex, "Invalid Algerian phone number").optional()
+  ).openapi({ description: "Optional secondary phone number" }),
+  vehicleType: z.enum(["motorcycle", "car", "van"]).nullable().optional().openapi({
+    description: "Type of vehicle. Omit or null if unknown.",
+  }),
+  status: z.enum(["available", "busy", "inactive"]).default("available").openapi({
+    description: "Availability status. Defaults to `available`.",
+  }),
+  notes: z.preprocess(
+    (v) => (v === "" || v == null ? undefined : v),
+    z.string().optional().nullable()
+  ).openapi({
+    description: "Internal notes about the driver (not visible to customers)",
+  }),
+});
+
+const updateBodySchema = z.object({
+  firstName: z.string().min(1, "First name is required").optional(),
+  lastName: z.string().min(1, "Last name is required").optional(),
+  phone: phoneField().optional(),
+  phone2: z.preprocess(
+    (v) => (v === "" ? null : v),
+    z.string().regex(phoneRegex, "Invalid Algerian phone number").nullable().optional()
+  ).openapi({ description: "Updated secondary phone. Send `null` to clear it." }),
+  vehicleType: z.enum(["motorcycle", "car", "van"]).nullable().optional().openapi({
+    description: "Updated vehicle type. Send `null` to clear it.",
+  }),
+  notes: z.preprocess(
+    (v) => (v === "" ? null : v),
+    z.string().nullable().optional()
+  ).openapi({ description: "Updated internal notes. Send `null` to clear." }),
+});
+
+const updateStatusBodySchema = z.object({
+  status: z.enum(["available", "busy", "inactive"]).openapi({
+    description: "New availability status for the driver",
+  }),
+});
+
+const setCompensationBodySchema = z.object({
+  feePerDelivery: z.number().min(0).openapi({
+    description: "DZD per delivery in this wilaya.",
+    example: 350,
+  }),
+});
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const listDriversRoute = defineRoute({
   method: "get",
   path: "/",
-  middleware: [requireScope(SCOPES.DELIVERY_READ)],
+  auth: { scope: SCOPES.DELIVERY_READ },
   tags: ["Drivers"],
   summary: "List drivers",
   description:
     "Returns a paginated list of drivers. Each item includes `compensationWilayaCount` — the number of wilayas with a configured per-delivery fee for this driver.",
   operationId: "listDrivers",
-  request: {
-    query: z.object({
-      wilayaId: z.coerce.number().int().min(1).max(58).optional().openapi({
-        description: "Filter to drivers with a configured compensation row for this wilaya (1–58)",
-      }),
-      status: z.enum(["available", "busy", "inactive"]).optional().openapi({
-        description: "Filter by availability status",
-      }),
-      vehicleType: z.enum(["motorcycle", "car", "van"]).optional().openapi({
-        description: "Filter by vehicle type",
-      }),
-      search: z.string().optional().openapi({
-        description: "Search by first name, last name, or phone",
-      }),
-      limit: z.coerce.number().int().positive().max(100).default(50).openapi({
-        description: "Maximum number of results to return",
-      }),
-      offset: z.coerce.number().int().min(0).default(0).openapi({
-        description: "Number of results to skip for pagination",
-      }),
-    }),
-  },
+  query: listQuerySchema,
   responses: {
     200: {
       description: "List of drivers",
       content: jsonContent(ListResponseSchema(DriverSchema)),
     },
-    400: errorResponse("Validation error - invalid query parameters"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.listDrivers,
 });
 
-const createDriverRoute = createRoute({
+const createDriverRoute = defineRoute({
   method: "post",
   path: "/",
-  middleware: [requireScope(SCOPES.DELIVERY_MANAGE)],
+  auth: { scope: SCOPES.DELIVERY_MANAGE },
   tags: ["Drivers"],
   summary: "Create driver",
   description: "Register a new delivery driver.",
   operationId: "createDriver",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          firstName: z.string().min(1, "First name is required").openapi({ example: "Mohamed" }),
-          lastName: z.string().min(1, "Last name is required").openapi({ example: "Amiri" }),
-          phone: phoneField(),
-          phone2: z.preprocess(
-            (v) => (v === "" || v == null ? undefined : v),
-            z.string().regex(phoneRegex, "Invalid Algerian phone number").optional()
-          ).openapi({ description: "Optional secondary phone number" }),
-          vehicleType: z.enum(["motorcycle", "car", "van"]).nullable().optional().openapi({
-            description: "Type of vehicle. Omit or null if unknown.",
-          }),
-          status: z.enum(["available", "busy", "inactive"]).default("available").openapi({
-            description: "Availability status. Defaults to `available`.",
-          }),
-          notes: z.preprocess(
-            (v) => (v === "" || v == null ? undefined : v),
-            z.string().optional().nullable()
-          ).openapi({
-            description: "Internal notes about the driver (not visible to customers)",
-          }),
-        })
-      ),
-    },
-  },
+  body: createBodySchema,
   responses: {
     201: {
       description:
         "Driver created. Returns full driver record including `compensationWilayaCount` and `recentOrders`.",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          data: DriverSchema,
-          message: z.string().openapi({ example: "Driver created successfully" }),
-        })
-      ),
+      content: jsonContent(SuccessWithMessageSchema(DriverSchema)),
     },
-    400: errorResponse("Validation error (invalid phone format, missing required fields)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:manage scope"),
-    409: errorResponse("Duplicate phone number - a driver with this phone already exists (code: DUPLICATE_PHONE)"),
+    409: {
+      description: "Duplicate phone number - a driver with this phone already exists (code: DUPLICATE_PHONE)",
+    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.createDriver,
 });
 
-const getDriverRoute = createRoute({
+const getDriverRoute = defineRoute({
   method: "get",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.DELIVERY_READ)],
+  auth: { scope: SCOPES.DELIVERY_READ },
   tags: ["Drivers"],
   summary: "Get driver",
   description:
     "Returns full driver detail including `compensationWilayaCount` and `recentOrders` (up to 10 most recent orders assigned to this driver). Use `GET /{id}/compensations` for the per-wilaya pay grid.",
   operationId: "getDriver",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Driver detail",
       content: jsonContent(SuccessResponseSchema(DriverSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:read scope"),
-    404: errorResponse("Driver not found (DRIVER_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.getDriver,
 });
 
-const updateDriverRoute = createRoute({
+const updateDriverRoute = defineRoute({
   method: "patch",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.DELIVERY_MANAGE)],
+  auth: { scope: SCOPES.DELIVERY_MANAGE },
   tags: ["Drivers"],
   summary: "Update driver",
   description:
     "Partial update — only include fields you want to change. Use `PATCH /{id}/status` to change availability status. Set `phone2`, `vehicleType`, or `notes` to null to clear them.",
   operationId: "updateDriver",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          firstName: z.string().min(1, "First name is required").optional(),
-          lastName: z.string().min(1, "Last name is required").optional(),
-          phone: phoneField().optional(),
-          phone2: z.preprocess(
-            (v) => (v === "" ? null : v),
-            z.string().regex(phoneRegex, "Invalid Algerian phone number").nullable().optional()
-          ).openapi({ description: "Updated secondary phone. Send `null` to clear it." }),
-          vehicleType: z.enum(["motorcycle", "car", "van"]).nullable().optional().openapi({
-            description: "Updated vehicle type. Send `null` to clear it.",
-          }),
-          notes: z.preprocess(
-            (v) => (v === "" ? null : v),
-            z.string().nullable().optional()
-          ).openapi({ description: "Updated internal notes. Send `null` to clear." }),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: updateBodySchema,
   responses: {
     200: {
       description: "Driver updated. Returns full updated driver record.",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          data: DriverSchema,
-          message: z.string().openapi({ example: "Driver updated successfully" }),
-        })
-      ),
+      content: jsonContent(SuccessWithMessageSchema(DriverSchema)),
     },
-    400: errorResponse("Validation error (invalid phone format)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:manage scope"),
-    404: errorResponse("Driver not found (DRIVER_NOT_FOUND)"),
-    409: errorResponse("Duplicate phone number - a driver with this phone already exists (code: DUPLICATE_PHONE)"),
+    409: {
+      description: "Duplicate phone number - a driver with this phone already exists (code: DUPLICATE_PHONE)",
+    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.updateDriver,
 });
 
-const updateDriverStatusRoute = createRoute({
+const updateDriverStatusRoute = defineRoute({
   method: "patch",
   path: "/{id}/status",
-  middleware: [requireScope(SCOPES.DELIVERY_MANAGE)],
+  auth: { scope: SCOPES.DELIVERY_MANAGE },
   tags: ["Drivers"],
   summary: "Update driver status",
   description: "Updates driver availability status. Returns the full updated driver record.",
   operationId: "updateDriverStatus",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          status: z.enum(["available", "busy", "inactive"]).openapi({
-            description: "New availability status for the driver",
-          }),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: updateStatusBodySchema,
   responses: {
     200: {
       description: "Status updated",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          data: DriverSchema,
-          message: z.string().openapi({ example: "Driver status updated" }),
-        })
-      ),
+      content: jsonContent(SuccessWithMessageSchema(DriverSchema)),
     },
-    400: errorResponse("Validation error (invalid status value)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:manage scope"),
-    404: errorResponse("Driver not found (DRIVER_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.updateDriverStatus,
 });
 
-const deleteDriverRoute = createRoute({
+const deleteDriverRoute = defineRoute({
   method: "delete",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.DELIVERY_MANAGE)],
+  auth: { scope: SCOPES.DELIVERY_MANAGE },
   tags: ["Drivers"],
   summary: "Delete driver",
   description:
     "Permanently deletes the driver. **Returns 409 if the driver has orders in `assigned` or `out_for_delivery` status** — resolve those orders first.",
   operationId: "deleteDriver",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Driver deleted",
@@ -291,28 +244,23 @@ const deleteDriverRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:manage scope"),
-    404: errorResponse("Driver not found (DRIVER_NOT_FOUND)"),
-    409: errorResponse(
-      "Cannot delete driver with active orders (code: DRIVER_HAS_ACTIVE_ORDERS)"
-    ),
+    409: {
+      description: "Cannot delete driver with active orders (code: DRIVER_HAS_ACTIVE_ORDERS)",
+    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.deleteDriver,
 });
 
-const listCompensationsRoute = createRoute({
+const listCompensationsRoute = defineRoute({
   method: "get",
   path: "/{id}/compensations",
-  middleware: [requireScope(SCOPES.DELIVERY_READ)],
+  auth: { scope: SCOPES.DELIVERY_READ },
   tags: ["Drivers"],
   summary: "List driver compensations",
   description:
     "Returns all 58 wilayas with the driver's configured per-delivery fee. `feePerDelivery` is `null` when no row has been configured for that wilaya (in which case the assigned order's driver fee defaults to 0).",
   operationId: "listDriverCompensations",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Per-wilaya compensation grid for this driver.",
@@ -323,36 +271,21 @@ const listCompensationsRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:read scope"),
-    404: errorResponse("Driver not found (DRIVER_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.listCompensations,
 });
 
-const setCompensationRoute = createRoute({
+const setCompensationRoute = defineRoute({
   method: "put",
   path: "/{id}/compensations/{wilayaId}",
-  middleware: [requireScope(SCOPES.DELIVERY_MANAGE)],
+  auth: { scope: SCOPES.DELIVERY_MANAGE },
   tags: ["Drivers"],
   summary: "Upsert driver compensation for one wilaya",
   description:
     "Sets (or updates) the per-delivery fee this driver is paid for the given wilaya. Idempotent.",
   operationId: "setDriverCompensation",
-  request: {
-    params: compensationParams,
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          feePerDelivery: z.number().min(0).openapi({
-            description: "DZD per delivery in this wilaya.",
-            example: 350,
-          }),
-        })
-      ),
-    },
-  },
+  params: compensationParams,
+  body: setCompensationBodySchema,
   responses: {
     200: {
       description: "Compensation saved.",
@@ -371,26 +304,20 @@ const setCompensationRoute = createRoute({
         })
       ),
     },
-    400: errorResponse("Validation error (negative fee, invalid wilayaId)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:manage scope"),
-    404: errorResponse("Driver not found (DRIVER_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.setCompensation,
 });
 
-const deleteCompensationRoute = createRoute({
+const deleteCompensationRoute = defineRoute({
   method: "delete",
   path: "/{id}/compensations/{wilayaId}",
-  middleware: [requireScope(SCOPES.DELIVERY_MANAGE)],
+  auth: { scope: SCOPES.DELIVERY_MANAGE },
   tags: ["Drivers"],
   summary: "Remove driver compensation for one wilaya",
   description:
     "Removes the per-delivery fee row for this driver/wilaya pair. Future assignments in that wilaya will compute driverFee = 0 until a new row is set.",
   operationId: "deleteDriverCompensation",
-  request: {
-    params: compensationParams,
-  },
+  params: compensationParams,
   responses: {
     200: {
       description: "Compensation removed.",
@@ -401,25 +328,26 @@ const deleteCompensationRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:manage scope"),
-    404: errorResponse(
-      "Driver not found (`DRIVER_NOT_FOUND`) **or** no compensation row exists for this (driver, wilaya) pair (`DRIVER_COMPENSATION_NOT_FOUND`). Distinguish via the `code` field."
-    ),
+    404: {
+      description:
+        "Driver not found (`DRIVER_NOT_FOUND`) **or** no compensation row exists for this (driver, wilaya) pair (`DRIVER_COMPENSATION_NOT_FOUND`). Distinguish via the `code` field.",
+    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.deleteCompensation,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(listDriversRoute, handlers.listDrivers);
-router.openapi(createDriverRoute, handlers.createDriver);
-router.openapi(getDriverRoute, handlers.getDriver);
-router.openapi(updateDriverRoute, handlers.updateDriver);
-router.openapi(updateDriverStatusRoute, handlers.updateDriverStatus);
-router.openapi(deleteDriverRoute, handlers.deleteDriver);
-router.openapi(listCompensationsRoute, handlers.listCompensations);
-router.openapi(setCompensationRoute, handlers.setCompensation);
-router.openapi(deleteCompensationRoute, handlers.deleteCompensation);
+router.openapi(listDriversRoute.route, listDriversRoute.handler);
+router.openapi(createDriverRoute.route, createDriverRoute.handler);
+router.openapi(getDriverRoute.route, getDriverRoute.handler);
+router.openapi(updateDriverRoute.route, updateDriverRoute.handler);
+router.openapi(updateDriverStatusRoute.route, updateDriverStatusRoute.handler);
+router.openapi(deleteDriverRoute.route, deleteDriverRoute.handler);
+router.openapi(listCompensationsRoute.route, listCompensationsRoute.handler);
+router.openapi(setCompensationRoute.route, setCompensationRoute.handler);
+router.openapi(deleteCompensationRoute.route, deleteCompensationRoute.handler);
 
 export default router;

--- a/cod-server/src/endpoints/images/routes.ts
+++ b/cod-server/src/endpoints/images/routes.ts
@@ -12,22 +12,21 @@
  *       cannot be expressed in a @hono/zod-openapi createRoute path. Its
  *       documentation is preserved as a legacy path entry in openapi.ts.
  *
- * Upload/presign migrated to @hono/zod-openapi: route definitions are the
- * single source of truth for validation and the OpenAPI spec. MIME-type and
- * size checks stay in the handlers to preserve their specific error codes.
+ * Built with defineRoute() — the standard route-builder pattern.
+ * MIME-type and size checks stay in the handlers to preserve their
+ * specific error codes.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import { Hono } from "hono";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import * as h from "./handlers";
 import { presignUpload } from "./presign";
 import {
   UploadedImageSchema,
   PresignedUploadSchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
 } from "@/openapi/schemas";
 
@@ -35,30 +34,22 @@ const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
 
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
-});
+// ─── Routes ───────────────────────────────────────────────────────────────────
 
-const uploadImageRoute = createRoute({
+const uploadImageRoute = defineRoute({
   method: "post",
   path: "/upload",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
   tags: ["Images"],
   summary: "Upload image",
   description:
     "Upload an image file (jpg, png, webp, gif) to R2 storage. Max 10 MB. Content type must be multipart/form-data with a single `file` field.",
   operationId: "uploadImage",
-  request: {
-    body: {
-      required: true,
-      content: {
-        "multipart/form-data": {
-          schema: z.object({
-            file: z.instanceof(File).openapi({ type: "string", format: "binary" }),
-          }),
-        },
-      },
+  bodyContent: {
+    "multipart/form-data": {
+      schema: z.object({
+        file: z.instanceof(File).openapi({ type: "string", format: "binary" }),
+      }),
     },
   },
   responses: {
@@ -66,58 +57,51 @@ const uploadImageRoute = createRoute({
       description: "Image uploaded successfully",
       content: jsonContent(SuccessResponseSchema(UploadedImageSchema)),
     },
-    400: errorResponse(
-      "Validation error - missing file, invalid type, or file too large (VALIDATION_FAILED / REQUIRED_FIELD_MISSING / INVALID_FILE_TYPE / FILE_TOO_LARGE)"
-    ),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:manage scope"),
-    500: errorResponse("System error - R2 storage failure (INTERNAL_SERVER_ERROR)"),
+    400: {
+      description:
+        "Validation error - missing file, invalid type, or file too large (VALIDATION_FAILED / REQUIRED_FIELD_MISSING / INVALID_FILE_TYPE / FILE_TOO_LARGE)",
+    },
+    500: { description: "System error - R2 storage failure (INTERNAL_SERVER_ERROR)" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.uploadImage,
 });
 
-const presignRoute = createRoute({
+const presignRoute = defineRoute({
   method: "post",
   path: "/presign",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
   tags: ["Images"],
   summary: "Get presigned upload URL",
   description:
     "Get a presigned URL for direct client-side upload to R2. The client PUTs the file to `presignedUrl`, then calls POST /api/products/{id}/images with the returned `key`. Allowed content types: image/jpeg, image/png, image/webp, image/gif.",
   operationId: "presignUpload",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          contentType: z.string().min(1).openapi({
-            description:
-              "MIME type — one of: image/jpeg, image/png, image/webp, image/gif (validated server-side; invalid values return INVALID_FILE_TYPE)",
-            example: "image/jpeg",
-          }),
-        })
-      ),
-    },
-  },
+  body: z.object({
+    contentType: z.string().min(1).openapi({
+      description:
+        "MIME type — one of: image/jpeg, image/png, image/webp, image/gif (validated server-side; invalid values return INVALID_FILE_TYPE)",
+      example: "image/jpeg",
+    }),
+  }),
   responses: {
     200: {
       description: "Presigned URL generated",
       content: jsonContent(SuccessResponseSchema(PresignedUploadSchema)),
     },
-    400: errorResponse("Invalid or unsupported content type (INVALID_FILE_TYPE)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing products:manage scope"),
-    500: errorResponse(
-      "R2 credentials not configured on server or presigned URL generation failed (INTERNAL_SERVER_ERROR)"
-    ),
+    400: { description: "Invalid or unsupported content type (INVALID_FILE_TYPE)" },
+    500: {
+      description:
+        "R2 credentials not configured on server or presigned URL generation failed (INTERNAL_SERVER_ERROR)",
+    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: presignUpload,
 });
+
+// ─── Routers ──────────────────────────────────────────────────────────────────
 
 // Upload route — requires auth (goes through /api/* middleware)
 export const uploadRouter = new OpenAPIHono<AppContext>();
-uploadRouter.openapi(uploadImageRoute, h.uploadImage);
-uploadRouter.openapi(presignRoute, presignUpload);
+uploadRouter.openapi(uploadImageRoute.route, uploadImageRoute.handler);
+uploadRouter.openapi(presignRoute.route, presignRoute.handler);
 
 // Serve route — no auth, mounted outside /api/*
 // Plain Hono on purpose: `:key{.+}` regex param is required so that object

--- a/cod-server/src/endpoints/offers/routes.ts
+++ b/cod-server/src/endpoints/offers/routes.ts
@@ -4,21 +4,17 @@
  * CRM endpoints for managing "Buy X Get Y" promotional offers. Offers are
  * auto-applied server-side when a store order meets the trigger conditions —
  * no coupon code input is required from the customer.
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import * as h from "./handlers";
 import { createOfferSchema, updateOfferSchema } from "./validation";
 import {
   OfferSchema,
-  ErrorResponseSchema,
   ListResponseSchema,
   SuccessResponseSchema,
 } from "@/openapi/schemas";
@@ -27,19 +23,16 @@ const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
 
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
-});
-
 const idParams = z.object({
   id: z.string().openapi({ description: "Offer UUID", example: "off_abc123" }),
 });
 
-const listOffersRoute = createRoute({
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const listOffersRoute = defineRoute({
   method: "get",
   path: "/",
-  middleware: [requireScope(SCOPES.OFFERS_READ)],
+  auth: { scope: SCOPES.OFFERS_READ },
   tags: ["Offers"],
   summary: "List offers",
   description:
@@ -50,40 +43,33 @@ const listOffersRoute = createRoute({
       description: "List of offers",
       content: jsonContent(ListResponseSchema(OfferSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires offers:read"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.listOffers,
 });
 
-const getOfferRoute = createRoute({
+const getOfferRoute = defineRoute({
   method: "get",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.OFFERS_READ)],
+  auth: { scope: SCOPES.OFFERS_READ },
   tags: ["Offers"],
   summary: "Get offer",
   description:
     "Get a single offer by ID with fully resolved product and variant references.",
   operationId: "getOffer",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Offer details",
       content: jsonContent(SuccessResponseSchema(OfferSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires offers:read"),
-    404: errorResponse("Offer not found (OFFER_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.getOffer,
 });
 
-const createOfferRoute = createRoute({
+const createOfferRoute = defineRoute({
   method: "post",
   path: "/",
-  middleware: [requireScope(SCOPES.OFFERS_MANAGE)],
+  auth: { scope: SCOPES.OFFERS_MANAGE },
   tags: ["Offers"],
   summary: "Create offer",
   description: `Create a new Buy X Get Y promotional offer.
@@ -95,84 +81,62 @@ const createOfferRoute = createRoute({
 - If the reward item is out of stock, the offer is silently skipped (order still succeeds).
 - The reward is inserted as a \`$0\` order line item; the COD total only reflects paid products + delivery.`,
   operationId: "createOffer",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(createOfferSchema),
-    },
-  },
+  body: createOfferSchema,
   responses: {
     201: {
       description: "Offer created",
       content: jsonContent(SuccessResponseSchema(OfferSchema)),
     },
-    400: errorResponse(
-      "Validation error (e.g. rewardProductId missing for 'free' discount type)"
-    ),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires offers:manage"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.createOffer,
 });
 
-const updateOfferRoute = createRoute({
+const updateOfferRoute = defineRoute({
   method: "patch",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.OFFERS_MANAGE)],
+  auth: { scope: SCOPES.OFFERS_MANAGE },
   tags: ["Offers"],
   summary: "Update offer",
   description:
     "Partially update an offer. All fields are optional — send only the fields you want to change.",
   operationId: "updateOffer",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: jsonContent(updateOfferSchema),
-    },
-  },
+  params: idParams,
+  body: updateOfferSchema,
   responses: {
     200: {
       description: "Updated offer",
       content: jsonContent(SuccessResponseSchema(OfferSchema)),
     },
-    400: errorResponse("Validation error"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires offers:manage"),
-    404: errorResponse("Offer not found (OFFER_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.updateOffer,
 });
 
-const deleteOfferRoute = createRoute({
+const deleteOfferRoute = defineRoute({
   method: "delete",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.OFFERS_MANAGE)],
+  auth: { scope: SCOPES.OFFERS_MANAGE },
   tags: ["Offers"],
   summary: "Delete offer",
   description: "Permanently delete an offer. Already-placed orders are not affected.",
   operationId: "deleteOffer",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Offer deleted",
       content: jsonContent(z.object({ success: z.boolean().openapi({ example: true }) })),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires offers:manage"),
-    404: errorResponse("Offer not found (OFFER_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.deleteOffer,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(listOffersRoute, h.listOffers);
-router.openapi(getOfferRoute, h.getOffer);
-router.openapi(createOfferRoute, h.createOffer);
-router.openapi(updateOfferRoute, h.updateOffer);
-router.openapi(deleteOfferRoute, h.deleteOffer);
+router.openapi(listOffersRoute.route, listOffersRoute.handler);
+router.openapi(getOfferRoute.route, getOfferRoute.handler);
+router.openapi(createOfferRoute.route, createOfferRoute.handler);
+router.openapi(updateOfferRoute.route, updateOfferRoute.handler);
+router.openapi(deleteOfferRoute.route, deleteOfferRoute.handler);
 
 export default router;

--- a/cod-server/src/endpoints/product-groups/routes.ts
+++ b/cod-server/src/endpoints/product-groups/routes.ts
@@ -3,20 +3,16 @@
  *
  * CRUD endpoints for the product category/collection hierarchy.
  * All routes require an API key with the appropriate product_groups scope.
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import * as h from "./handlers";
 import {
   ProductCategorySchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
   ListResponseSchema,
 } from "@/openapi/schemas";
@@ -25,12 +21,9 @@ const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
 
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
-});
-
 const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+// ─── Request schemas ──────────────────────────────────────────────────────────
 
 const groupBaseFields = {
   name: z.string().min(1).openapi({ example: "Electronics" }),
@@ -52,143 +45,116 @@ const groupBaseFields = {
   metaKeywords: z.string().nullable().optional(),
 };
 
-const listGroupsRoute = createRoute({
+const listQuerySchema = z.object({
+  search: z.string().optional().openapi({ description: "Search by name" }),
+  parentId: z.string().optional().openapi({
+    description: "Filter to direct sub-categories of this parent group ID",
+  }),
+});
+
+const createBodySchema = z.object({
+  ...groupBaseFields,
+  position: z.number().int().min(0).default(0),
+});
+
+const idParams = z.object({
+  id: z.string().openapi({ description: "Product group ID", example: "cat_123" }),
+});
+
+const updateBodySchema = z.object({
+  ...groupBaseFields,
+  position: z.number().int().min(0).optional(),
+});
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const listGroupsRoute = defineRoute({
   method: "get",
   path: "/",
-  middleware: [requireScope(SCOPES.PRODUCT_GROUPS_READ)],
+  auth: { scope: SCOPES.PRODUCT_GROUPS_READ },
   tags: ["Product Groups"],
   summary: "List product groups",
   description:
     "Get all product categories/groups, ordered by position. Each item includes productsCount (active, non-deleted products).",
   operationId: "listProductGroups",
-  request: {
-    query: z.object({
-      search: z.string().optional().openapi({ description: "Search by name" }),
-      parentId: z.string().optional().openapi({
-        description: "Filter to direct sub-categories of this parent group ID",
-      }),
-    }),
-  },
+  query: listQuerySchema,
   responses: {
     200: {
       description: "List of product groups",
       content: jsonContent(ListResponseSchema(ProductCategorySchema)),
     },
-    400: errorResponse("Validation error - invalid query parameters"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing product_groups:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.listGroups,
 });
 
-const createGroupRoute = createRoute({
+const createGroupRoute = defineRoute({
   method: "post",
   path: "/",
-  middleware: [requireScope(SCOPES.PRODUCT_GROUPS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCT_GROUPS_MANAGE },
   tags: ["Product Groups"],
   summary: "Create product group",
   description:
     "Create a new product category/group. Provide parentId to create a sub-category; slug is auto-generated from name when omitted.",
   operationId: "createProductGroup",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          ...groupBaseFields,
-          position: z.number().int().min(0).default(0),
-        })
-      ),
-    },
-  },
+  body: createBodySchema,
   responses: {
     201: {
       description: "Group created",
       content: jsonContent(SuccessResponseSchema(ProductCategorySchema)),
     },
-    400: errorResponse("Validation error (missing name, invalid slug or URL)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing product_groups:manage scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.createGroup,
 });
 
-const getGroupRoute = createRoute({
+const getGroupRoute = defineRoute({
   method: "get",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.PRODUCT_GROUPS_READ)],
+  auth: { scope: SCOPES.PRODUCT_GROUPS_READ },
   tags: ["Product Groups"],
   summary: "Get product group",
   description:
     "Returns the group with its immediate children (sub-categories) and productsCount.",
   operationId: "getProductGroup",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Product group ID", example: "cat_123" }),
-    }),
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Group details with children and product count",
       content: jsonContent(SuccessResponseSchema(ProductCategorySchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing product_groups:read scope"),
-    404: errorResponse("Product group not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.getGroup,
 });
 
-const updateGroupRoute = createRoute({
+const updateGroupRoute = defineRoute({
   method: "patch",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.PRODUCT_GROUPS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCT_GROUPS_MANAGE },
   tags: ["Product Groups"],
   summary: "Update product group",
   description:
     "Partial update — only include fields you want to change. Set parentId to null to move a group to the top level; set SEO fields to null to clear them.",
   operationId: "updateProductGroup",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Product group ID", example: "cat_123" }),
-    }),
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          ...groupBaseFields,
-          position: z.number().int().min(0).optional(),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: updateBodySchema,
   responses: {
     200: {
       description: "Group updated",
       content: jsonContent(SuccessResponseSchema(ProductCategorySchema)),
     },
-    400: errorResponse("Validation error (invalid slug or URL)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing product_groups:manage scope"),
-    404: errorResponse("Product group not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.updateGroup,
 });
 
-const deleteGroupRoute = createRoute({
+const deleteGroupRoute = defineRoute({
   method: "delete",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.PRODUCT_GROUPS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCT_GROUPS_MANAGE },
   tags: ["Product Groups"],
   summary: "Delete product group",
   description:
     "Permanently deletes a product group. Blocked while the group still has active products — reassign or remove those products first.",
   operationId: "deleteProductGroup",
-  request: {
-    params: z.object({
-      id: z.string().openapi({ description: "Product group ID", example: "cat_123" }),
-    }),
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Group deleted",
@@ -198,20 +164,19 @@ const deleteGroupRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing product_groups:manage scope"),
-    404: errorResponse("Product group not found"),
-    422: errorResponse("Product group has existing products - cannot delete"),
+    422: { description: "Product group has existing products - cannot delete" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.deleteGroup,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(listGroupsRoute, h.listGroups);
-router.openapi(createGroupRoute, h.createGroup);
-router.openapi(getGroupRoute, h.getGroup);
-router.openapi(updateGroupRoute, h.updateGroup);
-router.openapi(deleteGroupRoute, h.deleteGroup);
+router.openapi(listGroupsRoute.route, listGroupsRoute.handler);
+router.openapi(createGroupRoute.route, createGroupRoute.handler);
+router.openapi(getGroupRoute.route, getGroupRoute.handler);
+router.openapi(updateGroupRoute.route, updateGroupRoute.handler);
+router.openapi(deleteGroupRoute.route, deleteGroupRoute.handler);
 
 export default router;

--- a/cod-server/src/endpoints/shipping-profiles/routes.ts
+++ b/cod-server/src/endpoints/shipping-profiles/routes.ts
@@ -4,15 +4,12 @@
  * Profile CRUD, bulk wilaya-rule replacement, commune-level overrides, and
  * the default-profile auto-fill endpoint. All routes require an API key with
  * the appropriate delivery scope.
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import * as handlers from "./handlers";
 import {
@@ -20,7 +17,6 @@ import {
   ShippingProfileWithRulesSchema,
   ShippingRuleSchema,
   CommuneOverrideSchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
   ListResponseSchema,
 } from "@/openapi/schemas";
@@ -29,10 +25,7 @@ const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
 
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
-});
+// ─── Params ───────────────────────────────────────────────────────────────────
 
 const idParams = z.object({
   id: z.string().openapi({ description: "Shipping profile ID", example: "profile_123" }),
@@ -51,10 +44,45 @@ const communeParams = z.object({
   communeId: z.string().openapi({ description: "Commune ID", example: "c-16-001" }),
 });
 
-const listProfilesRoute = createRoute({
+// ─── Request schemas ──────────────────────────────────────────────────────────
+
+const createBodySchema = z.object({
+  name: z.string().min(1, "Name is required").openapi({ example: "Standard Rates" }),
+  isDefault: z.boolean().default(false).optional(),
+  notes: z.string().nullable().optional(),
+});
+
+const updateBodySchema = z.object({
+  name: z.string().min(1, "Name is required").optional(),
+  isDefault: z.boolean().optional(),
+  notes: z.string().nullable().optional(),
+});
+
+const setRulesBodySchema = z.object({
+  rules: z.array(
+    z.object({
+      wilayaId: z.number().int().min(1).max(58),
+      homePrice: z.number().min(0).default(0),
+      stopDeskPrice: z.number().min(0).default(0),
+      homeEnabled: z.boolean().default(true).optional(),
+      stopDeskEnabled: z.boolean().default(false).optional(),
+    })
+  ),
+});
+
+const communeOverrideBodySchema = z.object({
+  homeEnabled: z.boolean().nullable().optional(),
+  stopDeskEnabled: z.boolean().nullable().optional(),
+  homePrice: z.number().min(0).nullable().optional(),
+  stopDeskPrice: z.number().min(0).nullable().optional(),
+});
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const listProfilesRoute = defineRoute({
   method: "get",
   path: "/",
-  middleware: [requireScope(SCOPES.DELIVERY_READ)],
+  auth: { scope: SCOPES.DELIVERY_READ },
   tags: ["Shipping Profiles"],
   summary: "List shipping profiles",
   description:
@@ -65,49 +93,33 @@ const listProfilesRoute = createRoute({
       description: "List of shipping profiles",
       content: jsonContent(ListResponseSchema(ShippingProfileSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.listProfiles,
 });
 
-const createProfileRoute = createRoute({
+const createProfileRoute = defineRoute({
   method: "post",
   path: "/",
-  middleware: [requireScope(SCOPES.DELIVERY_MANAGE)],
+  auth: { scope: SCOPES.DELIVERY_MANAGE },
   tags: ["Shipping Profiles"],
   summary: "Create shipping profile",
   description:
     "Creates a profile (rate-card metadata only). Use `PUT /{id}/rules` afterwards to populate wilaya rates. Setting `isDefault: true` atomically unsets the current default profile.",
   operationId: "createShippingProfile",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          name: z.string().min(1, "Name is required").openapi({ example: "Standard Rates" }),
-          isDefault: z.boolean().default(false).optional(),
-          notes: z.string().nullable().optional(),
-        })
-      ),
-    },
-  },
+  body: createBodySchema,
   responses: {
     201: {
       description: "Profile created",
       content: jsonContent(SuccessResponseSchema(ShippingProfileWithRulesSchema)),
     },
-    400: errorResponse("Validation error — missing/empty name"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:manage scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.createProfile,
 });
 
-const getDefaultRulesRoute = createRoute({
+const getDefaultRulesRoute = defineRoute({
   method: "get",
   path: "/default/rules",
-  middleware: [requireScope(SCOPES.DELIVERY_READ)],
+  auth: { scope: SCOPES.DELIVERY_READ },
   tags: ["Shipping Profiles"],
   summary: "Get default-profile rules",
   description:
@@ -123,79 +135,58 @@ const getDefaultRulesRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:read scope"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.getDefaultRules,
 });
 
-const getProfileRoute = createRoute({
+const getProfileRoute = defineRoute({
   method: "get",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.DELIVERY_READ)],
+  auth: { scope: SCOPES.DELIVERY_READ },
   tags: ["Shipping Profiles"],
   summary: "Get shipping profile",
   description:
     "Returns a single profile with its full list of wilaya rules (including `homeEnabled` / `stopDeskEnabled`).",
   operationId: "getShippingProfile",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Profile with rules",
       content: jsonContent(SuccessResponseSchema(ShippingProfileWithRulesSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:read scope"),
-    404: errorResponse("Shipping profile not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.getProfile,
 });
 
-const updateProfileRoute = createRoute({
+const updateProfileRoute = defineRoute({
   method: "patch",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.DELIVERY_MANAGE)],
+  auth: { scope: SCOPES.DELIVERY_MANAGE },
   tags: ["Shipping Profiles"],
   summary: "Update shipping profile",
   description:
     "Partial update of profile metadata. Include only the fields you want to change. Set `notes` to `null` to clear it.\n\n" +
     "**Default invariant:** the system always keeps exactly one profile marked `isDefault`. Setting `isDefault: true` here atomically unsets the current default. Setting `isDefault: false` on the **only** default profile is rejected with `422 DEFAULT_PROFILE_REQUIRED`.",
   operationId: "updateShippingProfile",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          name: z.string().min(1, "Name is required").optional(),
-          isDefault: z.boolean().optional(),
-          notes: z.string().nullable().optional(),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: updateBodySchema,
   responses: {
     200: {
       description: "Profile updated",
       content: jsonContent(SuccessResponseSchema(ShippingProfileWithRulesSchema)),
     },
-    400: errorResponse("Validation error"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:manage scope"),
-    404: errorResponse("Shipping profile not found"),
-    422: errorResponse(
-      "Cannot unset the last default profile — one profile must always be default (code: DEFAULT_PROFILE_REQUIRED)"
-    ),
+    422: {
+      description:
+        "Cannot unset the last default profile — one profile must always be default (code: DEFAULT_PROFILE_REQUIRED)",
+    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.updateProfile,
 });
 
-const deleteProfileRoute = createRoute({
+const deleteProfileRoute = defineRoute({
   method: "delete",
   path: "/{id}",
-  middleware: [requireScope(SCOPES.DELIVERY_MANAGE)],
+  auth: { scope: SCOPES.DELIVERY_MANAGE },
   tags: ["Shipping Profiles"],
   summary: "Delete shipping profile",
   description:
@@ -204,30 +195,24 @@ const deleteProfileRoute = createRoute({
     "- The profile is currently referenced by one or more products → `422 PROFILE_IN_USE`\n" +
     "- The profile is the default profile → `422 DEFAULT_PROFILE_REQUIRED` (set another profile as default first)",
   operationId: "deleteShippingProfile",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "Profile deleted",
-      content: jsonContent(
-        z.object({ success: z.boolean().openapi({ example: true }) })
-      ),
+      content: jsonContent(z.object({ success: z.boolean().openapi({ example: true }) })),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:manage scope"),
-    404: errorResponse("Shipping profile not found"),
-    422: errorResponse(
-      "Profile cannot be deleted — disambiguate via `code`: PROFILE_IN_USE or DEFAULT_PROFILE_REQUIRED"
-    ),
+    422: {
+      description:
+        "Profile cannot be deleted — disambiguate via `code`: PROFILE_IN_USE or DEFAULT_PROFILE_REQUIRED",
+    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.deleteProfile,
 });
 
-const setProfileRulesRoute = createRoute({
+const setProfileRulesRoute = defineRoute({
   method: "put",
   path: "/{id}/rules",
-  middleware: [requireScope(SCOPES.DELIVERY_MANAGE)],
+  auth: { scope: SCOPES.DELIVERY_MANAGE },
   tags: ["Shipping Profiles"],
   summary: "Replace wilaya rules",
   description:
@@ -237,44 +222,25 @@ const setProfileRulesRoute = createRoute({
     "- Setting both `homeEnabled: false` and `stopDeskEnabled: false` on a wilaya effectively disables delivery for that wilaya under this profile.\n" +
     "- Sending an empty `rules` array clears all rules for the profile.",
   operationId: "setProfileRules",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          rules: z.array(
-            z.object({
-              wilayaId: z.number().int().min(1).max(58),
-              homePrice: z.number().min(0).default(0),
-              stopDeskPrice: z.number().min(0).default(0),
-              homeEnabled: z.boolean().default(true).optional(),
-              stopDeskEnabled: z.boolean().default(false).optional(),
-            })
-          ),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: setRulesBodySchema,
   responses: {
     200: {
       description: "Rules replaced — returns the profile with its new rules",
       content: jsonContent(SuccessResponseSchema(ShippingProfileWithRulesSchema)),
     },
-    400: errorResponse(
-      "Validation error, including duplicate wilayaId in rules array (code: DUPLICATE_WILAYA_RULE)"
-    ),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:manage scope"),
-    404: errorResponse("Shipping profile not found"),
+    400: {
+      description:
+        "Validation error, including duplicate wilayaId in rules array (code: DUPLICATE_WILAYA_RULE)",
+    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.setProfileRules,
 });
 
-const listCommuneOverridesRoute = createRoute({
+const listCommuneOverridesRoute = defineRoute({
   method: "get",
   path: "/{id}/rules/{wilayaId}/communes",
-  middleware: [requireScope(SCOPES.DELIVERY_READ)],
+  auth: { scope: SCOPES.DELIVERY_READ },
   tags: ["Shipping Profiles"],
   summary: "List commune overrides",
   description:
@@ -284,9 +250,7 @@ const listCommuneOverridesRoute = createRoute({
     "- **hasOverride** — `true` if any override row exists for this commune.\n\n" +
     "Requires that the profile already has a rule for the given wilaya — otherwise responds `404 SHIPPING_RULE_NOT_FOUND`.",
   operationId: "listCommuneOverrides",
-  request: {
-    params: ruleParams,
-  },
+  params: ruleParams,
   responses: {
     200: {
       description: "All communes in this wilaya with override status",
@@ -297,19 +261,14 @@ const listCommuneOverridesRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:read scope"),
-    404: errorResponse(
-      "No rule configured for this wilaya in this profile — configure one first via PUT /{id}/rules (code: SHIPPING_RULE_NOT_FOUND)"
-    ),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.listCommuneOverrides,
 });
 
-const setCommuneOverrideRoute = createRoute({
+const setCommuneOverrideRoute = defineRoute({
   method: "put",
   path: "/{id}/rules/{wilayaId}/communes/{communeId}",
-  middleware: [requireScope(SCOPES.DELIVERY_MANAGE)],
+  auth: { scope: SCOPES.DELIVERY_MANAGE },
   tags: ["Shipping Profiles"],
   summary: "Set or update commune override",
   description:
@@ -320,76 +279,49 @@ const setCommuneOverrideRoute = createRoute({
     "- Prices must be ≥ 0 when provided.\n\n" +
     "**Effects on orders:** subsequent online orders with this wilaya + commune pair will use the overridden values. Disabling `homeEnabled` or `stopDeskEnabled` causes `422 DELIVERY_NOT_AVAILABLE` at order creation for that mode.",
   operationId: "setCommuneOverride",
-  request: {
-    params: communeParams,
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          homeEnabled: z.boolean().nullable().optional(),
-          stopDeskEnabled: z.boolean().nullable().optional(),
-          homePrice: z.number().min(0).nullable().optional(),
-          stopDeskPrice: z.number().min(0).nullable().optional(),
-        })
-      ),
-    },
-  },
+  params: communeParams,
+  body: communeOverrideBodySchema,
   responses: {
     200: {
       description: "Override upserted (or removed if all fields null)",
-      content: jsonContent(
-        z.object({ success: z.boolean().openapi({ example: true }) })
-      ),
+      content: jsonContent(z.object({ success: z.boolean().openapi({ example: true }) })),
     },
-    400: errorResponse("Validation error (e.g. negative price)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:manage scope"),
-    404: errorResponse(
-      "No rule configured for this wilaya in this profile (code: SHIPPING_RULE_NOT_FOUND)"
-    ),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.setCommuneOverride,
 });
 
-const deleteCommuneOverrideRoute = createRoute({
+const deleteCommuneOverrideRoute = defineRoute({
   method: "delete",
   path: "/{id}/rules/{wilayaId}/communes/{communeId}",
-  middleware: [requireScope(SCOPES.DELIVERY_MANAGE)],
+  auth: { scope: SCOPES.DELIVERY_MANAGE },
   tags: ["Shipping Profiles"],
   summary: "Remove commune override",
   description:
     "Removes the commune override row — the commune will again inherit the wilaya rule. Returns `404 COMMUNE_OVERRIDE_NOT_FOUND` if no override row exists for this commune.",
   operationId: "deleteCommuneOverride",
-  request: {
-    params: communeParams,
-  },
+  params: communeParams,
   responses: {
     200: {
       description: "Override removed — commune reverts to wilaya defaults",
-      content: jsonContent(
-        z.object({ success: z.boolean().openapi({ example: true }) })
-      ),
+      content: jsonContent(z.object({ success: z.boolean().openapi({ example: true }) })),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Missing delivery:manage scope"),
-    404: errorResponse(
-      "No wilaya rule for this profile/wilaya (SHIPPING_RULE_NOT_FOUND) or no override configured for this commune (COMMUNE_OVERRIDE_NOT_FOUND)"
-    ),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.deleteCommuneOverride,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(listProfilesRoute, handlers.listProfiles);
-router.openapi(createProfileRoute, handlers.createProfile);
-router.openapi(getDefaultRulesRoute, handlers.getDefaultRules);
-router.openapi(getProfileRoute, handlers.getProfile);
-router.openapi(updateProfileRoute, handlers.updateProfile);
-router.openapi(deleteProfileRoute, handlers.deleteProfile);
-router.openapi(setProfileRulesRoute, handlers.setProfileRules);
-router.openapi(listCommuneOverridesRoute, handlers.listCommuneOverrides);
-router.openapi(setCommuneOverrideRoute, handlers.setCommuneOverride);
-router.openapi(deleteCommuneOverrideRoute, handlers.deleteCommuneOverride);
+router.openapi(listProfilesRoute.route, listProfilesRoute.handler);
+router.openapi(createProfileRoute.route, createProfileRoute.handler);
+router.openapi(getDefaultRulesRoute.route, getDefaultRulesRoute.handler);
+router.openapi(getProfileRoute.route, getProfileRoute.handler);
+router.openapi(updateProfileRoute.route, updateProfileRoute.handler);
+router.openapi(deleteProfileRoute.route, deleteProfileRoute.handler);
+router.openapi(setProfileRulesRoute.route, setProfileRulesRoute.handler);
+router.openapi(listCommuneOverridesRoute.route, listCommuneOverridesRoute.handler);
+router.openapi(setCommuneOverrideRoute.route, setCommuneOverrideRoute.handler);
+router.openapi(deleteCommuneOverrideRoute.route, deleteCommuneOverrideRoute.handler);
 
 export default router;

--- a/cod-server/src/endpoints/stock/routes.ts
+++ b/cod-server/src/endpoints/stock/routes.ts
@@ -7,14 +7,12 @@
  *   - productStockRouter  → /api/products/*       (adjust/history/threshold
  *     for simple products and variants, nested under the product path)
  *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireScope } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import { SCOPES } from "../../../../cod-shared/rbac/scopes";
 import * as h from "./handlers";
 import {
@@ -27,17 +25,11 @@ import {
   StockMovementSchema,
   StockAlertItemSchema,
   StockOverviewSchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
 } from "@/openapi/schemas";
 
 const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
-});
-
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
 });
 
 const idParams = z.object({
@@ -62,15 +54,12 @@ const adjustResponse = jsonContent(
   })
 );
 
-const thresholdBody = jsonContent(updateThresholdSchema);
-const adjustBody = jsonContent(adjustStockSchema);
-
 // ─── /api/stock/* ─────────────────────────────────────────────────────────────
 
-const getStockOverviewRoute = createRoute({
+const getStockOverviewRoute = defineRoute({
   method: "get",
   path: "/overview",
-  middleware: [requireScope(SCOPES.PRODUCTS_READ)],
+  auth: { scope: SCOPES.PRODUCTS_READ },
   tags: ["Stock"],
   summary: "Stock overview",
   description:
@@ -81,24 +70,20 @@ const getStockOverviewRoute = createRoute({
       description: "Stock health overview",
       content: jsonContent(SuccessResponseSchema(StockOverviewSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires products:read"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.getStockOverview,
 });
 
-const getStockAlertsRoute = createRoute({
+const getStockAlertsRoute = defineRoute({
   method: "get",
   path: "/alerts",
-  middleware: [requireScope(SCOPES.PRODUCTS_READ)],
+  auth: { scope: SCOPES.PRODUCTS_READ },
   tags: ["Stock"],
   summary: "Low stock and out-of-stock alerts",
   description:
     "Paginated list of all SKUs at or below their low stock threshold (includes out-of-stock). Sorted: out-of-stock first, then by inventory ascending.",
   operationId: "getStockAlerts",
-  request: {
-    query: stockAlertsFiltersSchema,
-  },
+  query: stockAlertsFiltersSchema,
   responses: {
     200: {
       description: "Paginated alert items",
@@ -115,22 +100,20 @@ const getStockAlertsRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires products:read"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.getStockAlerts,
 });
 
 export const stockRouter = new OpenAPIHono<AppContext>();
-stockRouter.openapi(getStockOverviewRoute, h.getStockOverview);
-stockRouter.openapi(getStockAlertsRoute, h.getStockAlerts);
+stockRouter.openapi(getStockOverviewRoute.route, getStockOverviewRoute.handler);
+stockRouter.openapi(getStockAlertsRoute.route, getStockAlertsRoute.handler);
 
 // ─── Simple-product stock (/api/products/{id}/stock/*) ───────────────────────
 
-const adjustProductStockRoute = createRoute({
+const adjustProductStockRoute = defineRoute({
   method: "post",
   path: "/{id}/stock/adjust",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
   tags: ["Stock"],
   summary: "Adjust stock for a simple product",
   description:
@@ -138,42 +121,32 @@ const adjustProductStockRoute = createRoute({
     "**`reason` is required for types:** `ADJUSTMENT_ADD`, `ADJUSTMENT_REMOVE`, `OFFLINE_SALE`.\n\n" +
     "**Delta sign convention:** positive = stock arriving, negative = stock leaving. The server rejects adjustments that would result in negative inventory (HTTP 422).",
   operationId: "adjustProductStock",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: adjustBody,
-    },
-  },
+  params: idParams,
+  body: adjustStockSchema,
   responses: {
     200: {
       description: "Stock adjusted successfully",
       content: adjustResponse,
     },
-    400: errorResponse("Validation error — invalid type, zero delta, or missing reason (VALIDATION_FAILED)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires products:manage"),
-    404: errorResponse("Product not found (PRODUCT_NOT_FOUND)"),
-    422: errorResponse(
-      "Adjustment would result in negative inventory (INSUFFICIENT_STOCK). Context includes `stockId`, `productName`, `available`, and `required`."
-    ),
+    422: {
+      description:
+        "Adjustment would result in negative inventory (INSUFFICIENT_STOCK). Context includes `stockId`, `productName`, `available`, and `required`.",
+    },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.adjustProductStock,
 });
 
-const getProductStockHistoryRoute = createRoute({
+const getProductStockHistoryRoute = defineRoute({
   method: "get",
   path: "/{id}/stock/history",
-  middleware: [requireScope(SCOPES.PRODUCTS_READ)],
+  auth: { scope: SCOPES.PRODUCTS_READ },
   tags: ["Stock"],
   summary: "Stock movement history for a product",
   description:
     "Paginated movement log for a product. Use `variantId` to narrow to a specific variant's history. Results are ordered newest-first.",
   operationId: "getProductStockHistory",
-  request: {
-    params: idParams,
-    query: stockHistoryFiltersSchema,
-  },
+  params: idParams,
+  query: stockHistoryFiltersSchema,
   responses: {
     200: {
       description: "Paginated movement history",
@@ -190,105 +163,76 @@ const getProductStockHistoryRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires products:read"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.getProductStockHistory,
 });
 
-const updateProductThresholdRoute = createRoute({
+const updateProductThresholdRoute = defineRoute({
   method: "patch",
   path: "/{id}/stock/threshold",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
   tags: ["Stock"],
   summary: "Update low stock threshold for a simple product",
   description:
     "Sets the `lowStockThreshold` for a simple (non-variant) product. When inventory drops at or below this value, the product appears in stock alerts.",
   operationId: "updateProductThreshold",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: thresholdBody,
-    },
-  },
+  params: idParams,
+  body: updateThresholdSchema,
   responses: {
     200: {
       description: "Threshold updated",
       content: jsonContent(z.object({ success: z.boolean().openapi({ example: true }) })),
     },
-    400: errorResponse("Validation error — non-integer, negative value, or value > 9999 (VALIDATION_FAILED)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires products:manage"),
-    404: errorResponse("Product not found (PRODUCT_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.updateProductThreshold,
 });
 
 // ─── Variant-level stock (/api/products/{productId}/variants/{variantId}/stock/*)
 
-const adjustVariantStockRoute = createRoute({
+const adjustVariantStockRoute = defineRoute({
   method: "post",
   path: "/{productId}/variants/{variantId}/stock/adjust",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
   tags: ["Stock"],
   summary: "Adjust stock for a product variant",
   description:
     "Same semantics as the simple-product adjust endpoint but targets a specific variant. The `variantId` must belong to `productId`.",
   operationId: "adjustVariantStock",
-  request: {
-    params: variantIdParams,
-    body: {
-      required: true,
-      content: adjustBody,
-    },
-  },
+  params: variantIdParams,
+  body: adjustStockSchema,
   responses: {
     200: {
       description: "Variant stock adjusted",
       content: adjustResponse,
     },
-    400: errorResponse("Validation error — invalid type, zero delta, or missing reason (VALIDATION_FAILED)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires products:manage"),
-    404: errorResponse("Variant not found or does not belong to the given product (VARIANT_NOT_FOUND)"),
-    422: errorResponse("Adjustment would result in negative inventory (INSUFFICIENT_STOCK)"),
+    422: { description: "Adjustment would result in negative inventory (INSUFFICIENT_STOCK)" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.adjustVariantStock,
 });
 
-const updateVariantThresholdRoute = createRoute({
+const updateVariantThresholdRoute = defineRoute({
   method: "patch",
   path: "/{productId}/variants/{variantId}/stock/threshold",
-  middleware: [requireScope(SCOPES.PRODUCTS_MANAGE)],
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
   tags: ["Stock"],
   summary: "Update low stock threshold for a variant",
   description:
     "Sets the `lowStockThreshold` for a specific product variant. The variant must belong to the specified product.",
   operationId: "updateVariantThreshold",
-  request: {
-    params: variantIdParams,
-    body: {
-      required: true,
-      content: thresholdBody,
-    },
-  },
+  params: variantIdParams,
+  body: updateThresholdSchema,
   responses: {
     200: {
       description: "Threshold updated",
       content: jsonContent(z.object({ success: z.boolean().openapi({ example: true }) })),
     },
-    400: errorResponse("Validation error — non-integer, negative value, or value > 9999 (VALIDATION_FAILED)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Insufficient scope — requires products:manage"),
-    404: errorResponse("Variant not found or does not belong to the given product (VARIANT_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: h.updateVariantThreshold,
 });
 
 export const productStockRouter = new OpenAPIHono<AppContext>();
-productStockRouter.openapi(adjustProductStockRoute, h.adjustProductStock);
-productStockRouter.openapi(getProductStockHistoryRoute, h.getProductStockHistory);
-productStockRouter.openapi(updateProductThresholdRoute, h.updateProductThreshold);
-productStockRouter.openapi(adjustVariantStockRoute, h.adjustVariantStock);
-productStockRouter.openapi(updateVariantThresholdRoute, h.updateVariantThreshold);
+productStockRouter.openapi(adjustProductStockRoute.route, adjustProductStockRoute.handler);
+productStockRouter.openapi(getProductStockHistoryRoute.route, getProductStockHistoryRoute.handler);
+productStockRouter.openapi(updateProductThresholdRoute.route, updateProductThresholdRoute.handler);
+productStockRouter.openapi(adjustVariantStockRoute.route, adjustVariantStockRoute.handler);
+productStockRouter.openapi(updateVariantThresholdRoute.route, updateVariantThresholdRoute.handler);

--- a/cod-server/src/endpoints/store/routes.ts
+++ b/cod-server/src/endpoints/store/routes.ts
@@ -4,14 +4,12 @@
  * Public storefront surface (cod-astro/theme01). Authenticated globally via
  * storeAuthMiddleware (X-Store-API-Key) applied to /store/* in src/index.ts —
  * a different credential from the dashboard X-API-Key.
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
+import { defineRoute } from "@/lib/route-builder";
 import * as h from "./handlers";
 import { storeOrderSchema, storeReviewSchema } from "./validation";
 import {
@@ -19,20 +17,12 @@ import {
   StoreProductListSchema,
   StoreProductDetailSchema,
   ProductCategoryRowSchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
 } from "@/openapi/schemas";
 
 const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
-
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
-});
-
-const unauthorized = errorResponse("Missing or invalid X-Store-API-Key");
 
 const countEnvelope = <T extends z.ZodType>(itemSchema: T) =>
   jsonContent(
@@ -43,11 +33,52 @@ const countEnvelope = <T extends z.ZodType>(itemSchema: T) =>
     })
   );
 
+// ─── Request schemas ──────────────────────────────────────────────────────────
+
+const productsQuerySchema = z.object({
+  featured: z.enum(["true", "false"]).optional().openapi({
+    description: "When true, only return products where `storeFeatured=true`.",
+  }),
+  categoryId: z.string().optional().openapi({ description: "Filter by category ID." }),
+  limit: z.coerce.number().int().max(100).default(24).openapi({
+    description: "Maximum number of products to return. Server cap: 100.",
+  }),
+});
+
+const handleParams = z.object({
+  handle: z.string().openapi({ example: "samsung-galaxy-a54" }),
+});
+
+const wilayaIdParams = z.object({
+  wilayaId: z.coerce.number().int().min(1).max(58).openapi({
+    description: "Wilaya number (1–58).",
+    example: 16,
+  }),
+});
+
+const reviewsQuerySchema = z.object({
+  productId: z.string().min(1).openapi({
+    description: "Product ID to fetch reviews for.",
+  }),
+  limit: z.coerce.number().int().max(50).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+const reviewItemSchema = z.object({
+  id: z.string(),
+  customerName: z.string(),
+  rating: z.number().int().min(1).max(5),
+  title: z.string().nullable(),
+  body: z.string(),
+  createdAt: z.string().datetime(),
+});
+
 // ─── Config ───────────────────────────────────────────────────────────────────
 
-const getStoreConfigRoute = createRoute({
+const getStoreConfigRoute = defineRoute({
   method: "get",
   path: "/config",
+  auth: "store",
   tags: ["Store API"],
   summary: "Get store configuration",
   description:
@@ -58,70 +89,54 @@ const getStoreConfigRoute = createRoute({
       description: "Store configuration",
       content: jsonContent(SuccessResponseSchema(StoreConfigSchema)),
     },
-    401: unauthorized,
-    404: errorResponse("Store not found for this API key (STORE_NOT_FOUND)"),
   },
-  security: [{ StoreAuth: [] }],
+  handler: h.getStoreConfig,
 });
 
 // ─── Catalog ──────────────────────────────────────────────────────────────────
 
-const listStoreProductsRoute = createRoute({
+const listStoreProductsRoute = defineRoute({
   method: "get",
   path: "/products",
+  auth: "store",
   tags: ["Store API"],
   summary: "List store products",
   description:
     "Get the public product catalog for the storefront. Only returns products where `status=ACTIVE`, `showInStore=true`, `visibility=true`, and `deletedAt=null`.",
   operationId: "listStoreProducts",
-  request: {
-    query: z.object({
-      featured: z.enum(["true", "false"]).optional().openapi({
-        description: "When true, only return products where `storeFeatured=true`.",
-      }),
-      categoryId: z.string().optional().openapi({ description: "Filter by category ID." }),
-      limit: z.coerce.number().int().max(100).default(24).openapi({
-        description: "Maximum number of products to return. Server cap: 100.",
-      }),
-    }),
-  },
+  query: productsQuerySchema,
   responses: {
     200: {
       description: "List of products",
       content: countEnvelope(StoreProductListSchema),
     },
-    401: unauthorized,
   },
-  security: [{ StoreAuth: [] }],
+  handler: h.listStoreProducts,
 });
 
-const getStoreProductRoute = createRoute({
+const getStoreProductRoute = defineRoute({
   method: "get",
   path: "/products/{handle}",
+  auth: "store",
   tags: ["Store API"],
   summary: "Get store product",
   description:
     "Get a single product by its URL handle. Same visibility filters as the list endpoint. Returns parsed `variantOptions`, `tags`, joined `category`, active `variants`, all `images`, and `offers` — the active Buy X Get Y promotions currently applicable to this product.",
   operationId: "getStoreProduct",
-  request: {
-    params: z.object({
-      handle: z.string().openapi({ example: "samsung-galaxy-a54" }),
-    }),
-  },
+  params: handleParams,
   responses: {
     200: {
       description: "Product details",
       content: jsonContent(SuccessResponseSchema(StoreProductDetailSchema)),
     },
-    401: unauthorized,
-    404: errorResponse("Product not found (PRODUCT_NOT_FOUND)"),
   },
-  security: [{ StoreAuth: [] }],
+  handler: h.getStoreProduct,
 });
 
-const listStoreCategoriesRoute = createRoute({
+const listStoreCategoriesRoute = defineRoute({
   method: "get",
   path: "/categories",
+  auth: "store",
   tags: ["Store API"],
   summary: "List store categories",
   description: "Get product categories ordered by position.",
@@ -131,16 +146,16 @@ const listStoreCategoriesRoute = createRoute({
       description: "List of categories",
       content: countEnvelope(ProductCategoryRowSchema),
     },
-    401: unauthorized,
   },
-  security: [{ StoreAuth: [] }],
+  handler: h.listStoreCategories,
 });
 
 // ─── Shipping ─────────────────────────────────────────────────────────────────
 
-const getShippingRatesRoute = createRoute({
+const getShippingRatesRoute = defineRoute({
   method: "get",
   path: "/shipping-rates",
+  auth: "store",
   tags: ["Store API"],
   summary: "Get shipping rates",
   description:
@@ -168,27 +183,20 @@ const getShippingRatesRoute = createRoute({
         })
       ),
     },
-    401: unauthorized,
   },
-  security: [{ StoreAuth: [] }],
+  handler: h.getShippingRates,
 });
 
-const communesRoute = createRoute({
+const communesRoute = defineRoute({
   method: "get",
   path: "/communes/{wilayaId}",
+  auth: "store",
   tags: ["Store API"],
   summary: "List communes for a wilaya",
   description:
     "Get all communes for a given wilaya. Use the returned `id` as `communeId` when submitting an order.",
   operationId: "listStoreCommunes",
-  request: {
-    params: z.object({
-      wilayaId: z.coerce.number().int().min(1).max(58).openapi({
-        description: "Wilaya number (1–58).",
-        example: 16,
-      }),
-    }),
-  },
+  params: wilayaIdParams,
   responses: {
     200: {
       description: "List of communes for the wilaya",
@@ -203,17 +211,17 @@ const communesRoute = createRoute({
         })
       ),
     },
-    400: errorResponse("Invalid wilaya ID — must be 1–58 (VALUE_OUT_OF_RANGE)"),
-    401: unauthorized,
+    400: { description: "Invalid wilaya ID — must be 1–58 (VALUE_OUT_OF_RANGE)" },
   },
-  security: [{ StoreAuth: [] }],
+  handler: h.listStoreCommunes,
 });
 
 // ─── Orders ───────────────────────────────────────────────────────────────────
 
-const createStoreOrderRoute = createRoute({
+const createStoreOrderRoute = defineRoute({
   method: "post",
   path: "/orders",
+  auth: "store",
   tags: ["Store API"],
   summary: "Create store order",
   description: `Submit a customer order from the public storefront. Finds or creates the customer by phone number. Delivery fee is resolved from the default shipping profile.
@@ -226,12 +234,7 @@ const createStoreOrderRoute = createRoute({
 
 **Multi-unit variant orders:** when different variants are selected per unit, send \`variantSelections\` — one entry per unit. Identical variants are grouped into a single line and inventory deducts per-variant.`,
   operationId: "createStoreOrder",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(storeOrderSchema),
-    },
-  },
+  body: storeOrderSchema,
   responses: {
     201: {
       description: "Order created",
@@ -248,44 +251,27 @@ const createStoreOrderRoute = createRoute({
         })
       ),
     },
-    400: errorResponse("Validation error"),
-    401: unauthorized,
-    404: errorResponse("Referenced SKU/product record missing (REQUIRED_FIELD_MISSING)"),
-    422: errorResponse(
-      "Insufficient stock (INSUFFICIENT_STOCK) or missing SKU before accepting orders"
-    ),
+    404: { description: "Referenced SKU/product record missing (REQUIRED_FIELD_MISSING)" },
+    422: {
+      description:
+        "Insufficient stock (INSUFFICIENT_STOCK) or missing SKU before accepting orders",
+    },
   },
-  security: [{ StoreAuth: [] }],
+  handler: h.createStoreOrder,
 });
 
 // ─── Reviews ──────────────────────────────────────────────────────────────────
 
-const reviewItemSchema = z.object({
-  id: z.string(),
-  customerName: z.string(),
-  rating: z.number().int().min(1).max(5),
-  title: z.string().nullable(),
-  body: z.string(),
-  createdAt: z.string().datetime(),
-});
-
-const listStoreReviewsRoute = createRoute({
+const listStoreReviewsRoute = defineRoute({
   method: "get",
   path: "/reviews",
+  auth: "store",
   tags: ["Store API"],
   summary: "List approved reviews for a product",
   description:
     "Get approved product reviews for the storefront. Returns only reviews with `status=approved`.",
   operationId: "listStoreReviews",
-  request: {
-    query: z.object({
-      productId: z.string().min(1).openapi({
-        description: "Product ID to fetch reviews for.",
-      }),
-      limit: z.coerce.number().int().max(50).default(20),
-      offset: z.coerce.number().int().min(0).default(0),
-    }),
-  },
+  query: reviewsQuerySchema,
   responses: {
     200: {
       description: "List of approved reviews",
@@ -300,15 +286,15 @@ const listStoreReviewsRoute = createRoute({
         })
       ),
     },
-    400: errorResponse("productId is required (REQUIRED_FIELD_MISSING)"),
-    401: unauthorized,
+    400: { description: "productId is required (REQUIRED_FIELD_MISSING)" },
   },
-  security: [{ StoreAuth: [] }],
+  handler: h.listProductReviews,
 });
 
-const submitStoreReviewRoute = createRoute({
+const submitStoreReviewRoute = defineRoute({
   method: "post",
   path: "/reviews",
+  auth: "store",
   tags: ["Store API"],
   summary: "Submit a product review",
   description: `Submit a product review from the storefront.
@@ -317,12 +303,7 @@ const submitStoreReviewRoute = createRoute({
 
 Identity is derived from the resolved order — no customer login required. One review per order: a second submission returns **409 ORDER_ALREADY_REVIEWED**. Reviews are created with \`status=pending\` and require merchant approval before appearing publicly.`,
   operationId: "submitStoreReview",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(storeReviewSchema),
-    },
-  },
+  body: storeReviewSchema,
   responses: {
     201: {
       description: "Review submitted (pending moderation)",
@@ -333,24 +314,24 @@ Identity is derived from the resolved order — no customer login required. One 
         })
       ),
     },
-    400: errorResponse("Validation error — malformed order number or missing/invalid field"),
-    401: unauthorized,
-    404: errorResponse("No order in this store matches the supplied order number"),
-    409: errorResponse("A review has already been submitted for this order (ORDER_ALREADY_REVIEWED)"),
+    404: { description: "No order in this store matches the supplied order number" },
+    409: { description: "A review has already been submitted for this order (ORDER_ALREADY_REVIEWED)" },
   },
-  security: [{ StoreAuth: [] }],
+  handler: h.submitReview,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(getStoreConfigRoute, h.getStoreConfig);
-router.openapi(listStoreProductsRoute, h.listStoreProducts);
-router.openapi(getStoreProductRoute, h.getStoreProduct);
-router.openapi(listStoreCategoriesRoute, h.listStoreCategories);
-router.openapi(getShippingRatesRoute, h.getShippingRates);
-router.openapi(communesRoute, h.listStoreCommunes);
-router.openapi(createStoreOrderRoute, h.createStoreOrder);
-router.openapi(listStoreReviewsRoute, h.listProductReviews);
-router.openapi(submitStoreReviewRoute, h.submitReview);
+router.openapi(getStoreConfigRoute.route, getStoreConfigRoute.handler);
+router.openapi(listStoreProductsRoute.route, listStoreProductsRoute.handler);
+router.openapi(getStoreProductRoute.route, getStoreProductRoute.handler);
+router.openapi(listStoreCategoriesRoute.route, listStoreCategoriesRoute.handler);
+router.openapi(getShippingRatesRoute.route, getShippingRatesRoute.handler);
+router.openapi(communesRoute.route, communesRoute.handler);
+router.openapi(createStoreOrderRoute.route, createStoreOrderRoute.handler);
+router.openapi(listStoreReviewsRoute.route, listStoreReviewsRoute.handler);
+router.openapi(submitStoreReviewRoute.route, submitStoreReviewRoute.handler);
 
 export default router;

--- a/cod-server/src/endpoints/stores/routes.ts
+++ b/cod-server/src/endpoints/stores/routes.ts
@@ -3,23 +3,19 @@
  *
  * Dashboard endpoints for reading and updating the store configuration and
  * Meta pixel tracking config. Single-tenant: the store is resolved from the
- * D1 database, not from the path. All routes are admin-only (requireAdmin).
+ * D1 database, not from the path. All routes are admin-only.
  *
  * Not to be confused with /api/store/* — the public storefront API.
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireAdmin } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import * as handlers from "./handlers";
 import {
   StoreSchema,
   StorePixelConfigSchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
 } from "@/openapi/schemas";
 
@@ -27,17 +23,42 @@ const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
 
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
-});
-
 const hexColor = z.string().regex(/^#[0-9a-fA-F]{3,8}$/, "Invalid hex color");
 
-const getMyStoreRoute = createRoute({
+// ─── Request schemas ──────────────────────────────────────────────────────────
+
+const updateStoreBodySchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  logoUrl: z.string().url().nullable().optional(),
+  primaryColor: hexColor.optional(),
+  accentColor: hexColor.optional(),
+  bgColor: hexColor.optional(),
+  fontFamily: z.string().min(1).max(200).optional(),
+  fontUrl: z.string().url().nullable().optional(),
+  lang: z.enum(["ar", "en"]).optional(),
+  currencySymbol: z.string().min(1).max(10).optional(),
+  contentJson: z.string().nullable().optional(),
+  metaTitle: z.string().max(200).nullable().optional(),
+  metaDescription: z.string().max(500).nullable().optional(),
+  ogImage: z.string().url().nullable().optional(),
+  announcementBar: z.string().max(500).nullable().optional(),
+  reviewsEnabled: z.boolean().optional(),
+  status: z.enum(["active", "inactive"]).optional(),
+});
+
+const savePixelBodySchema = z.object({
+  pixelId: z.string().min(1),
+  accessToken: z.string().default(""),
+  testEventCode: z.string().nullable().optional(),
+  enabled: z.boolean().optional(),
+});
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const getMyStoreRoute = defineRoute({
   method: "get",
   path: "/me",
-  middleware: [requireAdmin()],
+  auth: "admin",
   tags: ["Store Settings"],
   summary: "Get store configuration",
   description:
@@ -48,64 +69,33 @@ const getMyStoreRoute = createRoute({
       description: "Store configuration",
       content: jsonContent(SuccessResponseSchema(StoreSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin role required"),
-    404: errorResponse("Store not found (code: STORE_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.getMyStore,
 });
 
-const updateMyStoreRoute = createRoute({
+const updateMyStoreRoute = defineRoute({
   method: "patch",
   path: "/me",
-  middleware: [requireAdmin()],
+  auth: "admin",
   tags: ["Store Settings"],
   summary: "Update store configuration",
   description:
     "Partially updates the store configuration. All fields are optional — only include the fields you want to change. Set nullable fields to `null` to clear them.",
   operationId: "updateMyStore",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          name: z.string().min(1).max(100).optional(),
-          logoUrl: z.string().url().nullable().optional(),
-          primaryColor: hexColor.optional(),
-          accentColor: hexColor.optional(),
-          bgColor: hexColor.optional(),
-          fontFamily: z.string().min(1).max(200).optional(),
-          fontUrl: z.string().url().nullable().optional(),
-          lang: z.enum(["ar", "en"]).optional(),
-          currencySymbol: z.string().min(1).max(10).optional(),
-          contentJson: z.string().nullable().optional(),
-          metaTitle: z.string().max(200).nullable().optional(),
-          metaDescription: z.string().max(500).nullable().optional(),
-          ogImage: z.string().url().nullable().optional(),
-          announcementBar: z.string().max(500).nullable().optional(),
-          reviewsEnabled: z.boolean().optional(),
-          status: z.enum(["active", "inactive"]).optional(),
-        })
-      ),
-    },
-  },
+  body: updateStoreBodySchema,
   responses: {
     200: {
       description: "Updated store configuration",
       content: jsonContent(SuccessResponseSchema(StoreSchema)),
     },
-    400: errorResponse("Validation error (e.g. invalid hex color)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin role required"),
-    404: errorResponse("Store not found (code: STORE_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.updateMyStore,
 });
 
-const getPixelConfigRoute = createRoute({
+const getPixelConfigRoute = defineRoute({
   method: "get",
   path: "/pixel-config",
-  middleware: [requireAdmin()],
+  auth: "admin",
   tags: ["Store Settings"],
   summary: "Get pixel configuration",
   description:
@@ -121,53 +111,36 @@ const getPixelConfigRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin role required"),
-    404: errorResponse("Store not found (code: STORE_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.getPixelConfig,
 });
 
-const savePixelConfigRoute = createRoute({
+const savePixelConfigRoute = defineRoute({
   method: "post",
   path: "/pixel-config",
-  middleware: [requireAdmin()],
+  auth: "admin",
   tags: ["Store Settings"],
   summary: "Save pixel configuration",
   description:
     "Upserts the store's Meta pixel tracking configuration. Omitted optional fields fall back to defaults (`accessToken` empty, `enabled` true).",
   operationId: "savePixelConfig",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          pixelId: z.string().min(1),
-          accessToken: z.string().default(""),
-          testEventCode: z.string().nullable().optional(),
-          enabled: z.boolean().optional(),
-        })
-      ),
-    },
-  },
+  body: savePixelBodySchema,
   responses: {
     200: {
       description: "Saved pixel configuration",
       content: jsonContent(SuccessResponseSchema(StorePixelConfigSchema)),
     },
-    400: errorResponse("Validation error (missing pixelId)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin role required"),
-    404: errorResponse("Store not found (code: STORE_NOT_FOUND)"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.savePixelConfig,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(getMyStoreRoute, handlers.getMyStore);
-router.openapi(updateMyStoreRoute, handlers.updateMyStore);
-router.openapi(getPixelConfigRoute, handlers.getPixelConfig);
-router.openapi(savePixelConfigRoute, handlers.savePixelConfig);
+router.openapi(getMyStoreRoute.route, getMyStoreRoute.handler);
+router.openapi(updateMyStoreRoute.route, updateMyStoreRoute.handler);
+router.openapi(getPixelConfigRoute.route, getPixelConfigRoute.handler);
+router.openapi(savePixelConfigRoute.route, savePixelConfigRoute.handler);
 
 export default router;

--- a/cod-server/src/endpoints/users/routes.ts
+++ b/cod-server/src/endpoints/users/routes.ts
@@ -2,22 +2,18 @@
  * Users Routes
  *
  * Team-member management: CRUD, role changes, scope grant/revoke, and API-key
- * rotation. Every route is admin-only (requireAdmin) — staff are rejected
- * regardless of scopes.
- *
- * Migrated to @hono/zod-openapi: route definitions below are the single
- * source of truth for validation and the OpenAPI spec. Handlers are
- * unchanged and remain independently mountable/testable.
+ * rotation. Every route is admin-only — staff are rejected regardless of scopes.
+ * Built with defineRoute() — the standard route-builder pattern.
  */
 
-import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AppContext } from "@/types";
-import { requireAdmin } from "@/rbac/middleware";
+import { defineRoute } from "@/lib/route-builder";
 import * as handlers from "./handlers";
 import {
   UserSchema,
-  ErrorResponseSchema,
   SuccessResponseSchema,
+  SuccessWithMessageSchema,
   ListResponseSchema,
 } from "@/openapi/schemas";
 
@@ -25,49 +21,77 @@ const jsonContent = <T extends z.ZodType>(schema: T) => ({
   "application/json": { schema },
 });
 
-const errorResponse = (description: string) => ({
-  description,
-  content: jsonContent(ErrorResponseSchema),
-});
-
 const idParams = z.object({
   id: z.string().openapi({ description: "User ID", example: "a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8" }),
 });
 
-const listUsersRoute = createRoute({
+// ─── Request schemas ──────────────────────────────────────────────────────────
+
+const listQuerySchema = z.object({
+  role: z.enum(["admin", "staff"]).optional(),
+  status: z.enum(["active", "inactive"]).optional(),
+  search: z.string().optional().openapi({ description: "Search by name or email" }),
+  limit: z.coerce.number().int().positive().max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+const createBodySchema = z.object({
+  email: z.string().email("Invalid email format").openapi({ example: "staff@example.com" }),
+  name: z.string().min(1, "Name is required").openapi({ example: "Ahmed Benali" }),
+  role: z.enum(["admin", "staff"]).default("staff").openapi({
+    description: "Defaults to `staff`.",
+  }),
+  scopes: z.array(z.string()).default([]).openapi({
+    description: "Initial permission scopes. Ignored if role is `admin`.",
+    example: ["orders:read", "customers:read"],
+  }),
+});
+
+const updateBodySchema = z.object({
+  email: z.string().email("Invalid email format").optional(),
+  name: z.string().min(1, "Name is required").optional(),
+  role: z.enum(["admin", "staff"]).optional(),
+  status: z.enum(["active", "inactive"]).optional(),
+});
+
+const updateRoleBodySchema = z.object({
+  role: z.enum(["admin", "staff"]),
+});
+
+const grantScopeBodySchema = z.object({
+  scope: z.string().min(1, "Scope is required").openapi({ example: "customers:read" }),
+});
+
+const revokeScopeParams = z.object({
+  ...idParams.shape,
+  scope: z.string().openapi({ description: "The scope to revoke", example: "customers:read" }),
+});
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+const listUsersRoute = defineRoute({
   method: "get",
   path: "/",
-  middleware: [requireAdmin()],
+  auth: "admin",
   tags: ["Users"],
   summary: "List users",
   description:
     'Returns a paginated list of team members. Each user includes their `scopes` array (`["*"]` for admins).',
   operationId: "listUsers",
-  request: {
-    query: z.object({
-      role: z.enum(["admin", "staff"]).optional(),
-      status: z.enum(["active", "inactive"]).optional(),
-      search: z.string().optional().openapi({ description: "Search by name or email" }),
-      limit: z.coerce.number().int().positive().max(100).default(50),
-      offset: z.coerce.number().int().min(0).default(0),
-    }),
-  },
+  query: listQuerySchema,
   responses: {
     200: {
       description: "List of users",
       content: jsonContent(ListResponseSchema(UserSchema)),
     },
-    400: errorResponse("Validation error (invalid query parameters)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin role required"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.listUsers,
 });
 
-const createUserRoute = createRoute({
+const createUserRoute = defineRoute({
   method: "post",
   path: "/",
-  middleware: [requireAdmin()],
+  auth: "admin",
   tags: ["Users"],
   summary: "Create user",
   description:
@@ -83,24 +107,7 @@ const createUserRoute = createRoute({
     "- They should change their password on first login for security\n\n" +
     '**Note:** `scopes` are ignored for `admin` users — admins always have `["*"]`.',
   operationId: "createUser",
-  request: {
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          email: z.string().email("Invalid email format").openapi({ example: "staff@example.com" }),
-          name: z.string().min(1, "Name is required").openapi({ example: "Ahmed Benali" }),
-          role: z.enum(["admin", "staff"]).default("staff").openapi({
-            description: "Defaults to `staff`.",
-          }),
-          scopes: z.array(z.string()).default([]).openapi({
-            description: "Initial permission scopes. Ignored if role is `admin`.",
-            example: ["orders:read", "customers:read"],
-          }),
-        })
-      ),
-    },
-  },
+  body: createBodySchema,
   responses: {
     201: {
       description:
@@ -125,202 +132,118 @@ const createUserRoute = createRoute({
         })
       ),
     },
-    400: errorResponse("Validation error (invalid email, missing required fields)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin access required"),
-    409: errorResponse("A user with this email already exists (code: DUPLICATE_EMAIL)"),
+    409: { description: "A user with this email already exists (code: DUPLICATE_EMAIL)" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.createUser,
 });
 
-const getUserRoute = createRoute({
+const getUserRoute = defineRoute({
   method: "get",
   path: "/{id}",
-  middleware: [requireAdmin()],
+  auth: "admin",
   tags: ["Users"],
   summary: "Get user",
   description: "Returns full user record including their `scopes` array.",
   operationId: "getUser",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "User detail with scopes",
       content: jsonContent(SuccessResponseSchema(UserSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin role required"),
-    404: errorResponse("User not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.getUser,
 });
 
-const updateUserRoute = createRoute({
+const updateUserRoute = defineRoute({
   method: "patch",
   path: "/{id}",
-  middleware: [requireAdmin()],
+  auth: "admin",
   tags: ["Users"],
   summary: "Update user",
   description:
     "Partial update — only include fields you want to change. To change scopes, use `POST /{id}/scopes` and `DELETE /{id}/scopes/{scope}`. To change role only, prefer `PATCH /{id}/role`.",
   operationId: "updateUser",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          email: z.string().email("Invalid email format").optional(),
-          name: z.string().min(1, "Name is required").optional(),
-          role: z.enum(["admin", "staff"]).optional(),
-          status: z.enum(["active", "inactive"]).optional(),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: updateBodySchema,
   responses: {
     200: {
       description: "User updated",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          data: UserSchema,
-          message: z.string().openapi({ example: "User updated successfully" }),
-        })
-      ),
+      content: jsonContent(SuccessWithMessageSchema(UserSchema)),
     },
-    400: errorResponse("Validation error (invalid email format)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin role required"),
-    404: errorResponse("User not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.updateUser,
 });
 
-const updateUserRoleRoute = createRoute({
+const updateUserRoleRoute = defineRoute({
   method: "patch",
   path: "/{id}/role",
-  middleware: [requireAdmin()],
+  auth: "admin",
   tags: ["Users"],
   summary: "Update user role",
   description:
     'Dedicated endpoint for role-only changes. Changing to `admin` effectively grants `["*"]` scope.',
   operationId: "updateUserRole",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          role: z.enum(["admin", "staff"]),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: updateRoleBodySchema,
   responses: {
     200: {
       description: "Role updated",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          data: UserSchema,
-          message: z.string().openapi({ example: "User role updated successfully" }),
-        })
-      ),
+      content: jsonContent(SuccessWithMessageSchema(UserSchema)),
     },
-    400: errorResponse("Validation error (invalid role value)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin role required"),
-    404: errorResponse("User not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.updateUserRole,
 });
 
-const grantScopeRoute = createRoute({
+const grantScopeRoute = defineRoute({
   method: "post",
   path: "/{id}/scopes",
-  middleware: [requireAdmin()],
+  auth: "admin",
   tags: ["Users"],
   summary: "Grant scope to user",
   description: "Grants a single permission scope to the user. Returns the full updated user record.",
   operationId: "grantScope",
-  request: {
-    params: idParams,
-    body: {
-      required: true,
-      content: jsonContent(
-        z.object({
-          scope: z.string().min(1, "Scope is required").openapi({ example: "customers:read" }),
-        })
-      ),
-    },
-  },
+  params: idParams,
+  body: grantScopeBodySchema,
   responses: {
     200: {
       description: "Scope granted",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          data: UserSchema,
-          message: z.string().openapi({ example: "Scope granted successfully" }),
-        })
-      ),
+      content: jsonContent(SuccessWithMessageSchema(UserSchema)),
     },
-    400: errorResponse("Validation error (empty scope)"),
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin role required"),
-    404: errorResponse("User not found"),
-    409: errorResponse("Scope already granted to user (code: DUPLICATE_ENTITY)"),
+    409: { description: "Scope already granted to user (code: DUPLICATE_ENTITY)" },
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.grantScope,
 });
 
-const revokeScopeRoute = createRoute({
+const revokeScopeRoute = defineRoute({
   method: "delete",
   path: "/{id}/scopes/{scope}",
-  middleware: [requireAdmin()],
+  auth: "admin",
   tags: ["Users"],
   summary: "Revoke scope from user",
   description:
     "Removes a permission scope from the user. If the scope was not granted, the operation succeeds silently.",
   operationId: "revokeScope",
-  request: {
-    params: z.object({
-      ...idParams.shape,
-      scope: z.string().openapi({ description: "The scope to revoke", example: "customers:read" }),
-    }),
-  },
+  params: revokeScopeParams,
   responses: {
     200: {
       description: "Scope revoked. Returns full updated user record.",
-      content: jsonContent(
-        z.object({
-          success: z.boolean().openapi({ example: true }),
-          data: UserSchema,
-          message: z.string().openapi({ example: "Scope revoked successfully" }),
-        })
-      ),
+      content: jsonContent(SuccessWithMessageSchema(UserSchema)),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin role required"),
-    404: errorResponse("User not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.revokeScope,
 });
 
-const rotateApiKeyRoute = createRoute({
+const rotateApiKeyRoute = defineRoute({
   method: "post",
   path: "/{id}/api-key/rotate",
-  middleware: [requireAdmin()],
+  auth: "admin",
   tags: ["Users"],
   summary: "Rotate API key",
   description:
     "Generates a new API key for the user, invalidating the previous one. **Admin only. The raw key is returned only once** — store it securely.",
   operationId: "rotateApiKey",
-  request: {
-    params: idParams,
-  },
+  params: idParams,
   responses: {
     200: {
       description: "New API key issued. The raw key is shown only in this response.",
@@ -337,22 +260,21 @@ const rotateApiKeyRoute = createRoute({
         })
       ),
     },
-    401: errorResponse("Missing or invalid API key"),
-    403: errorResponse("Admin access required"),
-    404: errorResponse("User not found"),
   },
-  security: [{ ApiKeyAuth: [] }],
+  handler: handlers.rotateApiKey,
 });
+
+// ─── Router ───────────────────────────────────────────────────────────────────
 
 const router = new OpenAPIHono<AppContext>();
 
-router.openapi(listUsersRoute, handlers.listUsers);
-router.openapi(createUserRoute, handlers.createUser);
-router.openapi(getUserRoute, handlers.getUser);
-router.openapi(updateUserRoute, handlers.updateUser);
-router.openapi(updateUserRoleRoute, handlers.updateUserRole);
-router.openapi(grantScopeRoute, handlers.grantScope);
-router.openapi(revokeScopeRoute, handlers.revokeScope);
-router.openapi(rotateApiKeyRoute, handlers.rotateApiKey);
+router.openapi(listUsersRoute.route, listUsersRoute.handler);
+router.openapi(createUserRoute.route, createUserRoute.handler);
+router.openapi(getUserRoute.route, getUserRoute.handler);
+router.openapi(updateUserRoute.route, updateUserRoute.handler);
+router.openapi(updateUserRoleRoute.route, updateUserRoleRoute.handler);
+router.openapi(grantScopeRoute.route, grantScopeRoute.handler);
+router.openapi(revokeScopeRoute.route, revokeScopeRoute.handler);
+router.openapi(rotateApiKeyRoute.route, rotateApiKeyRoute.handler);
 
 export default router;

--- a/cod-server/src/lib/ROUTE-BUILDER-CHANGELOG.md
+++ b/cod-server/src/lib/ROUTE-BUILDER-CHANGELOG.md
@@ -1,5 +1,34 @@
 # Route Builder - Change Log
 
+## [Unreleased] - 2026-08-31 (2)
+
+### ✅ Added: bodyContent for Non-JSON Bodies (images migration)
+
+**Problem:**
+- `body` only produces `application/json` content — the images upload
+  route documents a `multipart/form-data` body with a binary `file` field
+
+**Added:**
+
+```typescript
+const uploadRoute = defineRoute({
+  method: "post",
+  path: "/upload",
+  auth: { scope: SCOPES.PRODUCTS_MANAGE },
+  bodyContent: {
+    "multipart/form-data": {
+      schema: z.object({ file: z.instanceof(File).openapi({ type: "string", format: "binary" }) }),
+    },
+  },
+  ...
+});
+```
+
+- `bodyContent` is passed through verbatim as `request.body.content` with
+  `required: true`; takes precedence over `body`
+
+---
+
 ## [Unreleased] - 2026-08-31
 
 ### ✅ Added: Public Routes and Header Schemas (webhooks migration)

--- a/cod-server/src/lib/route-builder.ts
+++ b/cod-server/src/lib/route-builder.ts
@@ -64,7 +64,8 @@ export interface RouteDefinition {
   operationId?: string;
   query?: ZodType;                            // Query parameters (GET /users?role=admin)
   params?: ZodType;                           // Path parameters (GET /users/:id)
-  body?: ZodType;                             // Request body (POST /users)
+  body?: ZodType;                             // Request body (POST /users, application/json)
+  bodyContent?: Record<string, { schema: ZodType }>; // Raw content map for non-JSON bodies (multipart/form-data)
   headers?: ZodType;                          // Request headers (POST /webhooks with svix-*)
   handler: (c: Context<AppContext>) => any;   // Your handler function
   
@@ -248,7 +249,12 @@ export function defineRoute(def: RouteDefinition): BuiltRoute {
   if (def.query) request.query = def.query;
   if (def.params) request.params = def.params;
   if (def.headers) request.headers = def.headers;
-  if (def.body) request.body = { content: jsonContent(def.body) };
+  if (def.bodyContent) {
+    // Raw content map (e.g. multipart/form-data) — used verbatim
+    request.body = { required: true, content: def.bodyContent };
+  } else if (def.body) {
+    request.body = { content: jsonContent(def.body) };
+  }
   
   // Use custom responses if provided, otherwise generate standard ones
   const responses = def.responses


### PR DESCRIPTION
## What

Completes the `defineRoute()` migration — every OpenAPI route file in cod-server now uses the route-builder pattern (PR #71 covered the first 8 domains). This PR migrates the remaining 11:

stores, offers, abandoned-orders (dashboard + storefront routers), product-groups, stock, images, store (public storefront API), users, shipping-profiles, drivers, delivery-companies

Also adds one route-builder capability:

- `bodyContent` — raw content map for non-JSON request bodies (multipart/form-data upload with binary file), logged in `ROUTE-BUILDER-CHANGELOG.md`

## Zero behavior change

- Same paths, validation schemas, response contracts, and registration order everywhere
- **delivery-companies** keeps its router-level `use()` RBAC verbatim — including the long-standing quirk that POST `/` and PATCH/DELETE `/{id}` are gated by `delivery:read` (not manage). Preserved as-is; flagging here in case you want a follow-up fix
- **abandoned-orders** inline handlers stay inline using the codebase's `(c.req as any).valid()` pattern
- **images** serveRouter stays plain Hono by design (regex path param for slash-containing keys)
- First uses of `auth: "admin"` (stores, users) and `auth: "store"` (store, abandoned-orders storefront)

## Verification

- Each domain validated side-by-side against the original router before graduating
- delivery-companies validated with a spec-equality test: all 12 path/method/summary/tag/security entries identical (operationIds newly derived from handler names — additive only)
- `npm run typecheck` clean
- Full suite: 70 files, 1154 tests passing

## Follow-ups worth considering

- delivery-companies RBAC quirk above (pre-existing, not introduced here)
- `mcp/routes.ts` is plain Hono by design (internal management surface, not in the OpenAPI spec)