### PR TITLE
docs: mark defineRoute() migration complete across all endpoint domains

### DIFF
--- a/.agents/skills/route-builder/MIGRATION.md
+++ b/.agents/skills/route-builder/MIGRATION.md
@@ -1,6 +1,10 @@
 # Migrating Existing Endpoints to Route Builder
 
-`defineRoute()` is the standard pattern. Every existing endpoint that still uses raw `createRoute()` ceremony will be migrated. This guide is the process.
+`defineRoute()` is the standard pattern. **The migration is complete — all 22
+domains are converted** (see `cod-server/src/endpoints/README.md`). This guide
+is retained for reference: use it if a `createRoute()` route ever reappears
+(e.g. copied from old code), or as the model for converting any new raw route
+that lands in review.
 
 ## Why Migrate?
 

--- a/.agents/skills/route-builder/SKILL.md
+++ b/.agents/skills/route-builder/SKILL.md
@@ -5,7 +5,7 @@ description: Build and migrate API routes using the defineRoute() pattern. Use w
 
 # Route Builder Pattern
 
-`defineRoute()` is the **standard pattern** for all endpoints in cod-server. Every new endpoint must use it. Every existing endpoint will be migrated to it.
+`defineRoute()` is the **standard pattern** for all endpoints in cod-server. Every new endpoint must use it. **All existing domains are already migrated** — if you encounter a raw `createRoute()` route, convert it using the migration workflow.
 
 Two workflows:
 1. **Creating new endpoints** — see [NEW-ENDPOINTS.md](NEW-ENDPOINTS.md)
@@ -42,13 +42,26 @@ router.openapi(myRoute.route, myRoute.handler);
 ## Auth Strategies
 
 ```typescript
-auth: "api-key"                            // Any authenticated dashboard user
-auth: "admin"                              // Admin role only
-auth: "store"                              // Store API key (X-Store-API-Key)
-auth: { scope: SCOPES.ORDERS_READ }        // Specific scope (most common)
-auth: { anyOf: [SCOPES.READ, SCOPES.ALL] } // Any of multiple scopes
+auth: "public"                            // No auth — no middleware, security omitted from spec (webhook receivers)
+auth: "api-key"                           // Any authenticated dashboard user
+auth: "admin"                             // Admin role only (stores, users)
+auth: "store"                             // Store API key (X-Store-API-Key) — store/*, abandoned-orders storefront
+auth: { scope: SCOPES.ORDERS_READ }       // Specific scope (most common)
+auth: { anyOf: [SCOPES.READ, SCOPES.ALL] }   // Any of multiple scopes
 auth: { allOf: [SCOPES.READ, SCOPES.ADMIN] } // All scopes required
 ```
+
+Non-JSON request bodies use `bodyContent` (raw content map):
+
+```typescript
+bodyContent: {
+  "multipart/form-data": {
+    schema: z.object({ file: z.instanceof(File).openapi({ type: "string", format: "binary" }) }),
+  },
+}
+```
+
+Header schemas (e.g. svix webhook receivers): `headers: MyHeadersSchema`.
 
 ## What `defineRoute()` generates automatically
 

--- a/cod-server/README.md
+++ b/cod-server/README.md
@@ -196,10 +196,13 @@ An hourly cron sweeps pending orders older than 30 minutes to `abandoned`.
 
 - One endpoint = one folder in `src/endpoints/`, following the
   `routes.ts` / `handlers.ts` / `validation.ts` split.
-- Define routes with `@hono/zod-openapi` (`createRoute` on an `OpenAPIHono`
-  router): the route definition is the single source of truth for both request
-  validation and the OpenAPI spec — there are no hand-written spec files to
-  keep in sync. Reuse shared response schemas from `src/openapi/schemas.ts`.
+- Define routes with `defineRoute()` from `src/lib/route-builder` on an
+  `OpenAPIHono` router: the route definition is the single source of truth
+  for both request validation and the OpenAPI spec — there are no
+  hand-written spec files to keep in sync. Every domain is already on this
+  pattern; see `src/endpoints/README.md` for the current state and
+  `.agents/skills/route-builder/NEW-ENDPOINTS.md` for the how-to. Reuse
+  shared response schemas from `src/openapi/schemas.ts`.
 - Shared schema and read queries live in `cod-shared` — do not duplicate them
   in `cod-server/src/db`.
 - Keep `wrangler.toml` free of real credentials; if you add an env var, declare

--- a/cod-server/src/endpoints/README.md
+++ b/cod-server/src/endpoints/README.md
@@ -1,61 +1,55 @@
 # Endpoints Directory
 
 Each subdirectory is one API domain. The standard pattern for all routes is
-`defineRoute()` from `@/lib/route-builder`. Two endpoints have completed this
-migration; the rest still use raw `createRoute()` from `@hono/zod-openapi` and
-are pending conversion.
+`defineRoute()` from `@/lib/route-builder`. **All domains have completed this
+migration** — raw `createRoute()` from `@hono/zod-openapi` is no longer used
+anywhere. New endpoints must use `defineRoute()` (see
+`.agents/skills/route-builder/NEW-ENDPOINTS.md`).
 
 ---
 
-## Migration status
-
-### Done — using `defineRoute()` ✅
-
-| Domain | Routes |
-|--------|--------|
-| `wilayas` | 2 |
-| `orders` | 17 |
-| `products` | 15 |
-
-### Pending — still using `createRoute()` ⏳
-
-These endpoints are fully on `@hono/zod-openapi` (validation + spec generation
-works), but have not been converted to `defineRoute()` yet. Convert one at a
-time following `MIGRATION.md` in `.agents/skills/route-builder/`.
+## All domains — on `defineRoute()` ✅
 
 | Domain | Routes | Notes |
 |--------|--------|-------|
-| `abandoned-orders` | 6 | Dashboard CRUD/stats + storefront upsert/convert |
-| `activity-logs` | 2 | Admin-only read |
+| `abandoned-orders` | 6 | Dashboard CRUD/stats + storefront upsert/convert (`auth: "store"` on the storefront router) |
+| `activity-logs` | 2 | Admin-only read; throw-based `adminOnly` middleware preserved for the documented `PERMISSION_DENIED` envelope |
 | `analytics` | 1 | Dashboard status-count stats |
 | `customer-groups` | 7 | Segments + member management |
 | `customer-tags` | 7 | Tags + assignment management |
 | `customers` | 8 | CRUD + orders/groups/tags lookups |
-| `delivery-companies` | 13 | CRUD + stop-desks + webhook config |
+| `delivery-companies` | 13 | CRUD + stop-desks + webhook config; RBAC stays on router-level `use()` patterns (preserves existing gating) |
 | `driver-payments` | 3 | Payment create + history + pending settlement |
 | `drivers` | 8 | Driver CRUD + status + per-wilaya compensations |
-| `images` | 3 | Upload + presign + public serve (plain-Hono exception, see below) |
+| `images` | 3 | Upload (multipart via `bodyContent`) + presign + public serve (plain-Hono exception, see below) |
 | `offers` | 5 | Promotional offer CRUD |
+| `orders` | 17 | Full order lifecycle |
 | `product-groups` | 5 | Category tree CRUD |
+| `products` | 15 | Product + variant CRUD (variants nested, see below) |
 | `reviews` | 3 | Moderation + RBAC |
 | `shipping-profiles` | 10 | Rate cards + wilaya rules + commune overrides |
 | `stock` | 7 | Inventory adjustments, history, thresholds (two sub-routers) |
-| `store` | 9 | Public storefront surface behind X-Store-API-Key |
-| `stores` | 4 | Store settings + Meta pixel config |
-| `users` | 8 | Team management + scopes + API-key rotation |
-| `webhooks` | 3 | Public receivers — no body validation (raw-byte signature contract) |
+| `store` | 9 | Public storefront surface behind X-Store-API-Key (`auth: "store"`) |
+| `stores` | 4 | Store settings + Meta pixel config (`auth: "admin"`) |
+| `users` | 8 | Team management + scopes + API-key rotation (`auth: "admin"`) |
+| `webhooks` | 3 | Public receivers (`auth: "public"`) — no body validation (raw-byte signature contract) |
+| `wilayas` | 2 | Read-only geography |
 
 ---
 
 ## Special cases
 
 - `variants/` — no `routes.ts`; handlers are mounted directly inside `products/routes.ts`.
-- `mcp/` — MCP server surface, not part of the REST API.
-- `images/{key}` public serve — stays plain-Hono (regex param); the `createRoute` documentation stub for it is intentional.
+- `mcp/` — MCP server surface, not part of the REST API (plain Hono by design).
+- `images/{key}` public serve — stays plain-Hono (regex param); the documentation stub for it is intentional.
+- Router-level RBAC (not per-route `auth`): `activity-logs` (throw-based
+  `adminOnly`) and `delivery-companies` (`use()` scope patterns) — both kept
+  deliberately to preserve existing behavior; see each file's docblock.
 
 ---
 
 ## Summary
 
-**3 / 22 domains on `defineRoute()` (14%)**
-19 domains still on `createRoute()` — fully functional, pending conversion.
+**22 / 22 domains on `defineRoute()` (100%)** — migration complete. Any new
+endpoint starts on `defineRoute()` directly; there is no `createRoute()` path
+left to convert.

--- a/cod-server/src/lib/ROUTE-BUILDER-CHANGELOG.md
+++ b/cod-server/src/lib/ROUTE-BUILDER-CHANGELOG.md
@@ -136,22 +136,21 @@ defineRoute({
 
 ---
 
-## Status: READY FOR MIGRATION
+## Status: MIGRATION COMPLETE ✅
 
-**Type Safety:** ✅ FIXED  
-**Tests:** ✅ ALL PASSING (22/22)  
-**Typecheck:** ✅ PASSING  
-**Code Review:** ✅ APPROVED  
+**All 22 endpoint domains** now use `defineRoute()` — no raw `createRoute()`
+remains in `src/endpoints/`. Status history:
 
-The route builder now has proper TypeScript types and is ready for migrating endpoints!
+- 2026-08-23: type safety fixed, route builder ready
+- 2026-08-31 (PR #71): 8 domains migrated (wilayas and orders/products were
+  already done); `auth: "public"` + `headers` added for webhooks
+- 2026-08-31 (PR #72): remaining 11 domains migrated; `bodyContent` added
+  for multipart uploads (images)
 
----
+Auth strategies now in use across the codebase: `"api-key"`, `"admin"`,
+`"store"`, `"public"`, and `{ scope }`. Two domains keep router-level RBAC
+deliberately (activity-logs' throw-based `adminOnly`, delivery-companies'
+`use()` patterns) — see their routes.ts docblocks.
 
-## Next Steps
-
-1. ✅ Type safety fixed
-2. ⏭️ Migrate wilayas endpoint (current prototype)
-3. ⏭️ Document the pattern in AGENTS.md
-4. ⏭️ Choose next endpoint to migrate
-
-See `PROTOTYPE-SUMMARY.md` and `CODE-REVIEW.md` for full details.
+The migration guide (`.agents/skills/route-builder/MIGRATION.md`) is retained
+for reference; new endpoints follow NEW-ENDPOINTS.md directly.


### PR DESCRIPTION
## What

The `defineRoute()` endpoint migration finished in PRs #71 and #72. This updates every doc that still described it as in progress:

- **`cod-server/src/endpoints/README.md`** — the done/pending split replaced with the complete 22-domain table (100% migrated), per-domain auth-strategy notes, and an expanded special-cases section (router-level RBAC rationale for activity-logs and delivery-companies, plain-Hono exceptions)
- **`cod-server/README.md`** — Contributing section now directs to `defineRoute()` from `src/lib/route-builder` instead of raw `createRoute`
- **`cod-server/src/lib/ROUTE-BUILDER-CHANGELOG.md`** — stale "READY FOR MIGRATION / Next Steps" block replaced with "MIGRATION COMPLETE" plus dated history
- **`.agents/skills/route-builder/`** — SKILL.md and MIGRATION.md reflect completion; SKILL.md now documents the `public`/`store` auth strategies, `bodyContent`, and `headers`

Docs only — no code changes.

## Verification

Per the repo rule that README claims must be code-verified:
- `grep` confirms zero `createRoute()` in any routes file (the only match is the README's own prose)
- The documented auth strategies (`public`, `store`, `admin`, `bodyContent`) all confirmed in use in the codebase
- `npm run typecheck` clean; full suite 70 files / 1154 tests passing