### PR TITLE
fix(theme01): abandoned-checkout tracking never fired — dead env vars and secret-leak design

### DIFF
--- a/cod-astro/theme01/src/core/api/client.ts
+++ b/cod-astro/theme01/src/core/api/client.ts
@@ -156,3 +156,53 @@ export async function placeOrder(
     return { success: false, error: e.message ?? "Network error" };
   }
 }
+
+/**
+ * Upsert an abandoned-checkout record (storefront abandonment tracking).
+ * Mirrors POST /store/abandoned on cod-server — fire-and-forget semantics.
+ * `forwardedHeaders` carries the shopper's User-Agent / forwarding headers so
+ * attribution captured by cod-server reflects the visitor, not this worker.
+ */
+export async function upsertAbandonedOrder(
+  body: Record<string, unknown>,
+  forwardedHeaders?: Record<string, string>
+): Promise<{ success: true; data: { id: string } } | { success: false; error: string }> {
+  try {
+    const res = await fetch(`${COD_SERVER_URL}/store/abandoned`, {
+      method: "POST",
+      headers: { ...storeHeaders(), ...forwardedHeaders },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as any;
+    if (!res.ok) return { success: false, error: json.error ?? "Tracking failed" };
+    return { success: true, data: { id: json.id } };
+  } catch (e: any) {
+    return { success: false, error: e.message ?? "Network error" };
+  }
+}
+
+/**
+ * Mark an abandoned-checkout session as converted after a successful order.
+ * Mirrors PATCH /store/abandoned/{sessionId}/convert — the server treats this
+ * as fire-and-forget (always 200, errors swallowed server-side).
+ */
+export async function markAbandonedConverted(
+  sessionId: string,
+  orderId: string,
+  orderNumber: string
+): Promise<{ success: true } | { success: false; error: string }> {
+  try {
+    const res = await fetch(`${COD_SERVER_URL}/store/abandoned/${encodeURIComponent(sessionId)}/convert`, {
+      method: "PATCH",
+      headers: storeHeaders(),
+      body: JSON.stringify({ orderId, orderNumber }),
+    });
+    if (!res.ok) {
+      const json = (await res.json().catch(() => ({}))) as any;
+      return { success: false, error: json.error ?? "Conversion failed" };
+    }
+    return { success: true };
+  } catch (e: any) {
+    return { success: false, error: e.message ?? "Network error" };
+  }
+}

--- a/cod-astro/theme01/src/core/endpoints/abandoned-convert.ts
+++ b/cod-astro/theme01/src/core/endpoints/abandoned-convert.ts
@@ -1,0 +1,69 @@
+// ╔══════════════════════════════════════════════════════════════════════╗
+// ║  CORE ENGINE — DO NOT MODIFY                                         ║
+// ║  Same-origin proxy marking an abandoned session as converted after   ║
+// ║  a successful order (browser → this endpoint → cod-server PATCH      ║
+// ║  /store/abandoned/{sessionId}/convert). Keeps the store API key      ║
+// ║  server-side.                                                        ║
+// ╚══════════════════════════════════════════════════════════════════════╝
+import type { APIRoute } from "astro";
+import { z } from "astro/zod";
+import { markAbandonedConverted } from "@/core/api/client";
+
+const convertSchema = z.object({
+  sessionId: z.string().uuid(),
+  orderId: z.string().min(1).max(200),
+  orderNumber: z.string().min(1).max(100),
+});
+
+function isCrossOrigin(request: Request): boolean {
+  const origin = request.headers.get("Origin");
+  if (!origin) return false;
+  try {
+    return new URL(origin).origin !== new URL(request.url).origin;
+  } catch {
+    return true;
+  }
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (isCrossOrigin(request)) {
+    return new Response(JSON.stringify({ error: "Cross-origin not allowed" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const parsed = convertSchema.safeParse(raw);
+  if (!parsed.success) {
+    return new Response(JSON.stringify({ error: "Invalid conversion payload" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // cod-server treats conversion as fire-and-forget (always 200, unknown
+  // sessions succeed silently), so a 204 here means "received".
+  const result = await markAbandonedConverted(
+    parsed.data.sessionId,
+    parsed.data.orderId,
+    parsed.data.orderNumber
+  );
+  if (!result.success) {
+    return new Response(JSON.stringify({ error: result.error }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(null, { status: 204 });
+};

--- a/cod-astro/theme01/src/core/endpoints/abandoned.ts
+++ b/cod-astro/theme01/src/core/endpoints/abandoned.ts
@@ -1,0 +1,105 @@
+// ╔══════════════════════════════════════════════════════════════════════╗
+// ║  CORE ENGINE — DO NOT MODIFY                                         ║
+// ║  Same-origin proxy for abandoned-checkout tracking (browser → this   ║
+// ║  endpoint → cod-server POST /store/abandoned). Keeps the store API   ║
+// ║  key server-side; the browser script needs no credentials at all.    ║
+// ║  Accepts both fetch and navigator.sendBeacon payloads.               ║
+// ╚══════════════════════════════════════════════════════════════════════╝
+import type { APIRoute } from "astro";
+import { z } from "astro/zod";
+import { upsertAbandonedOrder } from "@/core/api/client";
+
+// Mirrors the cod-server /store/abandoned upsert contract
+// (see cod-server/src/endpoints/abandoned-orders/store-routes.ts).
+const upsertSchema = z.object({
+  sessionId: z.string().uuid(),
+  customerName: z.string().min(2).max(100),
+  phone: z
+    .string()
+    .min(9)
+    .max(20)
+    .regex(/^[0-9+\s-]+$/),
+  wilayaId: z.number().int().min(1).max(58).optional(),
+  communeId: z.string().max(200).optional(),
+  wilayaName: z.string().max(100).optional(),
+  communeName: z.string().max(100).optional(),
+  productId: z.string().max(200).optional(),
+  productName: z.string().max(200).optional(),
+  variantId: z.string().max(200).optional(),
+  variantLabel: z.string().max(200).optional(),
+  price: z.number().positive().optional(),
+  deliveryType: z.enum(["home", "stop_desk"]).optional(),
+  fbc: z.string().max(500).optional(),
+  fbp: z.string().max(500).optional(),
+});
+
+function noContent() {
+  return new Response(null, { status: 204 });
+}
+
+function badRequest(error: string) {
+  return new Response(JSON.stringify({ error }), {
+    status: 400,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Reject cross-site submissions: only same-origin pages may track.
+ * Mirrors Astro Actions' built-in CSRF check — requests without an Origin
+ * header (older browsers, curl, server-to-server) are allowed through.
+ */
+function isCrossOrigin(request: Request): boolean {
+  const origin = request.headers.get("Origin");
+  if (!origin) return false;
+  try {
+    return new URL(origin).origin !== new URL(request.url).origin;
+  } catch {
+    return true;
+  }
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (isCrossOrigin(request)) {
+    return new Response(JSON.stringify({ error: "Cross-origin not allowed" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+
+  const parsed = upsertSchema.safeParse(raw);
+  if (!parsed.success) {
+    return badRequest("Invalid tracking payload");
+  }
+
+  // Forward the shopper's attribution headers so cod-server records the
+  // visitor, not this worker. Cloudflare provides CF-Connecting-IP on the
+  // incoming request; the User-Agent passes through verbatim.
+  const forwardedHeaders: Record<string, string> = {};
+  const userAgent = request.headers.get("User-Agent");
+  if (userAgent) forwardedHeaders["User-Agent"] = userAgent;
+  const clientIp =
+    request.headers.get("CF-Connecting-IP") ??
+    request.headers.get("X-Forwarded-For")?.split(",")[0]?.trim();
+  if (clientIp) forwardedHeaders["X-Forwarded-For"] = clientIp;
+
+  // Fire-and-forget by contract: tracking must never break the storefront.
+  // Upstream failures return 502 for debuggability; the browser script
+  // ignores response status either way.
+  const result = await upsertAbandonedOrder(parsed.data, forwardedHeaders);
+  if (!result.success) {
+    return new Response(JSON.stringify({ error: result.error }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return noContent();
+};

--- a/cod-astro/theme01/src/pages/api/abandoned/convert.ts
+++ b/cod-astro/theme01/src/pages/api/abandoned/convert.ts
@@ -1,0 +1,7 @@
+// ╔══════════════════════════════════════════════════════════════════════╗
+// ║  PROXY FILE — DO NOT MODIFY                                          ║
+// ║  Re-exports endpoint from core layer.                                ║
+// ║  Astro requires API routes to be in src/pages/api/                   ║
+// ╚══════════════════════════════════════════════════════════════════════╝
+
+export { POST } from "@/core/endpoints/abandoned-convert";

--- a/cod-astro/theme01/src/pages/api/abandoned/index.ts
+++ b/cod-astro/theme01/src/pages/api/abandoned/index.ts
@@ -1,0 +1,7 @@
+// ╔══════════════════════════════════════════════════════════════════════╗
+// ║  PROXY FILE — DO NOT MODIFY                                          ║
+// ║  Re-exports endpoint from core layer.                                ║
+// ║  Astro requires API routes to be in src/pages/api/                   ║
+// ╚══════════════════════════════════════════════════════════════════════╝
+
+export { POST } from "@/core/endpoints/abandoned";

--- a/cod-astro/theme01/src/pages/products/[slug].astro
+++ b/cod-astro/theme01/src/pages/products/[slug].astro
@@ -20,9 +20,10 @@ const { config, content, isRTL } = await getStoreContext();
 
 // Action result (must be checked before rendering)
 const result = Astro.getActionResult(actions.placeOrder);
-// If order succeeded, pass data to client — the inline script below will call
-// __markAbandonedConverted (keepalive fetch) then redirect to /thank-you.
-// This avoids losing the conversion signal on a hard server redirect.
+// If order succeeded, pass data to client — the inline script below posts the
+// abandonment-conversion signal (bounded keepalive fetch) then redirects to
+// /thank-you. This avoids losing the conversion signal on a hard server
+// redirect.
 const orderSuccess = result?.data?.orderNumber
   ? {
       orderNumber: result.data.orderNumber,
@@ -62,8 +63,30 @@ const serverError  = result?.error && !isInputError(result.error) ? result.error
     define:vars={{ orderNumber: orderSuccess.orderNumber, total: orderSuccess.total, orderId: orderSuccess.orderId }}
   >
     (async () => {
-      if (typeof window.__markAbandonedConverted === "function") {
-        await window.__markAbandonedConverted(orderId, orderNumber);
+      // Mark the abandoned-checkout session as converted (fire-and-forget).
+      // Posts directly — the deferred tracking module may not have defined
+      // its global yet when this inline script runs. Bounded wait so a
+      // stalled network can never delay the thank-you page by more than 2.5s.
+      try {
+        var sessionId = sessionStorage.getItem("cod_session_id");
+        if (sessionId) {
+          await Promise.race([
+            fetch("/api/abandoned/convert", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                sessionId: sessionId,
+                orderId: orderId,
+                orderNumber: orderNumber,
+              }),
+              keepalive: true,
+            }).catch(function () {}),
+            new Promise(function (resolve) { setTimeout(resolve, 2500); }),
+          ]);
+          sessionStorage.removeItem("cod_session_id");
+        }
+      } catch (e) {
+        // Non-critical — conversion tracking must never block the redirect
       }
       window.location.replace(
         "/thank-you?order=" +

--- a/cod-astro/theme01/src/theme/scripts/track-abandonment.ts
+++ b/cod-astro/theme01/src/theme/scripts/track-abandonment.ts
@@ -1,23 +1,25 @@
 /**
  * Abandoned Order Tracking
  *
- * Fires a POST /store/abandoned when the visitor has typed a valid name + phone
- * and stays on the page for 3 seconds without submitting. All updates use the
- * same sessionId (UPSERT on server), so there's exactly one DB record per tab.
+ * Sends shopper contact details to the same-origin proxy
+ * POST /api/abandoned (which forwards to cod-server with the server-side
+ * store key) when the visitor has typed a valid name + phone and pauses for
+ * 3 seconds without submitting. All updates use the same sessionId (UPSERT
+ * on the server), so there is exactly one DB record per browser tab.
  *
- * Conversion is marked by calling window.__markAbandonedConverted after a
- * successful order placement.
+ * On page exit (tab close, navigation), a final capture is attempted via
+ * navigator.sendBeacon so abandoners who never submit are still recorded.
+ *
+ * Conversion is handled by the inline script on the product page
+ * (POST /api/abandoned/convert) — see pages/products/[slug].astro.
+ *
+ * Non-critical by contract: every failure is swallowed. Tracking can never
+ * affect the order flow, page speed, or console cleanliness.
  */
 
-const COD_SERVER_URL = (import.meta.env.PUBLIC_COD_SERVER_URL as string | undefined) ?? "";
-const STORE_API_KEY = (import.meta.env.PUBLIC_STORE_API_KEY as string | undefined) ?? "";
+const UPSERT_URL = "/api/abandoned";
 
-// Skip entirely if env vars are missing (dev without server, etc.)
-if (!COD_SERVER_URL || !STORE_API_KEY) {
-  console.debug("[abandonment] env vars missing — tracking disabled");
-} else {
-  initAbandonmentTracking();
-}
+initAbandonmentTracking();
 
 function initAbandonmentTracking() {
   // One session per tab — survives navigation within the tab, not cross-tab
@@ -85,23 +87,41 @@ function initAbandonmentTracking() {
     };
   }
 
+  function isCapturable(data: ReturnType<typeof collectFormData>) {
+    return isValidName(data.customerName) && isValidPhone(data.phone);
+  }
+
   async function sendAbandonment() {
     const data = collectFormData();
-    if (!isValidName(data.customerName) || !isValidPhone(data.phone)) return;
+    if (!isCapturable(data)) return;
 
     try {
-      await fetch(`${COD_SERVER_URL}/store/abandoned`, {
+      await fetch(UPSERT_URL, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Store-API-Key": STORE_API_KEY,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
         keepalive: true,
       });
       hasSentInitial = true;
     } catch {
       // Non-critical — tracking failure must never affect the order flow
+    }
+  }
+
+  /**
+   * Final capture attempt as the page unloads. sendBeacon is fire-and-forget
+   * and survives navigation/tab close where fetch would be killed.
+   */
+  function sendBeaconOnExit() {
+    const data = collectFormData();
+    if (!isCapturable(data)) return;
+    try {
+      navigator.sendBeacon(
+        UPSERT_URL,
+        new Blob([JSON.stringify(data)], { type: "application/json" })
+      );
+    } catch {
+      // Non-critical
     }
   }
 
@@ -117,33 +137,15 @@ function initAbandonmentTracking() {
   // Watch wilaya / commune / delivery type — immediate update once initial record exists
   ["#f-wilaya", "#f-commune"].forEach((sel) => {
     document.querySelector(sel)?.addEventListener("change", () => {
-      if (hasSentInitial) sendAbandonment();
+      if (hasSentInitial) void sendAbandonment();
     });
   });
   document.querySelectorAll<HTMLInputElement>("[name=deliveryType]").forEach((el) => {
     el.addEventListener("change", () => {
-      if (hasSentInitial) sendAbandonment();
+      if (hasSentInitial) void sendAbandonment();
     });
   });
 
-  // Exposed globally so the order-submit success handler can call it
-  (window as any).__markAbandonedConverted = async (
-    orderId: string,
-    orderNumber: string
-  ): Promise<void> => {
-    try {
-      await fetch(`${COD_SERVER_URL}/store/abandoned/${sessionId}/convert`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Store-API-Key": STORE_API_KEY,
-        },
-        body: JSON.stringify({ orderId, orderNumber }),
-        keepalive: true,
-      });
-    } catch {
-      // Non-critical
-    }
-    sessionStorage.removeItem("cod_session_id");
-  };
+  // Capture shoppers who close the tab or navigate away mid-checkout
+  window.addEventListener("pagehide", sendBeaconOnExit);
 }


### PR DESCRIPTION
## What

Abandoned checkouts were **never captured** — the tracking script was completely dead in every build.

**Root cause:** `track-abandonment.ts` read `PUBLIC_COD_SERVER_URL` and `PUBLIC_STORE_API_KEY`, which exist in no env source (astro.config declares only server-context vars; `.dev.vars` is wrangler-runtime only). Vite resolved both to `""` and tree-shook the entire module out of the bundle — verified: zero tracking code in `dist/client/`. The guard `if (!COD_SERVER_URL || !STORE_API_KEY)` silently disabled everything.

**Second bug (latent race):** even with vars set, conversion would never fire — the inline success script on the product page awaited `window.__markAbandonedConverted`, a global defined by the *deferred* tracking module that runs **after** the inline script. Always `undefined`.

**Architectural flaw:** the original design called cod-server directly from the browser, requiring `PUBLIC_STORE_API_KEY` — which would leak the store secret into every visitor's JS bundle, violating the theme's security model (all store API calls proxy server-side via core).

## The fix — same pattern as the existing `communes.ts` core endpoint

- **`core/api/client.ts`** — new `upsertAbandonedOrder` + `markAbandonedConverted` server functions (store key stays server-side)
- **`core/endpoints/abandoned.ts` / `abandoned-convert.ts`** — same-origin proxy endpoints: Zod validation, cross-origin (CSRF) rejection, shopper header forwarding (User-Agent / CF-Connecting-IP) so attribution reflects the visitor, not the worker
- **`pages/api/abandoned/*`** — proxy re-exports (Astro routing requirement)
- **`theme/scripts/track-abandonment.ts`** — rewritten to post same-origin; zero env vars, zero secrets; adds `navigator.sendBeacon` on `pagehide` so tab-close abandoners are captured
- **`products/[slug].astro`** — conversion posted directly by the inline success script (fixes the race), bounded at 2.5s so a stalled network can never delay the thank-you redirect

## Properties

- **Non-blocking by contract:** every failure swallowed, endpoints return 204, redirect bounded — tracking can never affect the order flow
- **Zero setup:** no new env vars — works whenever the store works (key stays server-side). Open-source theme users get tracking for free
- **Theme boundaries respected:** engine logic in `src/core/`, only the client script lives in `src/theme/`

## Verification (live, in production)

Deployed and tested against the real stack on `codflow-os-theme01.myaicourse22.workers.dev` → `api.codflow.store`:

- ✅ Capture: 204 → row in production D1 (name/phone/wilaya/product/price recorded)
- ✅ Same-session upsert: row updated, no duplicate
- ✅ Convert after order: status `converted` + order number stored
- ✅ 403 cross-origin, 400 invalid payload
- ✅ Tracking code present in served product HTML (was completely absent)
- ✅ `astro check` 0 errors, theme tests 6/6, string + style validators pass