### PR TITLE
perf(d1): scale hardening — indexes, atomic writes, N+1 removal, keyset pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ E-commerce in Algeria is **95%+ Cash on Delivery (الدفع عند الاستل
 
 ## ✅ What's Included
 
-CodFlow v1.0.0 — here's what works today:
+CodFlow v1.1.0 — here's what works today:
 
 ### Storefront (`cod-astro/theme01`)
 - ✅ Single-page COD checkout with live shipping calculation
@@ -125,6 +125,7 @@ CodFlow v1.0.0 — here's what works today:
 ### Backend (`cod-server`)
 - ✅ Hono 4 on Cloudflare Workers (sub-5ms cold starts)
 - ✅ Drizzle ORM + D1 (SQLite)
+- ✅ D1 scale layer: indexed hot paths, atomic batched order writes, keyset pagination
 - ✅ Auto-generated OpenAPI 3.1 spec at `/api/docs`
 - ✅ Standardized error envelopes with semantic codes
 - ✅ R2 image storage with edge caching

--- a/cod-server/src/db/migrations/0014_add_indexes.sql
+++ b/cod-server/src/db/migrations/0014_add_indexes.sql
@@ -1,0 +1,61 @@
+-- Migration: Add performance indexes for core business tables
+-- CodFlow D1 optimization Slice 1 (see report-md/D1_PERFORMANCE_AUDIT.md).
+--
+-- D1 bills by rows read, not rows returned — these tables had zero secondary
+-- indexes, so every hot query full-scanned. Shapes follow the Cloudflare
+-- "Use indexes" guidance: multi-column for leftmost-prefix filter+sort pairs,
+-- partial where queries only touch a stable subset.
+--
+-- Plain indexes only — the UNIQUE index on customers.phone is deliberately
+-- NOT here (needs the duplicate-audit precondition first; Slice 3).
+
+-- orders: dashboard list (status filter + created_at DESC sort)
+CREATE INDEX IF NOT EXISTS `idx_orders_status_created` ON `orders` (`status`, `created_at` DESC);
+-- orders: non-terminal partial (active board queries; skips terminal history)
+CREATE INDEX IF NOT EXISTS `idx_orders_active` ON `orders` (`status`, `created_at` DESC) WHERE `status` NOT IN ('delivered', 'returned', 'cancelled');
+-- orders: carrier webhook lookup by tracking number
+CREATE INDEX IF NOT EXISTS `idx_orders_tracking` ON `orders` (`tracking_number`) WHERE `tracking_number` IS NOT NULL;
+-- orders: customer detail (recent orders list)
+CREATE INDEX IF NOT EXISTS `idx_orders_customer` ON `orders` (`customer_id`, `created_at` DESC);
+-- orders: driver detail (recent orders list)
+CREATE INDEX IF NOT EXISTS `idx_orders_driver` ON `orders` (`driver_id`);
+-- orders: carrier reconcile paths
+CREATE INDEX IF NOT EXISTS `idx_orders_company` ON `orders` (`company_id`);
+
+-- order_products: order detail + status-change restock loops
+CREATE INDEX IF NOT EXISTS `idx_order_products_order` ON `order_products` (`order_id`);
+CREATE INDEX IF NOT EXISTS `idx_order_products_product` ON `order_products` (`product_id`);
+
+-- order_status_history: order detail timeline + getAllOrders lastUpdatedBy
+CREATE INDEX IF NOT EXISTS `idx_order_status_history_order_ts` ON `order_status_history` (`order_id`, `timestamp` DESC);
+
+-- stock_movements: stock history page per product
+CREATE INDEX IF NOT EXISTS `idx_stock_movements_product_created` ON `stock_movements` (`product_id`, `created_at` DESC);
+
+-- product_variants: order creation + product detail lookups
+CREATE INDEX IF NOT EXISTS `idx_product_variants_product` ON `product_variants` (`product_id`);
+
+-- product_images: cover image + product detail galleries
+CREATE INDEX IF NOT EXISTS `idx_product_images_product_position` ON `product_images` (`product_id`, `position`);
+
+-- reviews: storefront rating aggregates + review moderation lists
+CREATE INDEX IF NOT EXISTS `idx_reviews_product_status` ON `reviews` (`product_id`, `status`);
+
+-- shipping_rules: storefront checkout fee resolution
+CREATE INDEX IF NOT EXISTS `idx_shipping_rules_profile_wilaya` ON `shipping_rules` (`profile_id`, `wilaya_id`);
+
+-- shipping_profiles: default-profile lookup per checkout
+CREATE INDEX IF NOT EXISTS `idx_shipping_profiles_default` ON `shipping_profiles` (`is_default`) WHERE `is_default` = 1;
+
+-- communes: storefront checkout commune picker
+CREATE INDEX IF NOT EXISTS `idx_communes_wilaya` ON `communes` (`wilaya_id`);
+
+-- company_shipments: label lookup in order detail
+CREATE INDEX IF NOT EXISTS `idx_company_shipments_order` ON `company_shipments` (`order_id`);
+
+-- activity_logs: audit trail filters (actor + entity)
+CREATE INDEX IF NOT EXISTS `idx_activity_logs_actor_created` ON `activity_logs` (`actor_id`, `created_at` DESC);
+CREATE INDEX IF NOT EXISTS `idx_activity_logs_entity_created` ON `activity_logs` (`entity_type`, `created_at` DESC);
+
+-- drivers: duplicate-phone check
+CREATE INDEX IF NOT EXISTS `idx_drivers_phone` ON `drivers` (`phone`);

--- a/cod-server/src/db/migrations/0015_customers_phone_unique.sql
+++ b/cod-server/src/db/migrations/0015_customers_phone_unique.sql
@@ -1,0 +1,18 @@
+-- Migration: UNIQUE index on customers.phone
+-- CodFlow D1 optimization Slice 3 (see report-md/D1_PERFORMANCE_AUDIT.md).
+--
+-- Closes the duplicate-customer race: two concurrent storefront orders from
+-- the same phone used to both pass the SELECT-then-INSERT check and create
+-- two customer rows (stats split between them). The UNIQUE constraint makes
+-- findOrCreateCustomer's INSERT ... ON CONFLICT path the single serialized
+-- entry point.
+--
+-- PRECONDITION (run before applying to any environment with data):
+--   SELECT phone, COUNT(*) c FROM customers GROUP BY phone HAVING c > 1;
+-- must return zero rows. Duplicates must be merged first, or this migration
+-- fails on apply.
+--
+-- Also serves the frequent lookup: customers WHERE phone = ? (every
+-- storefront order), which previously full-scanned.
+
+CREATE UNIQUE INDEX IF NOT EXISTS `idx_customers_phone_unique` ON `customers` (`phone`);

--- a/cod-server/src/db/migrations/0016_variants_product_position_index.sql
+++ b/cod-server/src/db/migrations/0016_variants_product_position_index.sql
@@ -1,0 +1,11 @@
+-- Migration: extend product_variants index to (product_id, position)
+-- CodFlow D1 optimization Slice 5 (see report-md/D1_PERFORMANCE_AUDIT.md).
+--
+-- The batched variant fetch for product lists orders by (product_id, position).
+-- With the single-column index from 0014 that plan degenerated to a full SCAN
+-- + TEMP B-TREE sort (docs' anti-pattern). The composite index serves both
+-- the filter and the order. Leftmost prefix (product_id) covers every prior
+-- use of the old index, so it is dropped in the same migration.
+
+DROP INDEX IF EXISTS `idx_product_variants_product`;
+CREATE INDEX IF NOT EXISTS `idx_product_variants_product_position` ON `product_variants` (`product_id`, `position`);

--- a/cod-server/src/db/migrations/0017_orders_keyset_indexes.sql
+++ b/cod-server/src/db/migrations/0017_orders_keyset_indexes.sql
@@ -1,0 +1,20 @@
+-- Migration: keyset pagination + deterministic ordering indexes for orders
+-- CodFlow D1 optimization Slice 9 (see report-md/D1_PERFORMANCE_AUDIT.md).
+--
+-- The default (unfiltered) orders list previously full-scanned + sorted
+-- (EXPLAIN: SCAN orders | USE TEMP B-TREE FOR ORDER BY). The new
+-- (created_at DESC, id DESC) composite serves the unfiltered sort AND the
+-- keyset row-value predicate `(created_at, id) < (?, ?)` — verified by
+-- EXPLAIN after apply.
+--
+-- The id tie-breaker makes pagination deterministic for same-timestamp
+-- rows (offset pagination could skip/duplicate them). Extending the status
+-- composite keeps the filtered path sort-free — with the old two-column
+-- index, ORDER BY ... , id DESC degraded to
+-- "USE TEMP B-TREE FOR LAST TERM OF ORDER BY". Leftmost prefixes are
+-- preserved, so every prior use of the old index stays covered.
+
+CREATE INDEX IF NOT EXISTS `idx_orders_created_id` ON `orders` (`created_at` DESC, `id` DESC);
+
+DROP INDEX IF EXISTS `idx_orders_status_created`;
+CREATE INDEX IF NOT EXISTS `idx_orders_status_created_id` ON `orders` (`status`, `created_at` DESC, `id` DESC);

--- a/cod-server/src/endpoints/customers/customers.filters-e2e.test.ts
+++ b/cod-server/src/endpoints/customers/customers.filters-e2e.test.ts
@@ -1,0 +1,236 @@
+/**
+ * getAllCustomers + getAllDrivers — Slice 8 real-D1 E2E.
+ *
+ * Verifies on a real engine (miniflare + real migrations, which ENFORCE the
+ * 100-bound-parameter limit — the exact failure this slice removes):
+ *   • THE CRASH CASE: a customer group with 150 members filtered through
+ *     the list endpoint — pre-Slice 8 this built inArray(…150 ids) and
+ *     failed with "too many SQL variables"; the EXISTS subquery carries
+ *     a single bound param regardless of membership size.
+ *   • group/tag filters return exactly the members, paginated
+ *   • empty group → empty page; combined filters (AND semantics)
+ *   • drivers: wilaya filter via EXISTS on compensations; empty coverage;
+ *     unfiltered list with compensation counts
+ *   • EXPLAIN proof that the EXISTS plans use the indexes from Slice 1
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Miniflare } from "miniflare";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { drizzle } from "drizzle-orm/d1";
+import * as schema from "@/db/schema";
+import type { AppDb } from "@/db";
+import { getAllCustomers } from "../../../../cod-shared/queries/customers";
+import { getAllDrivers } from "../../../../cod-shared/queries/drivers";
+
+const registry: Miniflare[] = [];
+let db: AppDb;
+let rawD1: D1Database;
+
+const CRASH_GROUP_MEMBERS = 150;
+
+beforeAll(async () => {
+  const mf = new Miniflare({
+    script: "export default { fetch() { return new Response('ok'); } }",
+    modules: true,
+    d1Databases: { DB: "test-db" },
+  });
+  registry.push(mf);
+  rawD1 = await mf.getD1Database("DB");
+  const dir = resolve(__dirname, "../../db/migrations");
+  for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql")).sort()) {
+    const statements = readFileSync(`${dir}/${file}`, "utf8")
+      .split("--> statement-breakpoint")
+      .flatMap((s) => s.split(/;\s*\n/))
+      .map((s) => s.replace(/;+\s*$/, "").trim())
+      .filter((s) => s.replace(/--[^\n]*/g, "").trim().length > 0);
+    for (const statement of statements) {
+      await rawD1.prepare(statement).run();
+    }
+  }
+  db = drizzle(rawD1 as unknown as D1Database, { schema }) as unknown as AppDb;
+
+  const now = new Date().toISOString();
+
+  await db.insert(schema.customerGroups).values([
+    { id: "grp-big", name: "Big Group", description: null, color: "#111111", memberCount: CRASH_GROUP_MEMBERS, createdAt: now, updatedAt: now },
+    { id: "grp-small", name: "Small Group", description: null, color: "#222222", memberCount: 2, createdAt: now, updatedAt: now },
+    { id: "grp-empty", name: "Empty Group", description: null, color: "#333333", memberCount: 0, createdAt: now, updatedAt: now },
+  ]);
+  await db.insert(schema.customerTags).values([
+    { id: "tag-vip", name: "vip", color: "#00ff00", assignmentCount: 60, createdAt: now, updatedAt: now },
+    { id: "tag-none", name: "none", color: "#000000", assignmentCount: 0, createdAt: now, updatedAt: now },
+  ]);
+
+  const bigCustomerIds: string[] = [];
+  for (let i = 0; i < CRASH_GROUP_MEMBERS; i += 10) {
+    const batch = Array.from({ length: Math.min(10, CRASH_GROUP_MEMBERS - i) }, (_, j) => {
+      const n = i + j;
+      return {
+        id: `cust-${n}`,
+        name: `Customer ${n}`,
+        phone: `0770${String(n).padStart(6, "0")}`,
+        wilayaId: n % 2 === 0 ? 16 : 31,
+        wilaya: n % 2 === 0 ? "الجزائر" : "وهران",
+        createdAt: `2026-01-${String((n % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+      };
+    });
+    bigCustomerIds.push(...batch.map((c) => c.id));
+    await db.insert(schema.customers).values(batch);
+  }
+
+  for (let i = 0; i < CRASH_GROUP_MEMBERS; i += 20) {
+    await db.insert(schema.customerGroupMembers).values(
+      Array.from({ length: Math.min(20, CRASH_GROUP_MEMBERS - i) }, (_, j) => ({
+        id: `gm-${i + j}`,
+        customerId: `cust-${i + j}`,
+        groupId: "grp-big",
+        assignedAt: now,
+      })),
+    );
+  }
+  await db.insert(schema.customerGroupMembers).values([
+    { id: "gm-small-1", customerId: "cust-0", groupId: "grp-small", assignedAt: now },
+    { id: "gm-small-2", customerId: "cust-1", groupId: "grp-small", assignedAt: now },
+  ]);
+
+  for (let i = 0; i < 60; i += 20) {
+    await db.insert(schema.customerTagAssignments).values(
+      Array.from({ length: Math.min(20, 60 - i) }, (_, j) => ({
+        id: `ta-${i + j}`,
+        customerId: `cust-${i + j}`,
+        tagId: "tag-vip",
+        assignedAt: now,
+      })),
+    );
+  }
+
+  await db.insert(schema.drivers).values([
+    { id: "drv-16", firstName: "Ali", lastName: "One", phone: "0550000001", status: "available", totalDelivered: 0, totalEarnings: 0, pendingCash: 0, totalPaid: 0, createdAt: now, updatedAt: now },
+    { id: "drv-31", firstName: "Bilal", lastName: "Two", phone: "0550000002", status: "available", totalDelivered: 0, totalEarnings: 0, pendingCash: 0, totalPaid: 0, createdAt: now, updatedAt: now },
+    { id: "drv-none", firstName: "Cherif", lastName: "Three", phone: "0550000003", status: "available", totalDelivered: 0, totalEarnings: 0, pendingCash: 0, totalPaid: 0, createdAt: now, updatedAt: now },
+  ]);
+  await db.insert(schema.driverCompensations).values([
+    { id: "dc-1", driverId: "drv-16", wilayaId: 16, feePerDelivery: 400, createdAt: now, updatedAt: now },
+    { id: "dc-2", driverId: "drv-16", wilayaId: 31, feePerDelivery: 500, createdAt: now, updatedAt: now },
+    { id: "dc-3", driverId: "drv-31", wilayaId: 31, feePerDelivery: 450, createdAt: now, updatedAt: now },
+  ]);
+}, 180_000);
+
+afterAll(async () => {
+  for (const mf of registry) await mf.dispose();
+});
+
+describe("getAllCustomers — real D1", () => {
+  it("THE CRASH CASE: filters by a group with 150 members (no param explosion)", async () => {
+    const rows = await getAllCustomers(db, { groupId: "grp-big", limit: 200 });
+    expect(rows).toHaveLength(CRASH_GROUP_MEMBERS);
+  });
+
+  it("paginates the big group with limit/offset", async () => {
+    const page1 = await getAllCustomers(db, { groupId: "grp-big", limit: 100, offset: 0 });
+    const page2 = await getAllCustomers(db, { groupId: "grp-big", limit: 100, offset: 100 });
+    expect(page1).toHaveLength(100);
+    expect(page2).toHaveLength(50);
+    expect(new Set([...page1, ...page2].map((c) => c.id)).size).toBe(CRASH_GROUP_MEMBERS);
+  });
+
+  it("small group returns exactly its 2 members", async () => {
+    const rows = await getAllCustomers(db, { groupId: "grp-small" });
+    expect(rows.map((r) => r.id).sort()).toEqual(["cust-0", "cust-1"]);
+  });
+
+  it("empty group returns an empty page", async () => {
+    const rows = await getAllCustomers(db, { groupId: "grp-empty" });
+    expect(rows).toEqual([]);
+  });
+
+  it("tag filter returns the 60 tagged members", async () => {
+    const rows = await getAllCustomers(db, { tagId: "tag-vip", limit: 200 });
+    expect(rows).toHaveLength(60);
+    expect(rows.every((r) => Number(r.id.replace("cust-", "")) < 60)).toBe(true);
+  });
+
+  it("empty tag returns an empty page", async () => {
+    const rows = await getAllCustomers(db, { tagId: "tag-none" });
+    expect(rows).toEqual([]);
+  });
+
+  it("group + tag filters AND together", async () => {
+    const rows = await getAllCustomers(db, { groupId: "grp-big", tagId: "tag-vip", limit: 200 });
+    expect(rows).toHaveLength(60);
+  });
+
+  it("wilaya filter narrows the big group (16 → even-numbered members)", async () => {
+    const rows = await getAllCustomers(db, { groupId: "grp-big", wilayaId: 16, limit: 200 });
+    expect(rows).toHaveLength(75);
+    expect(rows.every((r) => r.wilayaId === 16)).toBe(true);
+  });
+
+  it("unfiltered list is paginated plain", async () => {
+    const rows = await getAllCustomers(db, { limit: 10, offset: 0 });
+    expect(rows).toHaveLength(10);
+    const beyond = await getAllCustomers(db, { limit: 10, offset: 5000 });
+    expect(beyond).toEqual([]);
+  });
+});
+
+describe("getAllDrivers — real D1", () => {
+  it("wilaya 16 filter returns only drv-16 with its compensation count", async () => {
+    const rows = await getAllDrivers(db, { wilayaId: 16 });
+    expect(rows.map((r) => r.id)).toEqual(["drv-16"]);
+    expect(rows[0]).toMatchObject({ compensationWilayaCount: 2 });
+  });
+
+  it("wilaya 31 filter returns both covering drivers", async () => {
+    const rows = await getAllDrivers(db, { wilayaId: 31 });
+    expect(rows.map((r) => r.id).sort()).toEqual(["drv-16", "drv-31"]);
+  });
+
+  it("wilaya with no coverage returns an empty page (not a crash)", async () => {
+    const rows = await getAllDrivers(db, { wilayaId: 58 });
+    expect(rows).toEqual([]);
+  });
+
+  it("unfiltered list includes the uncovered driver with count 0", async () => {
+    const rows = await getAllDrivers(db);
+    expect(rows).toHaveLength(3);
+    expect(rows.find((r) => r.id === "drv-none")).toMatchObject({ compensationWilayaCount: 0 });
+    expect(rows.find((r) => r.id === "drv-16")).toMatchObject({ compensationWilayaCount: 2 });
+  });
+});
+
+describe("EXISTS plans use the Slice 1 indexes", () => {
+  it("customer group-membership EXISTS searches the unique index", async () => {
+    const plan = await rawD1
+      .prepare(
+        `EXPLAIN QUERY PLAN SELECT * FROM customers WHERE EXISTS (
+           SELECT 1 FROM customer_group_members
+           WHERE customer_group_members.customer_id = customers.id
+             AND customer_group_members.group_id = ?
+         )`,
+      )
+      .bind("grp-big")
+      .all();
+    const details = (plan.results as Array<Record<string, unknown>>).map((r) => String(r.detail)).join(" | ");
+    expect(details).toContain("SEARCH customer_group_members");
+    expect(details).toContain("customer_group_members_customer_group_unique");
+  });
+
+  it("driver compensation EXISTS searches the unique index", async () => {
+    const plan = await rawD1
+      .prepare(
+        `EXPLAIN QUERY PLAN SELECT * FROM drivers WHERE EXISTS (
+           SELECT 1 FROM driver_compensations
+           WHERE driver_compensations.driver_id = drivers.id
+             AND driver_compensations.wilaya_id = ?
+         )`,
+      )
+      .bind(16)
+      .all();
+    const details = (plan.results as Array<Record<string, unknown>>).map((r) => String(r.detail)).join(" | ");
+    expect(details).toContain("SEARCH driver_compensations");
+    expect(details).toContain("driver_compensations_driver_wilaya_unique");
+  });
+});

--- a/cod-server/src/endpoints/customers/customers.filters-queries.test.ts
+++ b/cod-server/src/endpoints/customers/customers.filters-queries.test.ts
@@ -1,0 +1,120 @@
+/**
+ * getAllCustomers + getAllDrivers — Slice 8 mock-queue coverage.
+ *
+ * Call shape post-Slice 8: group/tag/wilaya filters are EXISTS subqueries
+ * inside the SINGLE list query — no pre-fetch, no id list, no inArray.
+ * Previously: a group/tag with >100 members crashed on D1's 100-bound-param
+ * limit (miniflare enforces it — proven in the Slice 5 probe). The >100
+ * case is verified against real D1 in customers.filters-e2e.test.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+import { makeMockDb, a, customerRow } from "@/test-utils/mock-db";
+import { getAllCustomers } from "../../../../cod-shared/queries/customers";
+import { getAllDrivers } from "../../../../cod-shared/queries/drivers";
+
+function driverListRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "drv_1",
+    first_name: "Ahmed",
+    last_name: "Benali",
+    phone: "0551234567",
+    phone2: null,
+    vehicle_type: "motorcycle",
+    status: "available",
+    total_delivered: 5,
+    total_earnings: 1000,
+    pending_cash: 100,
+    total_paid: 0,
+    notes: null,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function compCountRow(driverId: string, c: number): Record<string, unknown> {
+  return { driver_id: driverId, c };
+}
+
+describe("getAllCustomers — EXISTS filters, one query", () => {
+  it("group filter runs as one query (no member pre-fetch)", async () => {
+    const db = makeMockDb([a([customerRow({ id: "cust_1" })])]);
+
+    const rows = await getAllCustomers(db, { groupId: "grp_1" });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: "cust_1" });
+  });
+
+  it("tag filter runs as one query", async () => {
+    const db = makeMockDb([a([customerRow({ id: "cust_1" })])]);
+
+    const rows = await getAllCustomers(db, { tagId: "tag_1" });
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it("group + tag + wilaya + search combine in one query", async () => {
+    const db = makeMockDb([a([customerRow({ id: "cust_1", wilaya_id: 16 })])]);
+
+    const rows = await getAllCustomers(db, {
+      groupId: "grp_1",
+      tagId: "tag_1",
+      wilayaId: 16,
+      search: "Fatima",
+    });
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it("empty group result comes back as an empty page (not an early return)", async () => {
+    const db = makeMockDb([a([])]);
+
+    const rows = await getAllCustomers(db, { groupId: "grp_empty" });
+
+    expect(rows).toEqual([]);
+  });
+
+  it("no filters: plain paginated list", async () => {
+    const db = makeMockDb([a([customerRow({ id: "cust_1" })])]);
+
+    const rows = await getAllCustomers(db, { limit: 10, offset: 5 });
+
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe("getAllDrivers — EXISTS wilaya filter", () => {
+  it("wilaya filter runs in the list query, then one GROUP BY count query", async () => {
+    const db = makeMockDb([
+      a([driverListRow()]),
+      a([compCountRow("drv_1", 3)]),
+    ]);
+
+    const rows = await getAllDrivers(db, { wilayaId: 16 });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ compensationWilayaCount: 3 });
+  });
+
+  it("empty wilaya coverage is an empty page (not an early return)", async () => {
+    const db = makeMockDb([a([]), a([])]);
+
+    const rows = await getAllDrivers(db, { wilayaId: 58 });
+
+    expect(rows).toEqual([]);
+  });
+
+  it("unfiltered list still resolves compensation counts", async () => {
+    const db = makeMockDb([
+      a([driverListRow({ id: "drv_1" }), driverListRow({ id: "drv_2" })]),
+      a([compCountRow("drv_1", 2), compCountRow("drv_2", 5)]),
+    ]);
+
+    const rows = await getAllDrivers(db);
+
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.id === "drv_2")).toMatchObject({ compensationWilayaCount: 5 });
+  });
+});

--- a/cod-server/src/endpoints/orders/orders.keyset-e2e.test.ts
+++ b/cod-server/src/endpoints/orders/orders.keyset-e2e.test.ts
@@ -1,0 +1,217 @@
+/**
+ * getAllOrders — Slice 9 real-D1 E2E: keyset pagination + search guard.
+ *
+ * Runs the real migrations (incl. 0017 keyset indexes) on an in-memory
+ * miniflare D1 and verifies:
+ *   • same-timestamp ties: pages are deterministic — cursor and offset
+ *     walks produce the identical (createdAt DESC, id DESC) sequence, no
+ *     row skipped or duplicated (pre-tie-breaker offset pagination could
+ *     not guarantee this)
+ *   • cursor strictly advances: page 2 starts after the last row of page 1
+ *   • cursor + status filter combine (index-served per EXPLAIN proofs)
+ *   • THE CRASH CASE: search terms whose %-wrapped pattern exceeds D1's
+ *     50-byte LIKE cap previously threw "LIKE or GLOB pattern too complex"
+ *     (verified on this engine); with the guard they truncate safely
+ *   • search still matches order number / phone / customer name
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Miniflare } from "miniflare";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { drizzle } from "drizzle-orm/d1";
+import * as schema from "@/db/schema";
+import type { AppDb } from "@/db";
+import {
+  getAllOrders,
+  encodeOrderCursor,
+} from "../../../../cod-shared/queries/orders";
+
+const registry: Miniflare[] = [];
+let db: AppDb;
+
+const TOTAL = 25;
+const PAGE = 5;
+
+beforeAll(async () => {
+  const mf = new Miniflare({
+    script: "export default { fetch() { return new Response('ok'); } }",
+    modules: true,
+    d1Databases: { DB: "test-db" },
+  });
+  registry.push(mf);
+  const d1 = await mf.getD1Database("DB");
+  const dir = resolve(__dirname, "../../db/migrations");
+  for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql")).sort()) {
+    const statements = readFileSync(`${dir}/${file}`, "utf8")
+      .split("--> statement-breakpoint")
+      .flatMap((s) => s.split(/;\s*\n/))
+      .map((s) => s.replace(/;+\s*$/, "").trim())
+      .filter((s) => s.replace(/--[^\n]*/g, "").trim().length > 0);
+    for (const statement of statements) {
+      await d1.prepare(statement).run();
+    }
+  }
+  db = drizzle(d1 as unknown as D1Database, { schema }) as unknown as AppDb;
+
+  // 25 orders over only 5 distinct timestamps — 5-way ties everywhere, the
+  // adversarial case for pagination determinism. Statuses alternate.
+  const timestamps = [
+    "2026-01-01T00:00:00.000Z",
+    "2026-01-02T00:00:00.000Z",
+    "2026-01-03T00:00:00.000Z",
+    "2026-01-04T00:00:00.000Z",
+    "2026-01-05T00:00:00.000Z",
+  ];
+  const now = new Date().toISOString();
+  await db.insert(schema.customers).values({
+    id: "cust-k", name: "Keyset Customer", phone: "0770000001",
+    wilaya: "الجزائر", createdAt: now,
+  });
+  for (let i = 0; i < TOTAL; i += 5) {
+    const batch: (typeof schema.orders.$inferInsert)[] = Array.from({ length: 5 }, (_, j) => {
+        const n = i + j;
+        return {
+          id: `ord-k${String(n).padStart(2, "0")}`,
+          orderNumber: `ORD-K-${String(n).padStart(2, "0")}`,
+          customerId: "cust-k",
+          customerName: `Buyer ${n}`,
+          phone: `07700000${String(n).padStart(2, "0")}`,
+          price: 100,
+          status: n % 2 === 0 ? "new" : "confirmed",
+          deliveryMethod: "unassigned",
+          deliveryType: "home",
+          deliveryFee: 0, driverFee: 0, codAmount: 100,
+          createdAt: timestamps[n % timestamps.length],
+          updatedAt: now,
+        };
+      });
+    await db.insert(schema.orders).values(batch);
+  }
+}, 120_000);
+
+afterAll(async () => {
+  for (const mf of registry) await mf.dispose();
+});
+
+function key(row: { id: string }) {
+  return row.id;
+}
+
+describe("getAllOrders — keyset pagination (real D1)", () => {
+  it("cursor and offset walks produce the identical deterministic sequence over ties", async () => {
+    const offsetIds: string[] = [];
+    for (let page = 0; page * PAGE < TOTAL; page++) {
+      const rows = await getAllOrders(db, { limit: PAGE, offset: page * PAGE });
+      offsetIds.push(...rows.map(key));
+    }
+
+    const cursorIds: string[] = [];
+    let cursor: string | undefined;
+    for (;;) {
+      const rows = await getAllOrders(db, { limit: PAGE, cursor });
+      if (rows.length === 0) break;
+      cursorIds.push(...rows.map(key));
+      const last = rows[rows.length - 1];
+      cursor = encodeOrderCursor(last.createdAt, last.id);
+      if (cursorIds.length >= TOTAL) break;
+    }
+
+    expect(offsetIds).toHaveLength(TOTAL);
+    expect(cursorIds).toHaveLength(TOTAL);
+    expect(new Set(offsetIds).size).toBe(TOTAL);
+    expect(new Set(cursorIds).size).toBe(TOTAL);
+    expect(cursorIds).toEqual(offsetIds);
+  });
+
+  it("orders with equal createdAt break ties by id DESC", async () => {
+    const rows = await getAllOrders(db, { limit: TOTAL });
+    for (let i = 1; i < rows.length; i++) {
+      const prev = rows[i - 1];
+      const curr = rows[i];
+      if (prev.createdAt === curr.createdAt) {
+        expect(prev.id > curr.id).toBe(true);
+      } else {
+        expect(prev.createdAt > curr.createdAt).toBe(true);
+      }
+    }
+  });
+
+  it("cursor page starts strictly after the previous page's last row", async () => {
+    const page1 = await getAllOrders(db, { limit: PAGE });
+    const last = page1[PAGE - 1];
+    const cursor = encodeOrderCursor(last.createdAt, last.id);
+    const page2 = await getAllOrders(db, { limit: PAGE, cursor });
+
+    expect(page2).toHaveLength(PAGE);
+    expect(page2.every((r) => r.id !== last.id)).toBe(true);
+    for (const row of page2) {
+      const afterCursor =
+        row.createdAt < last.createdAt ||
+        (row.createdAt === last.createdAt && row.id < last.id);
+      expect(afterCursor).toBe(true);
+    }
+  });
+
+  it("cursor combines with the status filter", async () => {
+    const first = await getAllOrders(db, { status: "new", limit: 3 });
+    expect(first.every((r) => r.status === "new")).toBe(true);
+    const last = first[first.length - 1];
+    const cursor = encodeOrderCursor(last.createdAt, last.id);
+
+    const second = await getAllOrders(db, { status: "new", limit: 3, cursor });
+    expect(second.length).toBeGreaterThan(0);
+    expect(second.every((r) => r.status === "new")).toBe(true);
+    for (const row of second) {
+      const afterCursor =
+        row.createdAt < last.createdAt ||
+        (row.createdAt === last.createdAt && row.id < last.id);
+      expect(afterCursor).toBe(true);
+    }
+    expect(second.some((r) => first.some((f) => f.id === r.id))).toBe(false);
+  });
+
+  it("cursor takes precedence over offset", async () => {
+    const page1 = await getAllOrders(db, { limit: PAGE });
+    const last = page1[PAGE - 1];
+    const cursor = encodeOrderCursor(last.createdAt, last.id);
+
+    const viaCursor = await getAllOrders(db, { limit: PAGE, cursor, offset: 40 });
+    const viaCursorOnly = await getAllOrders(db, { limit: PAGE, cursor });
+
+    expect(viaCursor.map(key)).toEqual(viaCursorOnly.map(key));
+  });
+});
+
+describe("getAllOrders — search guard (real D1)", () => {
+  it("THE CRASH CASE: a 200-char search term no longer throws", async () => {
+    const rows = await getAllOrders(db, { search: "a".repeat(200) });
+    expect(rows).toEqual([]);
+  });
+
+  it("a long Arabic term (2 bytes/char) no longer throws", async () => {
+    const rows = await getAllOrders(db, { search: "أ".repeat(60) });
+    expect(rows).toEqual([]);
+  });
+
+  it("search still matches order number, phone, and customer name", async () => {
+    const byNumber = await getAllOrders(db, { search: "ORD-K-07" });
+    expect(byNumber.map(key)).toEqual(["ord-k07"]);
+
+    const byPhone = await getAllOrders(db, { search: "0770000012" });
+    expect(byPhone.map(key)).toEqual(["ord-k12"]);
+
+    const byName = await getAllOrders(db, { search: "Buyer 3" });
+    expect(byName.map(key)).toEqual(["ord-k03"]);
+  });
+
+  it("search combines with the cursor", async () => {
+    const page1 = await getAllOrders(db, { search: "Buyer", limit: 5 });
+    expect(page1.length).toBe(5);
+    const last = page1[page1.length - 1];
+    const cursor = encodeOrderCursor(last.createdAt, last.id);
+    const page2 = await getAllOrders(db, { search: "Buyer", limit: 5, cursor });
+    expect(page2.length).toBe(5);
+    expect(page2.some((r) => page1.some((f) => f.id === r.id))).toBe(false);
+  });
+});

--- a/cod-server/src/endpoints/orders/orders.keyset-queries.test.ts
+++ b/cod-server/src/endpoints/orders/orders.keyset-queries.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Slice 9 — keyset pagination + LIKE-pattern guard: unit + mock coverage.
+ *
+ *   • safeLikeTerm: D1 caps LIKE patterns at 50 bytes (verified: longer
+ *     patterns throw "LIKE or GLOB pattern too complex"); the guard
+ *     truncates terms to 48 bytes on UTF-8 code-point boundaries.
+ *   • encode/parseOrderCursor: opaque base64url cursor round-trip; garbage
+ *     parses to null.
+ *   • orderFiltersSchema: cursor refine → 400 on garbage at the API boundary.
+ *   • getAllOrders: cursor takes precedence over offset (defensive fallback
+ *     to the first page for unparseable cursors at the query level).
+ *
+ * WHERE/ordering semantics verified against real D1 in orders.keyset-e2e.test.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+import { makeMockDb, a, orderRow } from "@/test-utils/mock-db";
+import {
+  getAllOrders,
+  encodeOrderCursor,
+  parseOrderCursor,
+} from "../../../../cod-shared/queries/orders";
+import { safeLikeTerm } from "../../../../cod-shared/queries/search";
+import { orderFiltersSchema } from "./validation";
+
+function listRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ...orderRow(),
+    wilaya: "الجزائر",
+    commune: null,
+    driver_name: null,
+    has_review: 0,
+    last_updated_by: null,
+    ...overrides,
+  };
+}
+
+describe("safeLikeTerm", () => {
+  it("passes short ASCII terms through unchanged", () => {
+    expect(safeLikeTerm("ORD-001")).toBe("ORD-001");
+  });
+
+  it("passes the maximum in-budget Arabic term unchanged (24 chars = 48 bytes)", () => {
+    const term = "أ".repeat(24);
+    expect(safeLikeTerm(term)).toBe(term);
+  });
+
+  it("truncates a long ASCII term to 48 bytes", () => {
+    const out = safeLikeTerm("a".repeat(200));
+    expect(out).toHaveLength(48);
+  });
+
+  it("truncates Arabic text on a code-point boundary (never mid-character)", () => {
+    const out = safeLikeTerm("أ".repeat(60));
+    expect(out).toHaveLength(24);
+    expect(out).toBe("أ".repeat(24));
+  });
+
+  it("truncates mixed emoji (4-byte) text on a boundary", () => {
+    const out = safeLikeTerm("😀".repeat(30));
+    expect([...out]).toHaveLength(12);
+    expect(out).toBe("😀".repeat(12));
+    expect(new TextEncoder().encode(out).length).toBe(48);
+  });
+
+  it("an empty term stays empty", () => {
+    expect(safeLikeTerm("")).toBe("");
+  });
+});
+
+describe("order cursor codec", () => {
+  it("round-trips createdAt and id", () => {
+    const cursor = encodeOrderCursor("2026-09-04T12:00:00.000Z", "ord-123");
+    expect(parseOrderCursor(cursor)).toEqual({
+      createdAt: "2026-09-04T12:00:00.000Z",
+      id: "ord-123",
+    });
+  });
+
+  it("rejects non-base64 garbage", () => {
+    expect(parseOrderCursor("!!!not-base64!!!")).toBeNull();
+  });
+
+  it("rejects base64 of the wrong inner shape", () => {
+    expect(parseOrderCursor(btoa("no-separator"))).toBeNull();
+    expect(parseOrderCursor(btoa("|missing-createdat"))).toBeNull();
+    expect(parseOrderCursor(btoa("not-a-date|ord-1"))).toBeNull();
+  });
+});
+
+describe("orderFiltersSchema — cursor validation", () => {
+  it("accepts a valid cursor", () => {
+    const cursor = encodeOrderCursor("2026-09-04T12:00:00.000Z", "ord-1");
+    const parsed = orderFiltersSchema.parse({ cursor });
+    expect(parsed.cursor).toBe(cursor);
+  });
+
+  it("rejects a garbage cursor (400 at the API boundary)", () => {
+    expect(() => orderFiltersSchema.parse({ cursor: "garbage" })).toThrow();
+  });
+
+  it("cursor is optional (offset pagination unchanged)", () => {
+    const parsed = orderFiltersSchema.parse({ limit: 10, offset: 20 });
+    expect(parsed.cursor).toBeUndefined();
+  });
+});
+
+describe("getAllOrders — cursor precedence", () => {
+  it("uses the cursor row-value predicate in the single list query", async () => {
+    const db = makeMockDb([a([listRow()])]);
+    const cursor = encodeOrderCursor("2026-09-04T12:00:00.000Z", "ord-999");
+
+    const rows = await getAllOrders(db, { cursor, limit: 10, offset: 99 });
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it("falls back to the first page for an unparseable cursor (defensive)", async () => {
+    const db = makeMockDb([a([listRow()])]);
+
+    const rows = await getAllOrders(db, { cursor: "!!!", offset: 99 });
+
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/cod-server/src/endpoints/orders/orders.read-e2e.test.ts
+++ b/cod-server/src/endpoints/orders/orders.read-e2e.test.ts
@@ -1,0 +1,228 @@
+/**
+ * getAllOrders + getOrderById — Slice 4 real-D1 E2E.
+ *
+ * Runs the real migrations on an in-memory miniflare D1 (58 wilayas + 1551
+ * communes reference data included) and verifies:
+ *   • getOrderById: joined resolution (wilaya/commune/driver/label) in one
+ *     select + ONE read batch for lines and history
+ *   • null branches: no driver / wilaya / commune / shipment / review
+ *   • missing order → null (no batch executed)
+ *   • getAllOrders: EXISTS hasReview 1/0, lastUpdatedBy from latest history,
+ *     status / wilayaId / search filters, limit+offset pagination over
+ *     created_at DESC
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Miniflare } from "miniflare";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { drizzle } from "drizzle-orm/d1";
+import { eq } from "drizzle-orm";
+import * as schema from "@/db/schema";
+import type { AppDb } from "@/db";
+import { getAllOrders, getOrderById } from "../../../../cod-shared/queries/orders";
+
+const registry: Miniflare[] = [];
+let db: AppDb;
+
+beforeAll(async () => {
+  const mf = new Miniflare({
+    script: "export default { fetch() { return new Response('ok'); } }",
+    modules: true,
+    d1Databases: { DB: "test-db" },
+  });
+  registry.push(mf);
+  const d1 = await mf.getD1Database("DB");
+  const dir = resolve(__dirname, "../../db/migrations");
+  for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql")).sort()) {
+    const statements = readFileSync(`${dir}/${file}`, "utf8")
+      .split("--> statement-breakpoint")
+      .flatMap((s) => s.split(/;\s*\n/))
+      .map((s) => s.replace(/;+\s*$/, "").trim())
+      .filter((s) => s.replace(/--[^\n]*/g, "").trim().length > 0);
+    for (const statement of statements) {
+      await d1.prepare(statement).run();
+    }
+  }
+  db = drizzle(d1 as unknown as D1Database, { schema }) as unknown as AppDb;
+
+  const commune = await db
+    .select({ id: schema.communes.id, nameAr: schema.communes.nameAr })
+    .from(schema.communes)
+    .where(eq(schema.communes.wilayaId, 16))
+    .get();
+  const wilaya = await db
+    .select({ nameAr: schema.wilayas.nameAr })
+    .from(schema.wilayas)
+    .where(eq(schema.wilayas.id, 16))
+    .get();
+
+  const now = new Date().toISOString();
+  const earlier = "2025-12-01T00:00:00.000Z";
+
+  await db.insert(schema.users).values({
+    id: "user-e2e", name: "Sara Staff", email: "sara@example.com",
+    createdAt: new Date(), updatedAt: new Date(),
+  });
+  await db.insert(schema.drivers).values({
+    id: "drv-e2e", firstName: "Karim", lastName: "Hammadi", phone: "0555000010",
+    createdAt: now, updatedAt: now,
+  });
+  await db.insert(schema.customers).values({
+    id: "cust-e2e", name: "Full Buyer", phone: "0770000001",
+    wilaya: wilaya!.nameAr, commune: commune?.nameAr ?? null,
+    wilayaId: 16, communeId: commune?.id ?? null,
+    createdAt: now,
+  });
+  await db.insert(schema.customers).values({
+    id: "cust-e2e-2", name: "Bare Buyer", phone: "0770000002",
+    wilaya: "ولاية 99", createdAt: now,
+  });
+  await db.insert(schema.products).values({
+    id: "prod-e2e", name: "E2E Product", handle: "e2e-product", price: 1500,
+    hasVariants: false, inventory: 50, trackInventory: true,
+    status: "ACTIVE", visibility: true, showInStore: true,
+    createdAt: now, updatedAt: now,
+  });
+  await db.insert(schema.stores).values({
+    id: "store-e2e", name: "E2E Store", createdAt: now, updatedAt: now,
+  });
+
+  // Order A — full graph: wilaya, commune, driver, shipment, review, history by user
+  await db.insert(schema.orders).values({
+    id: "ord-e2e-a", orderNumber: "ORD-E2E-A", customerId: "cust-e2e",
+    customerName: "Full Buyer", phone: "0770000001",
+    wilayaId: 16, communeId: commune?.id ?? null,
+    price: 3000, status: "new", deliveryMethod: "driver", deliveryType: "home",
+    deliveryFee: 400, driverFee: 0, codAmount: 3400, driverId: "drv-e2e",
+    createdAt: now, updatedAt: now,
+  });
+  await db.insert(schema.orderProducts).values([
+    { id: "op-a1", orderId: "ord-e2e-a", productId: "prod-e2e", productName: "E2E Product", quantity: 1, pricePerUnit: 1500, lineTotal: 1500, createdAt: now },
+    { id: "op-a2", orderId: "ord-e2e-a", productId: "prod-e2e", productName: "E2E Product", quantity: 1, pricePerUnit: 1500, lineTotal: 1500, createdAt: now },
+  ]);
+  await db.insert(schema.orderStatusHistory).values([
+    { id: "h-a1", orderId: "ord-e2e-a", status: "new", timestamp: earlier, by: null },
+    { id: "h-a2", orderId: "ord-e2e-a", status: "confirmed", timestamp: now, by: "user-e2e" },
+  ]);
+  await db.insert(schema.deliveryCompanies).values({
+    id: "co-x", name: "E2E Carrier", nameAr: "ناقل", code: "e2e-carrier",
+    createdAt: now, updatedAt: now,
+  });
+  await db.insert(schema.companyShipments).values({
+    id: "shp-a", orderId: "ord-e2e-a", companyId: "co-x",
+    trackingNumber: "TRK-A", labelUrl: "https://example.com/label-a.pdf",
+    createdAt: now, updatedAt: now,
+  });
+  await db.insert(schema.reviews).values({
+    id: "rev-a", storeId: "store-e2e", productId: "prod-e2e",
+    orderId: "ord-e2e-a", orderNumber: "ORD-E2E-A", customerName: "Full Buyer",
+    rating: 5, body: "great", status: "approved",
+    createdAt: now, updatedAt: now,
+  });
+
+  // Order B — minimal: no wilaya/commune/driver/shipment/review; older timestamp
+  await db.insert(schema.orders).values({
+    id: "ord-e2e-b", orderNumber: "ORD-E2E-B", customerId: "cust-e2e-2",
+    customerName: "Bare Buyer", phone: "0770000002",
+    price: 1500, status: "confirmed", deliveryMethod: "unassigned", deliveryType: "home",
+    deliveryFee: 0, driverFee: 0, codAmount: 1500,
+    createdAt: earlier, updatedAt: earlier,
+  });
+  await db.insert(schema.orderProducts).values({
+    id: "op-b1", orderId: "ord-e2e-b", productId: "prod-e2e", productName: "E2E Product",
+    quantity: 1, pricePerUnit: 1500, lineTotal: 1500, createdAt: earlier,
+  });
+  await db.insert(schema.orderStatusHistory).values({
+    id: "h-b1", orderId: "ord-e2e-b", status: "confirmed", timestamp: earlier, by: null,
+  });
+}, 120_000);
+
+afterAll(async () => {
+  for (const mf of registry) await mf.dispose();
+});
+
+describe("getOrderById — real D1", () => {
+  it("resolves the full joined graph", async () => {
+    const order = await getOrderById(db, "ord-e2e-a");
+
+    expect(order).not.toBeNull();
+    expect(order!.driverName).toBe("Karim Hammadi");
+    expect(order!.wilaya).toBe("الجزائر");
+    expect(order!.commune).toBeTruthy();
+    expect(order!.labelUrl).toBe("https://example.com/label-a.pdf");
+    expect(order!.products).toHaveLength(2);
+    expect(order!.statusHistory).toHaveLength(2);
+    expect(order!.statusHistory[0].status).toBe("confirmed");
+    expect(order!.statusHistory[0].byName).toBe("Sara Staff");
+    expect(order!.statusHistory[1].byName).toBeNull();
+  });
+
+  it("resolves nulls for the minimal order (no driver/wilaya/commune/shipment)", async () => {
+    const order = await getOrderById(db, "ord-e2e-b");
+
+    expect(order).not.toBeNull();
+    expect(order!.driverName).toBeNull();
+    expect(order!.wilaya).toBeNull();
+    expect(order!.commune).toBeNull();
+    expect(order!.labelUrl).toBeNull();
+    expect(order!.products).toHaveLength(1);
+    expect(order!.statusHistory).toHaveLength(1);
+    expect(order!.statusHistory[0].byName).toBeNull();
+  });
+
+  it("returns null for a missing order", async () => {
+    expect(await getOrderById(db, "does-not-exist")).toBeNull();
+  });
+});
+
+describe("getAllOrders — real D1", () => {
+  it("lists newest-first with EXISTS hasReview and lastUpdatedBy", async () => {
+    const rows = await getAllOrders(db);
+
+    expect(rows).toHaveLength(2);
+    const [a, b] = rows;
+    expect(a.id).toBe("ord-e2e-a");
+    expect(b.id).toBe("ord-e2e-b");
+    expect(a.hasReview).toBe(1);
+    expect(b.hasReview).toBe(0);
+    expect(a.lastUpdatedBy).toBe("user-e2e");
+    expect(b.lastUpdatedBy).toBeNull();
+    expect(a.driverName).toBe("Karim Hammadi");
+    expect(b.driverName).toBeNull();
+  });
+
+  it("filters by status", async () => {
+    const rows = await getAllOrders(db, { status: "confirmed" });
+    expect(rows.map((r) => r.id)).toEqual(["ord-e2e-b"]);
+  });
+
+  it("filters by wilayaId", async () => {
+    const rows = await getAllOrders(db, { wilayaId: 16 });
+    expect(rows.map((r) => r.id)).toEqual(["ord-e2e-a"]);
+  });
+
+  it("searches by order number", async () => {
+    const rows = await getAllOrders(db, { search: "ORD-E2E-B" });
+    expect(rows.map((r) => r.id)).toEqual(["ord-e2e-b"]);
+  });
+
+  it("searches by phone", async () => {
+    const rows = await getAllOrders(db, { search: "0770000001" });
+    expect(rows.map((r) => r.id)).toEqual(["ord-e2e-a"]);
+  });
+
+  it("searches by customer name", async () => {
+    const rows = await getAllOrders(db, { search: "Bare" });
+    expect(rows.map((r) => r.id)).toEqual(["ord-e2e-b"]);
+  });
+
+  it("paginates with limit and offset over created_at DESC", async () => {
+    const page1 = await getAllOrders(db, { limit: 1, offset: 0 });
+    const page2 = await getAllOrders(db, { limit: 1, offset: 1 });
+    expect(page1.map((r) => r.id)).toEqual(["ord-e2e-a"]);
+    expect(page2.map((r) => r.id)).toEqual(["ord-e2e-b"]);
+    const empty = await getAllOrders(db, { limit: 1, offset: 5 });
+    expect(empty).toEqual([]);
+  });
+});

--- a/cod-server/src/endpoints/orders/orders.read-queries.test.ts
+++ b/cod-server/src/endpoints/orders/orders.read-queries.test.ts
@@ -1,0 +1,181 @@
+/**
+ * getAllOrders + getOrderById — Slice 4 read-path coverage.
+ *
+ * Mock queue verifies call shape and mapping (one joined select, then ONE
+ * read batch); WHERE/filter semantics are verified against real D1 in
+ * orders.read-e2e.test.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+import { makeMockDb, f, a, orderRow, NOW } from "@/test-utils/mock-db";
+import { getAllOrders, getOrderById } from "../../../../cod-shared/queries/orders";
+
+function opRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "op_1",
+    order_id: "ord_1",
+    product_id: "prod_1",
+    product_name: "Galaxy A54",
+    variant_id: null,
+    variant_label: null,
+    sku: null,
+    quantity: 2,
+    price_per_unit: 4500,
+    line_total: 9000,
+    status: "fulfilled",
+    returned_quantity: 0,
+    created_at: NOW,
+    ...overrides,
+  };
+}
+
+function listRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ...orderRow(),
+    wilaya: "الجزائر",
+    commune: "باب الزوار",
+    driver_name: "Ahmed Benali",
+    has_review: 0,
+    last_updated_by: "user_1",
+    ...overrides,
+  };
+}
+
+function detailRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ...orderRow(),
+    wilaya: "الجزائر",
+    commune: "باب الزوار",
+    driver_name: "Ahmed Benali",
+    label_url: "https://example.com/label.pdf",
+    ...overrides,
+  };
+}
+
+function historyRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "h_1",
+    order_id: "ord_1",
+    status: "new",
+    timestamp: NOW,
+    by: "user_1",
+    by_name: "Ahmed Benali",
+    ...overrides,
+  };
+}
+
+describe("getAllOrders", () => {
+  it("maps the joined select row including hasReview and lastUpdatedBy", async () => {
+    const db = makeMockDb([a([listRow({ has_review: 1 })])]);
+
+    const rows = await getAllOrders(db);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "ord_1",
+      orderNumber: "ORD-001",
+      wilaya: "الجزائر",
+      commune: "باب الزوار",
+      driverName: "Ahmed Benali",
+      hasReview: 1,
+      lastUpdatedBy: "user_1",
+    });
+  });
+
+  it("hasReview maps to 0 for unreviewed orders (EXISTS returns 1/0)", async () => {
+    const db = makeMockDb([a([listRow({ has_review: 0 })])]);
+
+    const rows = await getAllOrders(db);
+
+    expect(rows[0].hasReview).toBe(0);
+  });
+
+  it("accepts filters without extra queries (single list query)", async () => {
+    const db = makeMockDb([a([listRow()])]);
+
+    const rows = await getAllOrders(db, {
+      status: "new",
+      wilayaId: 16,
+      search: "ORD-001",
+      limit: 10,
+      offset: 5,
+    });
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it("returns an empty page without touching further queue entries", async () => {
+    const db = makeMockDb([a([])]);
+
+    const rows = await getAllOrders(db);
+
+    expect(rows).toEqual([]);
+  });
+});
+
+describe("getOrderById", () => {
+  it("resolves the order with one joined select and one read batch", async () => {
+    const db = makeMockDb([
+      f(detailRow()),
+      a([opRow({ id: "op_1", quantity: 2 }), opRow({ id: "op_2", quantity: 1 })]),
+      a([
+        historyRow({ id: "h_2", status: "preparing", timestamp: "2026-01-02T00:00:00.000Z" }),
+        historyRow({ id: "h_1", status: "new", timestamp: "2026-01-01T00:00:00.000Z" }),
+      ]),
+    ]);
+
+    const order = await getOrderById(db, "ord_1");
+
+    expect(order).not.toBeNull();
+    expect(order).toMatchObject({
+      id: "ord_1",
+      orderNumber: "ORD-001",
+      wilaya: "الجزائر",
+      commune: "باب الزوار",
+      driverName: "Ahmed Benali",
+      labelUrl: "https://example.com/label.pdf",
+    });
+    expect(order!.products).toHaveLength(2);
+    expect(order!.products[0]).toMatchObject({ id: "op_1", quantity: 2 });
+    expect(order!.statusHistory).toHaveLength(2);
+    expect(order!.statusHistory[0]).toMatchObject({
+      id: "h_2",
+      status: "preparing",
+      byName: "Ahmed Benali",
+    });
+  });
+
+  it("maps null driver/wilaya/commune/label when joins miss", async () => {
+    const db = makeMockDb([
+      f(detailRow({
+        wilaya: null,
+        commune: null,
+        driver_name: null,
+        label_url: null,
+        driver_id: null,
+        wilaya_id: null,
+        commune_id: null,
+      })),
+      a([opRow()]),
+      a([historyRow({ by: null, by_name: null })]),
+    ]);
+
+    const order = await getOrderById(db, "ord_1");
+
+    expect(order).toMatchObject({
+      wilaya: null,
+      commune: null,
+      driverName: null,
+      labelUrl: null,
+    });
+    expect(order!.statusHistory[0].byName).toBeNull();
+  });
+
+  it("returns null for a missing order without running the read batch", async () => {
+    const db = makeMockDb([f(null)]);
+
+    const order = await getOrderById(db, "nope");
+
+    expect(order).toBeNull();
+  });
+});

--- a/cod-server/src/endpoints/orders/orders.webhook-e2e.test.ts
+++ b/cod-server/src/endpoints/orders/orders.webhook-e2e.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Miniflare } from "miniflare";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { drizzle } from "drizzle-orm/d1";
+import { eq } from "drizzle-orm";
+import * as schema from "@/db/schema";
+import type { AppDb } from "@/db";
+import { updateOrderStatusWebhook } from "../../../../cod-shared/queries/orders";
+
+let db: AppDb;
+
+beforeAll(async () => {
+  const mf = new Miniflare({
+    script: "export default { fetch() { return new Response('ok'); } }",
+    modules: true,
+    d1Databases: { DB: "test-db" },
+  });
+  const d1 = await mf.getD1Database("DB");
+  const dir = resolve(__dirname, "../../db/migrations");
+  for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql")).sort()) {
+    const statements = readFileSync(`${dir}/${file}`, "utf8")
+      .split("--> statement-breakpoint")
+      .flatMap((s) => s.split(/;\s*\n/))
+      .map((s) => s.replace(/;+\s*$/, "").trim())
+      .filter((s) => s.replace(/--[^\n]*/g, "").trim().length > 0);
+    for (const statement of statements) {
+      await d1.prepare(statement).run();
+    }
+  }
+  db = drizzle(d1 as unknown as D1Database, { schema }) as unknown as AppDb;
+  registry.push(mf);
+}, 120_000);
+
+const registry: Miniflare[] = [];
+
+afterAll(async () => {
+  for (const mf of registry) await mf.dispose();
+});
+
+describe("updateOrderStatusWebhook — real D1 batch (E2E)", () => {
+  it("commits, guards rank, restocks, and rolls back atomically", async () => {
+    const now = new Date().toISOString();
+    const pid = "prod-e2e-1";
+
+    await db.insert(schema.products).values({
+      id: pid, name: "E2E Product", handle: "e2e-product", price: 1000,
+      hasVariants: false, inventory: 5, trackInventory: true, lowStockThreshold: 2,
+      status: "ACTIVE", visibility: true, showInStore: true, storeFeatured: false,
+      createdAt: now, updatedAt: now,
+    });
+    await db.insert(schema.customers).values({
+      id: "cust-e2e-1", name: "E2E Customer", phone: "0555000001",
+      wilaya: "الجزائر", totalOrders: 2, totalSpent: 2000, createdAt: now,
+    });
+    for (const [oid, opid, num] of [
+      ["ord-e2e-1", "op-e2e-1", "ORD-E2E-1"],
+      ["ord-e2e-2", "op-e2e-2", "ORD-E2E-2"],
+    ] as const) {
+      await db.insert(schema.orders).values({
+        id: oid, orderNumber: num, customerId: "cust-e2e-1",
+        customerName: "E2E Customer", phone: "0555000001", price: 2000,
+        status: "ready", deliveryMethod: "unassigned", deliveryType: "home",
+        deliveryFee: 0, driverFee: 0, codAmount: 2000, createdAt: now, updatedAt: now,
+      });
+      await db.insert(schema.orderProducts).values({
+        id: opid, orderId: oid, productId: pid, productName: "E2E Product",
+        quantity: 2, pricePerUnit: 1000, lineTotal: 2000, createdAt: now,
+      });
+    }
+
+    expect(await updateOrderStatusWebhook(db, "ord-e2e-1", "delivered", "e2e")).toEqual({ updated: true });
+
+    expect(await updateOrderStatusWebhook(db, "ord-e2e-1", "cancelled", "e2e")).toEqual({ updated: false });
+
+    expect(await updateOrderStatusWebhook(db, "ord-e2e-2", "cancelled", "e2e")).toEqual({ updated: true });
+
+    const inv = await db.select().from(schema.products).where(eq(schema.products.id, pid)).get();
+    expect(inv?.inventory).toBe(7);
+
+    const movements = await db.select().from(schema.stockMovements).all();
+    expect(movements).toHaveLength(1);
+    expect(movements[0]).toMatchObject({ type: "ORDER_CANCELLED", delta: 2, qtyBefore: 5, qtyAfter: 7 });
+
+    const line = await db.select().from(schema.orderProducts).where(eq(schema.orderProducts.id, "op-e2e-2")).get();
+    expect(line).toMatchObject({ status: "returned", returnedQuantity: 2 });
+
+    const cust = await db.select().from(schema.customers).where(eq(schema.customers.id, "cust-e2e-1")).get();
+    expect(cust?.totalSpent).toBe(0);
+
+    let batchFailed = false;
+    try {
+      await db.batch([
+        db.insert(schema.orders).values({
+          id: "ord-dupe", orderNumber: "ORD-E2E-2", customerId: "cust-e2e-1",
+          customerName: "x", phone: "x", price: 1, status: "new",
+          deliveryMethod: "unassigned", deliveryType: "home",
+          deliveryFee: 0, driverFee: 0, codAmount: 1, createdAt: now, updatedAt: now,
+        }),
+        db.insert(schema.orderStatusHistory).values({
+          id: "hist-dupe", orderId: "ord-dupe", status: "new", timestamp: now, by: null,
+        }),
+      ]);
+    } catch {
+      batchFailed = true;
+    }
+    expect(batchFailed).toBe(true);
+    expect(await db.select().from(schema.orders).where(eq(schema.orders.id, "ord-dupe")).get()).toBeUndefined();
+    expect(await db.select().from(schema.orderStatusHistory).where(eq(schema.orderStatusHistory.id, "hist-dupe")).get()).toBeUndefined();
+  });
+});

--- a/cod-server/src/endpoints/orders/orders.webhook-queries.test.ts
+++ b/cod-server/src/endpoints/orders/orders.webhook-queries.test.ts
@@ -1,0 +1,168 @@
+/**
+ * updateOrderStatusWebhook — Slice 2 batch-write coverage.
+ *
+ * Contract (cod-shared/queries/orders.ts):
+ *   • unknown order → { updated: false }
+ *   • rank guard: equal/lower-ranked status → { updated: false }, no writes
+ *   • accepted status → rank advance committed in ONE db.batch() call
+ *   • delivered + driverId → driver stats update inside the same batch
+ *   • cancelled/returned → customer stats + restock + movements in the same batch
+ *
+ * Uses makeMockDb's sequential read queue; all writes funnel through the
+ * mock's batch() which succeeds without consuming the queue.
+ */
+
+import { describe, it, expect } from "vitest";
+import { makeMockDb, f, a, orderRow, NOW } from "@/test-utils/mock-db";
+import { updateOrderStatusWebhook } from "../../../../cod-shared/queries/orders";
+
+function opRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "op_1",
+    order_id: "ord_1",
+    product_id: "prod_1",
+    product_name: "Galaxy A54",
+    variant_id: null,
+    variant_label: null,
+    sku: null,
+    quantity: 2,
+    price_per_unit: 4500,
+    line_total: 9000,
+    status: "fulfilled",
+    returned_quantity: 0,
+    created_at: NOW,
+    ...overrides,
+  };
+}
+
+describe("updateOrderStatusWebhook", () => {
+  it("returns { updated: false } for an unknown order", async () => {
+    const db = makeMockDb([f(null)]);
+
+    const result = await updateOrderStatusWebhook(db, "nope", "delivered", "yalidine");
+
+    expect(result).toEqual({ updated: false });
+  });
+
+  it("rejects a same-rank status (no regression)", async () => {
+    const db = makeMockDb([f(orderRow({ status: "delivered" }))]);
+
+    const result = await updateOrderStatusWebhook(db, "ord_1", "cancelled", "zr_express");
+
+    expect(result).toEqual({ updated: false });
+  });
+
+  it("rejects a lower-rank status", async () => {
+    const db = makeMockDb([f(orderRow({ status: "out_for_delivery" }))]);
+
+    const result = await updateOrderStatusWebhook(db, "ord_1", "preparing", "zr_express");
+
+    expect(result).toEqual({ updated: false });
+  });
+
+  it("commits a forward status change (batch path)", async () => {
+    const db = makeMockDb([f(orderRow({ status: "confirmed", driver_id: null }))]);
+
+    const result = await updateOrderStatusWebhook(db, "ord_1", "preparing", "zr_express");
+
+    expect(result).toEqual({ updated: true });
+  });
+
+  it("commits delivered with driver stats in the same batch", async () => {
+    const db = makeMockDb([
+      f(orderRow({ status: "out_for_delivery", driver_id: "drv_1", driver_fee: 350, cod_amount: 9600 })),
+    ]);
+
+    const result = await updateOrderStatusWebhook(db, "ord_1", "delivered", "yalidine");
+
+    expect(result).toEqual({ updated: true });
+  });
+
+  it("commits delivered without a driver (no driver update needed)", async () => {
+    const db = makeMockDb([f(orderRow({ status: "out_for_delivery", driver_id: null }))]);
+
+    const result = await updateOrderStatusWebhook(db, "ord_1", "delivered", "yalidine");
+
+    expect(result).toEqual({ updated: true });
+  });
+
+  it("restocks simple-product inventory on cancelled (resolve-then-batch reads)", async () => {
+    const db = makeMockDb([
+      f(orderRow({ status: "ready" })),
+      a([opRow({ quantity: 2, returned_quantity: 0 })]),
+      f({ track_inventory: 1 }),
+      f({ inventory: 5 }),
+    ]);
+
+    const result = await updateOrderStatusWebhook(db, "ord_1", "cancelled", "yalidine");
+
+    expect(result).toEqual({ updated: true });
+  });
+
+  it("restocks only remaining units when some already returned", async () => {
+    const db = makeMockDb([
+      f(orderRow({ status: "out_for_delivery" })),
+      a([opRow({ quantity: 3, returned_quantity: 1 })]),
+      f({ track_inventory: 1 }),
+      f({ inventory: 4 }),
+    ]);
+
+    const result = await updateOrderStatusWebhook(db, "ord_1", "returned", "zr_express");
+
+    expect(result).toEqual({ updated: true });
+  });
+
+  it("skips restock when all units already returned", async () => {
+    const db = makeMockDb([
+      f(orderRow({ status: "out_for_delivery" })),
+      a([opRow({ quantity: 2, returned_quantity: 2 })]),
+    ]);
+
+    const result = await updateOrderStatusWebhook(db, "ord_1", "cancelled", "zr_express");
+
+    expect(result).toEqual({ updated: true });
+  });
+
+  it("skips restock when the product does not track inventory", async () => {
+    const db = makeMockDb([
+      f(orderRow({ status: "ready" })),
+      a([opRow({ quantity: 3, returned_quantity: 0 })]),
+      f({ track_inventory: 0 }),
+    ]);
+
+    const result = await updateOrderStatusWebhook(db, "ord_1", "cancelled", "zr_express");
+
+    expect(result).toEqual({ updated: true });
+  });
+
+  it("restocks variant inventory when variantId is set", async () => {
+    const db = makeMockDb([
+      f(orderRow({ status: "ready" })),
+      a([opRow({ quantity: 2, returned_quantity: 0, variant_id: "var_1", product_id: "prod_1" })]),
+      f({ track_inventory: 1 }),
+      f({ inventory: 3 }),
+    ]);
+
+    const result = await updateOrderStatusWebhook(db, "ord_1", "returned", "zr_express");
+
+    expect(result).toEqual({ updated: true });
+  });
+
+  it("mixes multiple lines in one batch", async () => {
+    const db = makeMockDb([
+      f(orderRow({ status: "ready" })),
+      a([
+        opRow({ id: "op_1", quantity: 2, returned_quantity: 0 }),
+        opRow({ id: "op_2", quantity: 1, returned_quantity: 0, variant_id: "var_1" }),
+      ]),
+      f({ track_inventory: 1 }),
+      f({ track_inventory: 1 }),
+      f({ inventory: 5 }),
+      f({ inventory: 3 }),
+    ]);
+
+    const result = await updateOrderStatusWebhook(db, "ord_1", "cancelled", "zr_express");
+
+    expect(result).toEqual({ updated: true });
+  });
+});

--- a/cod-server/src/endpoints/orders/validation.ts
+++ b/cod-server/src/endpoints/orders/validation.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from "zod";
+import { parseOrderCursor } from "../../../../cod-shared/queries/orders";
 
 export const createOrderSchema = z.object({
   customerId: z.string().min(1),
@@ -78,6 +79,17 @@ export const orderFiltersSchema = z.object({
   search: z.string().optional(),
   limit: z.coerce.number().int().positive().max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
+  cursor: z
+    .string()
+    .min(1)
+    .max(300)
+    .refine((v) => parseOrderCursor(v) !== null, "Invalid cursor")
+    .optional()
+    .describe(
+      "Keyset pagination cursor (takes precedence over offset). " +
+        "Pass the (createdAt, id) cursor of the last row of the current page " +
+        "to fetch the next page; deep pages stay index-served unlike offset."
+    ),
 });
 
 /**

--- a/cod-server/src/endpoints/products/products.list-e2e.test.ts
+++ b/cod-server/src/endpoints/products/products.list-e2e.test.ts
@@ -1,0 +1,274 @@
+/**
+ * getAllProducts + getStoreProducts — Slice 5 real-D1 E2E.
+ *
+ * Runs the real migrations on an in-memory miniflare D1 and verifies the
+ * batched read shapes against a mixed catalog (30 products):
+ *   • variant / no-variant products; active + inactive variants
+ *   • approved / pending / zero reviews; avgRating rounding
+ *   • images / no images; cover = first by position
+ *   • soft-deleted exclusion; status/visibility filters
+ *   • featured-first ordering on the storefront list
+ *   • pagination (limit/offset)
+ *   • chunk boundary: a 91-product page issues two id-chunked variant
+ *     queries and stays under D1's 100-bound-parameter limit (miniflare
+ *     enforces it — verified by probe during implementation).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Miniflare } from "miniflare";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { drizzle } from "drizzle-orm/d1";
+import { eq } from "drizzle-orm";
+import * as schema from "@/db/schema";
+import type { AppDb } from "@/db";
+import { getAllProducts } from "../../../../cod-shared/queries/products";
+import { getStoreProducts } from "../../../../cod-shared/queries/store";
+
+const registry: Miniflare[] = [];
+let db: AppDb;
+
+const CATALOG = 30;
+const BIG_CATALOG = 95;
+
+beforeAll(async () => {
+  const mf = new Miniflare({
+    script: "export default { fetch() { return new Response('ok'); } }",
+    modules: true,
+    d1Databases: { DB: "test-db" },
+  });
+  registry.push(mf);
+  const d1 = await mf.getD1Database("DB");
+  const dir = resolve(__dirname, "../../db/migrations");
+  for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql")).sort()) {
+    const statements = readFileSync(`${dir}/${file}`, "utf8")
+      .split("--> statement-breakpoint")
+      .flatMap((s) => s.split(/;\s*\n/))
+      .map((s) => s.replace(/;+\s*$/, "").trim())
+      .filter((s) => s.replace(/--[^\n]*/g, "").trim().length > 0);
+    for (const statement of statements) {
+      await d1.prepare(statement).run();
+    }
+  }
+  db = drizzle(d1 as unknown as D1Database, { schema }) as unknown as AppDb;
+
+  const now = new Date().toISOString();
+  await db.insert(schema.stores).values({
+    id: "store-e2e", name: "E2E Store", createdAt: now, updatedAt: now,
+  });
+
+  for (let i = 0; i < CATALOG + BIG_CATALOG; i++) {
+    const big = i >= CATALOG;
+    const id = big ? `prod-big-${i}` : `prod-${i}`;
+    const createdAt = `2026-01-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.000Z`;
+
+    const product: typeof schema.products.$inferInsert = {
+      id,
+      name: big ? `Bulk Product ${i}` : `E2E Product ${i}`,
+      description: i === 2 ? "Contains the marker ZZDESCMARKERZZ in prose" : null,
+      handle: `e2e-${id}`,
+      price: 1000 + i,
+      hasVariants: !big && i % 3 === 0,
+      inventory: big ? 5 : 20 + i,
+      trackInventory: true,
+      status: big ? "ACTIVE" : i === 7 ? "DRAFT" : "ACTIVE",
+      visibility: true,
+      showInStore: big ? true : i !== 8,
+      storeFeatured: !big && i === 1,
+      createdAt,
+      updatedAt: now,
+    };
+    if (i === 9) product.deletedAt = now;
+    await db.insert(schema.products).values(product);
+
+    if (product.hasVariants) {
+      await db.insert(schema.productVariants).values([
+        {
+          id: `var-${id}-a`, productId: id, variations: '{"Color":"Red"}',
+          sku: `SKU-${id}-A`, price: 1000, inventory: 3, active: true, position: 1,
+          createdAt: now, updatedAt: now,
+        },
+        {
+          id: `var-${id}-b`, productId: id, variations: '{"Color":"Blue"}',
+          sku: `SKU-${id}-B`, price: 1100, inventory: 4, active: true, position: 2,
+          createdAt: now, updatedAt: now,
+        },
+        {
+          id: `var-${id}-c`, productId: id, variations: '{"Color":"Green"}',
+          sku: `SKU-${id}-C`, price: 1200, inventory: 99, active: false, position: 3,
+          createdAt: now, updatedAt: now,
+        },
+      ]);
+    }
+
+    if (!big && i % 4 === 0) {
+      await db.insert(schema.productImages).values([
+        { id: `img-${id}-2`, productId: id, src: `${id}-second.jpg`, position: 2, type: 1, createdAt: now, updatedAt: now },
+        { id: `img-${id}-1`, productId: id, src: `${id}-first.jpg`, position: 1, type: 1, createdAt: now, updatedAt: now },
+      ]);
+    }
+
+    if (!big && (i === 0 || i === 3 || i === 6)) {
+      await db.insert(schema.customers).values({
+        id: `cust-rev-${i}`, name: `Reviewer ${i}`, phone: `07700001${String(i).padStart(2, "0")}`,
+        wilaya: "الجزائر", createdAt: now,
+      });
+      await db.insert(schema.orders).values({
+        id: `ord-rev-${i}`, orderNumber: `ORD-REV-${i}`, customerId: `cust-rev-${i}`,
+        customerName: `Reviewer ${i}`, phone: `07700001${String(i).padStart(2, "0")}`,
+        price: 1000, status: "delivered", deliveryMethod: "unassigned", deliveryType: "home",
+        deliveryFee: 0, driverFee: 0, codAmount: 1000, createdAt, updatedAt: now,
+      });
+      await db.insert(schema.reviews).values({
+        id: `rev-${i}`, storeId: "store-e2e", productId: id,
+        orderId: `ord-rev-${i}`, orderNumber: `ORD-REV-${i}`,
+        customerName: `Reviewer ${i}`,
+        rating: 4, body: "good",
+        status: i === 6 ? "pending" : "approved",
+        createdAt: now, updatedAt: now,
+      });
+    }
+  }
+}, 180_000);
+
+afterAll(async () => {
+  for (const mf of registry) await mf.dispose();
+});
+
+describe("getAllProducts — real D1", () => {
+  it("returns the full mixed catalog with correct derived fields", async () => {
+    const rows = await getAllProducts(db, { limit: 200 });
+
+    expect(rows.length).toBe(CATALOG + BIG_CATALOG - 1);
+
+    const variantRow = rows.find((r) => r.id === "prod-0");
+    expect(variantRow).toMatchObject({
+      hasVariants: true,
+      variantsCount: 3,
+      totalInventory: 106,
+      reviewCount: 1,
+      avgRating: 4,
+      primaryImageSrc: "prod-0-first.jpg",
+    });
+    expect(variantRow!.variants.map((v) => v.id)).toEqual([
+      "var-prod-0-a", "var-prod-0-b", "var-prod-0-c",
+    ]);
+
+    const simpleRow = rows.find((r) => r.id === "prod-1");
+    expect(simpleRow).toMatchObject({
+      hasVariants: false,
+      variantsCount: 0,
+      totalInventory: 21,
+      reviewCount: 0,
+      avgRating: null,
+    });
+
+    const pendingOnly = rows.find((r) => r.id === "prod-6");
+    expect(pendingOnly).toMatchObject({ reviewCount: 0, avgRating: null });
+
+    const noImages = rows.find((r) => r.id === "prod-2");
+    expect(noImages!.primaryImageSrc).toBeNull();
+  });
+
+  it("excludes soft-deleted products", async () => {
+    const rows = await getAllProducts(db, { limit: 200 });
+    expect(rows.find((r) => r.id === "prod-9")).toBeUndefined();
+  });
+
+  it("filters by status and respects limit/offset", async () => {
+    const drafts = await getAllProducts(db, { status: "DRAFT" });
+    expect(drafts.map((r) => r.id)).toEqual(["prod-7"]);
+
+    const page1 = await getAllProducts(db, { limit: 10, offset: 0 });
+    const page2 = await getAllProducts(db, { limit: 10, offset: 10 });
+    expect(page1).toHaveLength(10);
+    expect(page2).toHaveLength(10);
+    expect(page1[0].id).not.toBe(page2[0].id);
+
+    const empty = await getAllProducts(db, { limit: 10, offset: 500 });
+    expect(empty).toEqual([]);
+  });
+
+  it("search matches name but no longer scans description text (Slice 9 hygiene)", async () => {
+    const byName = await getAllProducts(db, { search: "E2E Product 2" });
+    expect(byName.map((r) => r.id).sort()).toEqual(
+      ["prod-2", ...Array.from({ length: 10 }, (_, i) => `prod-2${i}`)].sort(),
+    );
+
+    const byDescriptionMarker = await getAllProducts(db, { search: "ZZDESCMARKERZZ" });
+    expect(byDescriptionMarker).toEqual([]);
+  });
+
+  it("chunks variant fetches for pages beyond the 90-id boundary", async () => {
+    const rows = await getAllProducts(db, { limit: 200 });
+    expect(rows.length).toBeGreaterThan(91);
+
+    const bulk = rows.filter((r) => r.id.startsWith("prod-big-"));
+    expect(bulk).toHaveLength(BIG_CATALOG);
+    expect(bulk.every((r) => r.variantsCount === 0 && r.totalInventory === 5)).toBe(true);
+  });
+});
+
+describe("getStoreProducts — real D1", () => {
+  it("lists store-visible ACTIVE products with featured first", async () => {
+    const rows = await getStoreProducts(db, { limit: 200 });
+
+    expect(rows.find((r) => r.id === "prod-9")).toBeUndefined();
+    expect(rows.find((r) => r.id === "prod-8")).toBeUndefined();
+    expect(rows.find((r) => r.id === "prod-7")).toBeUndefined();
+
+    expect(rows[0].id).toBe("prod-1");
+    expect(rows[0].storeFeatured).toBe(true);
+    expect(rows.slice(1).every((r) => !r.storeFeatured)).toBe(true);
+  });
+
+  it("derives inventory from ACTIVE variants only", async () => {
+    const rows = await getStoreProducts(db, { limit: 200 });
+
+    const variantProduct = rows.find((r) => r.id === "prod-0");
+    expect(variantProduct!.inventory).toBe(7);
+
+    const simpleProduct = rows.find((r) => r.id === "prod-1");
+    expect(simpleProduct!.inventory).toBe(21);
+  });
+
+  it("picks the cover image with the lowest position per product", async () => {
+    const rows = await getStoreProducts(db, { limit: 200 });
+
+    const withImages = rows.find((r) => r.id === "prod-0");
+    expect(withImages!.coverImage).toMatchObject({ id: "img-prod-0-1", src: "prod-0-first.jpg" });
+
+    const withoutImages = rows.find((r) => r.id === "prod-1");
+    expect(withoutImages!.coverImage).toBeNull();
+  });
+
+  it("maps reviewStats from approved reviews only", async () => {
+    const rows = await getStoreProducts(db, { limit: 200 });
+
+    const approved = rows.find((r) => r.id === "prod-0");
+    expect(approved!.reviewStats).toEqual({ avgRating: 4, reviewCount: 1 });
+
+    const pendingOnly = rows.find((r) => r.id === "prod-6");
+    expect(pendingOnly!.reviewStats).toBeNull();
+
+    const noReviews = rows.find((r) => r.id === "prod-1");
+    expect(noReviews!.reviewStats).toBeNull();
+  });
+
+  it("respects the limit cap", async () => {
+    const all = await getStoreProducts(db, { limit: 200 });
+    const page1 = await getStoreProducts(db, { limit: 5 });
+
+    expect(page1[0].id).toBe(all[0].id);
+    expect(page1).toHaveLength(5);
+    expect(page1.every((r) => all.some((a) => a.id === r.id))).toBe(true);
+    expect(await getStoreProducts(db, { limit: 500, featured: true })).toEqual(
+      await getStoreProducts(db, { limit: 5, featured: true }),
+    );
+  });
+
+  it("featured filter returns only the featured product", async () => {
+    const rows = await getStoreProducts(db, { featured: true, limit: 10 });
+    expect(rows.map((r) => r.id)).toEqual(["prod-1"]);
+  });
+});

--- a/cod-server/src/endpoints/products/products.list-queries.test.ts
+++ b/cod-server/src/endpoints/products/products.list-queries.test.ts
@@ -1,0 +1,112 @@
+/**
+ * getAllProducts — Slice 5 mock-queue coverage.
+ *
+ * Call shape: ONE main select (products + review/image scalar subqueries),
+ * then ONE follow-up per id-chunk fetching all variants of the page. No
+ * per-row queries. WHERE/aggregate semantics are verified against real D1
+ * in products.list-e2e.test.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+import { makeMockDb, f, a, productRow, variantRow } from "@/test-utils/mock-db";
+import { getAllProducts } from "../../../../cod-shared/queries/products";
+
+describe("getAllProducts", () => {
+  it("maps one row with review stats and cover image from the main select", async () => {
+    const db = makeMockDb([
+      a([
+        {
+          ...productRow(),
+          review_count: 7,
+          avg_rating: 4.5,
+          primary_image_src: "https://example.com/cover.jpg",
+        },
+      ]),
+      a([variantRow({ id: "var_1", position: 2 }), variantRow({ id: "var_2", position: 1 })]),
+    ]);
+
+    const rows = await getAllProducts(db);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "prod_1",
+      reviewCount: 7,
+      avgRating: 4.5,
+      primaryImageSrc: "https://example.com/cover.jpg",
+      variantsCount: 2,
+      totalInventory: 10,
+      hasVariants: false,
+    });
+    expect(rows[0].variants).toHaveLength(2);
+    expect(rows[0].variants[0]).toMatchObject({ id: "var_1", variations: { Color: "Red" } });
+  });
+
+  it("falls back to product inventory when a product has no variants", async () => {
+    const db = makeMockDb([
+      a([{ ...productRow(), review_count: 0, avg_rating: null, primary_image_src: null }]),
+      a([]),
+    ]);
+
+    const rows = await getAllProducts(db);
+
+    expect(rows[0]).toMatchObject({
+      variantsCount: 0,
+      totalInventory: 10,
+      primaryImageSrc: null,
+      reviewCount: 0,
+      avgRating: null,
+      variants: [],
+    });
+  });
+
+  it("returns [] for an empty page without running the variant follow-up", async () => {
+    const db = makeMockDb([a([])]);
+
+    const rows = await getAllProducts(db);
+
+    expect(rows).toEqual([]);
+  });
+
+  it("parses variantOptions and tags JSON", async () => {
+    const db = makeMockDb([
+      a([
+        {
+          ...productRow({
+            variant_options: JSON.stringify([{ name: "اللون", values: [{ value: "أحمر" }] }]),
+            tags: JSON.stringify(["sale"]),
+          }),
+          review_count: 0,
+          avg_rating: null,
+          primary_image_src: null,
+        },
+      ]),
+      a([]),
+    ]);
+
+    const rows = await getAllProducts(db);
+
+    expect(rows[0].variantOptions).toEqual([{ name: "اللون", values: [{ value: "أحمر" }] }]);
+    expect(rows[0].tags).toEqual(["sale"]);
+  });
+
+  it("pages beyond the chunk size issue one variant query per chunk", async () => {
+    const page = Array.from({ length: 91 }, (_, i) => ({
+      ...productRow({ id: `prod_${i}` }),
+      review_count: 0,
+      avg_rating: null,
+      primary_image_src: null,
+    }));
+    const db = makeMockDb([
+      a(page),
+      a([variantRow({ product_id: "prod_0" })]),
+      a([variantRow({ product_id: "prod_90" })]),
+    ]);
+
+    const rows = await getAllProducts(db, { limit: 91 });
+
+    expect(rows).toHaveLength(91);
+    expect(rows[0]).toMatchObject({ id: "prod_0", variantsCount: 1 });
+    expect(rows[89]).toMatchObject({ id: "prod_89", variantsCount: 0 });
+    expect(rows[90]).toMatchObject({ id: "prod_90", variantsCount: 1 });
+  });
+});

--- a/cod-server/src/endpoints/stock/list-count-e2e.test.ts
+++ b/cod-server/src/endpoints/stock/list-count-e2e.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Slice 7 — count+rows in one round trip: real-D1 E2E.
+ *
+ * Verifies on a real engine (miniflare + real migrations) that the batched
+ * list+count pairs keep exact semantics:
+ *   • totals stay correct on EMPTY pages (offset beyond the end) — the case
+ *     that rules out COUNT(*) OVER() (verified: window returns no rows there)
+ *   • filters apply identically to rows and total
+ *   • pendingCount is global, independent of the reviews filter
+ *   • stats math: conversion rate rounding, zero-attempt division guard
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Miniflare } from "miniflare";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { drizzle } from "drizzle-orm/d1";
+import * as schema from "@/db/schema";
+import type { AppDb } from "@/db";
+import { getStockHistory } from "../../../../cod-shared/queries/stock";
+import { getApprovedProductReviews } from "../../../../cod-shared/queries/store";
+import { getAllReviews } from "../../../../cod-shared/queries/reviews";
+import {
+  listAbandonedOrders,
+  getAbandonedOrderStats,
+} from "../../../../cod-shared/queries/abandoned-orders";
+
+const registry: Miniflare[] = [];
+let db: AppDb;
+
+beforeAll(async () => {
+  const mf = new Miniflare({
+    script: "export default { fetch() { return new Response('ok'); } }",
+    modules: true,
+    d1Databases: { DB: "test-db" },
+  });
+  registry.push(mf);
+  const d1 = await mf.getD1Database("DB");
+  const dir = resolve(__dirname, "../../db/migrations");
+  for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql")).sort()) {
+    const statements = readFileSync(`${dir}/${file}`, "utf8")
+      .split("--> statement-breakpoint")
+      .flatMap((s) => s.split(/;\s*\n/))
+      .map((s) => s.replace(/;+\s*$/, "").trim())
+      .filter((s) => s.replace(/--[^\n]*/g, "").trim().length > 0);
+    for (const statement of statements) {
+      await d1.prepare(statement).run();
+    }
+  }
+  db = drizzle(d1 as unknown as D1Database, { schema }) as unknown as AppDb;
+
+  const now = new Date().toISOString();
+  const day = (n: number) => `2026-01-${String(n).padStart(2, "0")}T00:00:00.000Z`;
+
+  await db.insert(schema.stores).values({ id: "store-1", name: "S", createdAt: now, updatedAt: now });
+  await db.insert(schema.products).values([
+    { id: "prod-1", name: "Product 1", handle: "p1", price: 1000, hasVariants: false, inventory: 10, trackInventory: true, status: "ACTIVE", visibility: true, showInStore: true, createdAt: now, updatedAt: now },
+    { id: "prod-2", name: "Product 2", handle: "p2", price: 2000, hasVariants: true, inventory: 0, trackInventory: true, status: "ACTIVE", visibility: true, showInStore: true, createdAt: now, updatedAt: now },
+  ]);
+  await db.insert(schema.productVariants).values([
+    { id: "var-1", productId: "prod-2", sku: "SKU-V1", variations: '{"Color":"Red"}', price: 2000, inventory: 5, active: true, position: 1, createdAt: now, updatedAt: now },
+  ]);
+  await db.insert(schema.customers).values([
+    { id: "cust-1", name: "C1", phone: "0770000001", wilaya: "w", createdAt: now },
+    { id: "cust-2", name: "C2", phone: "0770000002", wilaya: "w", createdAt: now },
+    { id: "cust-3", name: "C3", phone: "0770000003", wilaya: "w", createdAt: now },
+  ]);
+  await db.insert(schema.orders).values([
+    { id: "ord-1", orderNumber: "ORD-1", customerId: "cust-1", customerName: "C1", phone: "0770000001", price: 1000, status: "delivered", deliveryMethod: "unassigned", deliveryType: "home", deliveryFee: 0, driverFee: 0, codAmount: 1000, createdAt: now, updatedAt: now },
+    { id: "ord-2", orderNumber: "ORD-2", customerId: "cust-2", customerName: "C2", phone: "0770000002", price: 1000, status: "delivered", deliveryMethod: "unassigned", deliveryType: "home", deliveryFee: 0, driverFee: 0, codAmount: 1000, createdAt: now, updatedAt: now },
+    { id: "ord-3", orderNumber: "ORD-3", customerId: "cust-3", customerName: "C3", phone: "0770000003", price: 1000, status: "delivered", deliveryMethod: "unassigned", deliveryType: "home", deliveryFee: 0, driverFee: 0, codAmount: 1000, createdAt: now, updatedAt: now },
+    { id: "ord-4", orderNumber: "ORD-4", customerId: "cust-1", customerName: "C1", phone: "0770000001", price: 1000, status: "delivered", deliveryMethod: "unassigned", deliveryType: "home", deliveryFee: 0, driverFee: 0, codAmount: 1000, createdAt: now, updatedAt: now },
+    { id: "ord-5", orderNumber: "ORD-5", customerId: "cust-2", customerName: "C2", phone: "0770000002", price: 1000, status: "delivered", deliveryMethod: "unassigned", deliveryType: "home", deliveryFee: 0, driverFee: 0, codAmount: 1000, createdAt: now, updatedAt: now },
+  ]);
+
+  for (let i = 1; i <= 6; i++) {
+    await db.insert(schema.stockMovements).values({
+      id: `mv-${i}`, productId: i <= 4 ? "prod-1" : "prod-2",
+      variantId: i > 4 ? "var-1" : null,
+      type: i % 2 === 0 ? "PURCHASE" : "ORDER_DEDUCTED",
+      delta: i % 2 === 0 ? 5 : -2, qtyBefore: i, qtyAfter: i + (i % 2 === 0 ? 5 : -2),
+      reason: null, reference: `ord-${i}`, createdBy: "user-1", createdByName: "U",
+      createdAt: day(i),
+    });
+  }
+
+  await db.insert(schema.reviews).values([
+    { id: "rev-1", storeId: "store-1", productId: "prod-1", orderId: "ord-1", orderNumber: "ORD-1", customerName: "C1", rating: 5, body: "a", status: "approved", createdAt: day(1), updatedAt: now },
+    { id: "rev-2", storeId: "store-1", productId: "prod-1", orderId: "ord-2", orderNumber: "ORD-2", customerName: "C2", rating: 4, body: "b", status: "approved", createdAt: day(2), updatedAt: now },
+    { id: "rev-3", storeId: "store-1", productId: "prod-1", orderId: "ord-3", orderNumber: "ORD-3", customerName: "C3", rating: 3, body: "c", status: "pending", createdAt: day(3), updatedAt: now },
+    { id: "rev-4", storeId: "store-1", productId: "prod-2", orderId: "ord-4", orderNumber: "ORD-4", customerName: "C1", rating: 2, body: "d", status: "pending", createdAt: day(4), updatedAt: now },
+    { id: "rev-5", storeId: "store-1", productId: "prod-2", orderId: "ord-5", orderNumber: "ORD-5", customerName: "C2", rating: 1, body: "e", status: "rejected", createdAt: day(5), updatedAt: now },
+  ]);
+
+  await db.insert(schema.abandonedOrders).values([
+    { id: "ab-1", sessionId: "s1", customerName: "Sara", phone: "0550000001", wilayaId: 16, wilayaName: "الجزائر", productId: "prod-1", productName: "Product 1", price: 1500, status: "abandoned", createdAt: day(1), updatedAt: now },
+    { id: "ab-2", sessionId: "s2", customerName: "Karim", phone: "0550000002", wilayaId: 16, wilayaName: "الجزائر", price: 2500, status: "abandoned", createdAt: day(2), updatedAt: now },
+    { id: "ab-3", sessionId: "s3", customerName: "Lina", phone: "0550000003", wilayaId: 16, wilayaName: "الجزائر", price: 999, status: "converted", convertedOrderId: "ord-1", convertedOrderNumber: "ORD-1", createdAt: day(3), updatedAt: now },
+    { id: "ab-4", sessionId: "s4", customerName: "Omar", phone: "0550000004", wilayaId: 16, wilayaName: "الجزائر", price: 777, status: "pending", createdAt: day(4), updatedAt: now },
+    { id: "ab-5", sessionId: "s5", customerName: "Nour", phone: "0550000005", wilayaId: 16, wilayaName: "الجزائر", price: 1234, status: "contacted", createdAt: day(5), updatedAt: now },
+  ]);
+}, 120_000);
+
+afterAll(async () => {
+  for (const mf of registry) await mf.dispose();
+});
+
+describe("getStockHistory — real D1", () => {
+  it("pages movements newest-first with the exact total", async () => {
+    const all = await getStockHistory(db, "prod-1", { limit: 20, offset: 0 });
+    expect(all.movements).toHaveLength(4);
+    expect(all.total).toBe(4);
+    expect(all.movements[0].id).toBe("mv-4");
+
+    const page = await getStockHistory(db, "prod-1", { limit: 2, offset: 2 });
+    expect(page.movements.map((m) => m.id)).toEqual(["mv-2", "mv-1"]);
+    expect(page.total).toBe(4);
+  });
+
+  it("filters by variant", async () => {
+    const result = await getStockHistory(db, "prod-2", { limit: 20, offset: 0 });
+    expect(result.movements).toHaveLength(2);
+    expect(result.total).toBe(2);
+    expect(result.movements.every((m) => m.variantId === "var-1")).toBe(true);
+  });
+
+  it("empty page beyond the end keeps the total", async () => {
+    const result = await getStockHistory(db, "prod-1", { limit: 3, offset: 50 });
+    expect(result.movements).toEqual([]);
+    expect(result.total).toBe(4);
+  });
+
+  it("unknown product → empty page, zero total", async () => {
+    const result = await getStockHistory(db, "prod-none", { limit: 20, offset: 0 });
+    expect(result).toEqual({ movements: [], total: 0 });
+  });
+});
+
+describe("getApprovedProductReviews — real D1", () => {
+  it("returns only approved reviews for the product, paginated", async () => {
+    const result = await getApprovedProductReviews(db, "store-1", "prod-1", 20, 0);
+    expect(result.rows.map((r) => r.id)).toEqual(["rev-2", "rev-1"]);
+    expect(result.total).toBe(2);
+
+    const page = await getApprovedProductReviews(db, "store-1", "prod-1", 1, 1);
+    expect(page.rows.map((r) => r.id)).toEqual(["rev-1"]);
+    expect(page.total).toBe(2);
+  });
+
+  it("excludes pending and rejected; empty page keeps total", async () => {
+    const result = await getApprovedProductReviews(db, "store-1", "prod-2", 20, 0);
+    expect(result.rows).toEqual([]);
+    expect(result.total).toBe(0);
+
+    const beyond = await getApprovedProductReviews(db, "store-1", "prod-1", 20, 50);
+    expect(beyond.rows).toEqual([]);
+    expect(beyond.total).toBe(2);
+  });
+});
+
+describe("getAllReviews — real D1", () => {
+  it("unfiltered returns all reviews newest-first with global pendingCount", async () => {
+    const result = await getAllReviews(db, { limit: 20, offset: 0 });
+    expect(result.rows).toHaveLength(5);
+    expect(result.total).toBe(5);
+    expect(result.pendingCount).toBe(2);
+    expect(result.rows[0].id).toBe("rev-5");
+    expect(result.rows.every((r) => r.productName !== null)).toBe(true);
+  });
+
+  it("status filter applies to rows and total but not pendingCount", async () => {
+    const result = await getAllReviews(db, { status: "pending", limit: 20, offset: 0 });
+    expect(result.rows.map((r) => r.id)).toEqual(["rev-4", "rev-3"]);
+    expect(result.total).toBe(2);
+    expect(result.pendingCount).toBe(2);
+  });
+
+  it("productId filter narrows rows and total", async () => {
+    const result = await getAllReviews(db, { productId: "prod-1", limit: 20, offset: 0 });
+    expect(result.rows).toHaveLength(3);
+    expect(result.total).toBe(3);
+    expect(result.pendingCount).toBe(2);
+  });
+
+  it("empty page keeps totals", async () => {
+    const result = await getAllReviews(db, { limit: 2, offset: 50 });
+    expect(result.rows).toEqual([]);
+    expect(result.total).toBe(5);
+    expect(result.pendingCount).toBe(2);
+  });
+});
+
+describe("listAbandonedOrders — real D1", () => {
+  it("lists newest-first unfiltered with the exact total", async () => {
+    const result = await listAbandonedOrders(db, { limit: 10, offset: 0 });
+    expect(result.rows).toHaveLength(5);
+    expect(result.total).toBe(5);
+    expect(result.rows[0].id).toBe("ab-5");
+  });
+
+  it("status filter applies to rows and total", async () => {
+    const result = await listAbandonedOrders(db, { status: "abandoned", limit: 10, offset: 0 });
+    expect(result.rows.map((r) => r.id)).toEqual(["ab-2", "ab-1"]);
+    expect(result.total).toBe(2);
+  });
+
+  it("search matches name and phone", async () => {
+    const byName = await listAbandonedOrders(db, { search: "Sara", limit: 10, offset: 0 });
+    expect(byName.rows.map((r) => r.id)).toEqual(["ab-1"]);
+
+    const byPhone = await listAbandonedOrders(db, { search: "0550000004", limit: 10, offset: 0 });
+    expect(byPhone.rows.map((r) => r.id)).toEqual(["ab-4"]);
+  });
+
+  it("empty page keeps the total", async () => {
+    const result = await listAbandonedOrders(db, { limit: 2, offset: 50 });
+    expect(result.rows).toEqual([]);
+    expect(result.total).toBe(5);
+  });
+});
+
+describe("getAbandonedOrderStats — real D1", () => {
+  it("computes stats from real rows (3 abandoned, 1 converted → 25%)", async () => {
+    const stats = await getAbandonedOrderStats(db);
+    expect(stats).toEqual({
+      totalAbandoned: 2,
+      totalConverted: 1,
+      conversionRate: 33,
+      estimatedLostRevenue: 4000,
+    });
+  });
+});

--- a/cod-server/src/endpoints/stock/list-count-queries.test.ts
+++ b/cod-server/src/endpoints/stock/list-count-queries.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Slice 7 — count+rows in one round trip: mock-queue coverage.
+ *
+ * Call shape post-Slice 7 (queue order = batch statement order):
+ *   • getStockHistory          → [a(movements), count]
+ *   • getApprovedProductReviews → [a(reviews), count]
+ *   • getAllReviews            → [a(rows), total, pendingCount]
+ *   • listAbandonedOrders      → [a(rows), count]
+ *   • getAbandonedOrderStats   → [abandoned, converted, revenue]
+ *
+ * WHERE/ordering/pagination semantics verified against real D1 in
+ * list-count-e2e.test.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+import { makeMockDb, f, a, NOW } from "@/test-utils/mock-db";
+import { getStockHistory } from "../../../../cod-shared/queries/stock";
+import { getApprovedProductReviews } from "../../../../cod-shared/queries/store";
+import { getAllReviews } from "../../../../cod-shared/queries/reviews";
+import {
+  listAbandonedOrders,
+  getAbandonedOrderStats,
+} from "../../../../cod-shared/queries/abandoned-orders";
+
+function movementRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "mv_1",
+    product_id: "prod_1",
+    variant_id: null,
+    type: "PURCHASE",
+    delta: 10,
+    qty_before: 0,
+    qty_after: 10,
+    reason: "initial",
+    reference: null,
+    created_by: "user_1",
+    created_by_name: "Admin",
+    created_at: NOW,
+    ...overrides,
+  };
+}
+
+function reviewRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "rev_1",
+    store_id: "store_1",
+    product_id: "prod_1",
+    order_id: "ord_1",
+    order_number: "ORD-001",
+    customer_name: "Fatima",
+    rating: 5,
+    title: null,
+    body: "great",
+    status: "approved",
+    helpful_count: 0,
+    created_at: NOW,
+    updated_at: NOW,
+    ...overrides,
+  };
+}
+
+function reviewListRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "rev_1",
+    store_id: "store_1",
+    product_id: "prod_1",
+    order_id: "ord_1",
+    order_number: "ORD-001",
+    customer_name: "Fatima",
+    rating: 5,
+    title: null,
+    body: "great",
+    status: "approved",
+    helpful_count: 0,
+    created_at: NOW,
+    updated_at: NOW,
+    product_name: "T-Shirt",
+    ...overrides,
+  };
+}
+
+function abandonedRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "ab_1",
+    session_id: "sess_1",
+    customer_name: "Sara",
+    phone: "0550",
+    wilaya_id: 16,
+    commune_id: null,
+    wilaya_name: "الجزائر",
+    commune_name: null,
+    product_id: "prod_1",
+    product_name: "T-Shirt",
+    variant_id: null,
+    variant_label: null,
+    price: 2500,
+    delivery_type: "home",
+    fbc: null,
+    fbp: null,
+    ip_address: null,
+    user_agent: null,
+    status: "abandoned",
+    converted_order_id: null,
+    converted_order_number: null,
+    recovery_attempts: 0,
+    last_recovery_at: null,
+    created_at: NOW,
+    updated_at: NOW,
+    ...overrides,
+  };
+}
+
+describe("getStockHistory", () => {
+  it("returns page and total from one batch", async () => {
+    const db = makeMockDb([
+      a([movementRow({ id: "mv_1" }), movementRow({ id: "mv_2" })]),
+      f({ count: 9 }),
+    ]);
+
+    const result = await getStockHistory(db, "prod_1", { limit: 2, offset: 4 });
+
+    expect(result.movements).toHaveLength(2);
+    expect(result.movements[0]).toMatchObject({ id: "mv_1", type: "PURCHASE", delta: 10 });
+    expect(result.total).toBe(9);
+  });
+
+  it("maps an empty page with total 0", async () => {
+    const db = makeMockDb([a([]), f({ count: 0 })]);
+
+    const result = await getStockHistory(db, "prod_1", { limit: 20, offset: 0 });
+
+    expect(result.movements).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});
+
+describe("getApprovedProductReviews", () => {
+  it("returns page and total from one batch", async () => {
+    const db = makeMockDb([a([reviewRow()]), f({ count: 3 })]);
+
+    const result = await getApprovedProductReviews(db, "store_1", "prod_1", 20, 0);
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({ id: "rev_1", rating: 5 });
+    expect(result.total).toBe(3);
+  });
+
+  it("maps an empty page", async () => {
+    const db = makeMockDb([a([]), f({ count: 0 })]);
+
+    const result = await getApprovedProductReviews(db, "store_1", "prod_missing");
+
+    expect(result).toEqual({ rows: [], total: 0 });
+  });
+});
+
+describe("getAllReviews", () => {
+  it("returns rows, total, and pendingCount from one batch", async () => {
+    const db = makeMockDb([
+      a([reviewListRow({ status: "pending" })]),
+      f({ count: 5 }),
+      f({ count: 2 }),
+    ]);
+
+    const result = await getAllReviews(db, { status: "pending", limit: 20, offset: 0 });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({ productName: "T-Shirt", status: "pending" });
+    expect(result.total).toBe(5);
+    expect(result.pendingCount).toBe(2);
+  });
+
+  it("pendingCount is independent of the status filter", async () => {
+    const db = makeMockDb([
+      a([reviewListRow({ status: "approved" })]),
+      f({ count: 3 }),
+      f({ count: 7 }),
+    ]);
+
+    const result = await getAllReviews(db, { status: "approved", limit: 20, offset: 0 });
+
+    expect(result.total).toBe(3);
+    expect(result.pendingCount).toBe(7);
+  });
+});
+
+describe("listAbandonedOrders", () => {
+  it("returns page and total from one batch", async () => {
+    const db = makeMockDb([a([abandonedRow()]), f({ count: 12 })]);
+
+    const result = await listAbandonedOrders(db, { limit: 1, offset: 0 });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({ id: "ab_1", status: "abandoned" });
+    expect(result.total).toBe(12);
+  });
+
+  it("maps an empty page beyond the end", async () => {
+    const db = makeMockDb([a([]), f({ count: 12 })]);
+
+    const result = await listAbandonedOrders(db, { limit: 50, offset: 500 });
+
+    expect(result.rows).toEqual([]);
+    expect(result.total).toBe(12);
+  });
+});
+
+describe("getAbandonedOrderStats", () => {
+  it("derives stats from three counts in one batch", async () => {
+    const db = makeMockDb([
+      f({ count: 3 }),
+      f({ count: 1 }),
+      f({ total: 7500 }),
+    ]);
+
+    const stats = await getAbandonedOrderStats(db);
+
+    expect(stats).toEqual({
+      totalAbandoned: 3,
+      totalConverted: 1,
+      conversionRate: 25,
+      estimatedLostRevenue: 7500,
+    });
+  });
+
+  it("conversion rate rounds; zero attempted → 0%", async () => {
+    const db = makeMockDb([
+      f({ count: 1 }),
+      f({ count: 2 }),
+      f({ total: 0 }),
+    ]);
+
+    const stats = await getAbandonedOrderStats(db);
+
+    expect(stats.conversionRate).toBe(67);
+    expect(stats.estimatedLostRevenue).toBe(0);
+  });
+
+  it("empty table → all zeros, no division by zero", async () => {
+    const db = makeMockDb([
+      f({ count: 0 }),
+      f({ count: 0 }),
+      f({ total: 0 }),
+    ]);
+
+    const stats = await getAbandonedOrderStats(db);
+
+    expect(stats).toEqual({
+      totalAbandoned: 0,
+      totalConverted: 0,
+      conversionRate: 0,
+      estimatedLostRevenue: 0,
+    });
+  });
+});

--- a/cod-server/src/endpoints/stock/stock.overview-e2e.test.ts
+++ b/cod-server/src/endpoints/stock/stock.overview-e2e.test.ts
@@ -1,0 +1,260 @@
+/**
+ * getStockOverview + getStockAlerts — Slice 6 real-D1 E2E.
+ *
+ * Runs the real migrations on an in-memory miniflare D1 and verifies the
+ * SQL UNION replicates the original JS semantics EXACTLY, including the
+ * edge cases:
+ *   • negative inventory → out-of-stock bucket
+ *   • threshold = 0 → alerts disabled (in-stock items never low)
+ *   • inventory == threshold → low-stock (<= boundary)
+ *   • untracked / soft-deleted products excluded
+ *   • inactive variants excluded; variants of non-variant products excluded
+ *   • DRAFT status still included (no status filter — original behavior)
+ *   • variant parent with no variants contributes no SKUs
+ *   • ordering: out-of-stock first, then inventory ascending
+ *   • pagination: limit/offset, page beyond the end, total stays correct
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Miniflare } from "miniflare";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { drizzle } from "drizzle-orm/d1";
+import * as schema from "@/db/schema";
+import type { AppDb } from "@/db";
+import { getStockOverview, getStockAlerts } from "../../../../cod-shared/queries/stock";
+
+const registry: Miniflare[] = [];
+let db: AppDb;
+
+beforeAll(async () => {
+  const mf = new Miniflare({
+    script: "export default { fetch() { return new Response('ok'); } }",
+    modules: true,
+    d1Databases: { DB: "test-db" },
+  });
+  registry.push(mf);
+  const d1 = await mf.getD1Database("DB");
+  const dir = resolve(__dirname, "../../db/migrations");
+  for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql")).sort()) {
+    const statements = readFileSync(`${dir}/${file}`, "utf8")
+      .split("--> statement-breakpoint")
+      .flatMap((s) => s.split(/;\s*\n/))
+      .map((s) => s.replace(/;+\s*$/, "").trim())
+      .filter((s) => s.replace(/--[^\n]*/g, "").trim().length > 0);
+    for (const statement of statements) {
+      await d1.prepare(statement).run();
+    }
+  }
+  db = drizzle(d1 as unknown as D1Database, { schema }) as unknown as AppDb;
+
+  const now = new Date().toISOString();
+  const mk = (
+    id: string,
+    overrides: Partial<typeof schema.products.$inferInsert> = {},
+  ): typeof schema.products.$inferInsert => ({
+    id,
+    name: `Product ${id}`,
+    handle: `h-${id}`,
+    price: 100,
+    hasVariants: false,
+    inventory: 10,
+    trackInventory: true,
+    lowStockThreshold: 5,
+    status: "ACTIVE",
+    visibility: true,
+    showInStore: true,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  });
+
+  const fixtures = [
+    mk("simple-ok", { price: 100, inventory: 50 }),
+    mk("simple-low", { price: 200, inventory: 3 }),
+    mk("simple-out", { price: 300, inventory: 0 }),
+    mk("simple-neg", { price: 100, inventory: -2 }),
+    mk("thr-zero", { price: 100, inventory: 3, lowStockThreshold: 0 }),
+    mk("thr-boundary", { price: 100, inventory: 5, lowStockThreshold: 5 }),
+    mk("untracked", { price: 100, inventory: 0, trackInventory: false }),
+    mk("soft-deleted", { price: 100, inventory: 0, deletedAt: now }),
+    mk("draft-tracked", { price: 100, inventory: 4, status: "DRAFT" }),
+    mk("variant-parent", { hasVariants: true, price: 100 }),
+    mk("variant-parent-untracked", { hasVariants: true, trackInventory: false }),
+    mk("variant-parent-deleted", { hasVariants: true, deletedAt: now }),
+    mk("no-variant-parent", { hasVariants: true, price: 100 }),
+    mk("simple-with-stray-variant", { hasVariants: false, price: 100, inventory: 8 }),
+  ];
+  for (let i = 0; i < fixtures.length; i += 5) {
+    await db.insert(schema.products).values(fixtures.slice(i, i + 5));
+  }
+
+  const variantFixtures = [
+    { id: "vp-a", productId: "variant-parent", sku: "SKU-VP-A", variations: '{"Color":"Red"}', price: 150, inventory: 4, lowStockThreshold: 5, active: true, position: 1, createdAt: now, updatedAt: now },
+    { id: "vp-b", productId: "variant-parent", sku: "SKU-VP-B", variations: '{"Color":"Blue"}', price: 160, inventory: 0, lowStockThreshold: 5, active: true, position: 2, createdAt: now, updatedAt: now },
+    { id: "vp-c", productId: "variant-parent", sku: "SKU-VP-C", variations: '{"Color":"Green"}', price: 170, inventory: 0, lowStockThreshold: 5, active: false, position: 3, createdAt: now, updatedAt: now },
+    { id: "vp-d", productId: "variant-parent", sku: "SKU-VP-D", variations: '{"Color":"Black"}', price: 180, inventory: 60, lowStockThreshold: 5, active: true, position: 4, createdAt: now, updatedAt: now },
+    { id: "u-1", productId: "variant-parent-untracked", sku: "SKU-U-1", variations: '{"Color":"Grey"}', price: 100, inventory: 0, lowStockThreshold: 5, active: true, position: 1, createdAt: now, updatedAt: now },
+    { id: "d-1", productId: "variant-parent-deleted", sku: "SKU-D-1", variations: '{"Color":"White"}', price: 100, inventory: 0, lowStockThreshold: 5, active: true, position: 1, createdAt: now, updatedAt: now },
+    { id: "stray-1", productId: "simple-with-stray-variant", sku: "SKU-STRAY", variations: '{"Color":"Pink"}', price: 100, inventory: 0, lowStockThreshold: 5, active: true, position: 1, createdAt: now, updatedAt: now },
+  ];
+  for (let i = 0; i < variantFixtures.length; i += 6) {
+    await db.insert(schema.productVariants).values(variantFixtures.slice(i, i + 6));
+  }
+}, 120_000);
+
+afterAll(async () => {
+  for (const mf of registry) await mf.dispose();
+});
+
+describe("getStockOverview — real D1", () => {
+  it("replicates the original bucketing and totals exactly", async () => {
+    const overview = await getStockOverview(db);
+
+    const ids = (list: typeof overview.allItems) =>
+      list.map((i) => i.variantId ?? i.productId).sort();
+
+    expect(overview.totalSkus).toBe(11);
+    expect(ids(overview.allItems)).toEqual([
+      "simple-ok", "simple-low", "simple-out", "simple-neg",
+      "thr-zero", "thr-boundary", "draft-tracked",
+      "simple-with-stray-variant",
+      "vp-a", "vp-b", "vp-d",
+    ].sort());
+
+    expect(ids(overview.outOfStockItems)).toEqual(["simple-out", "simple-neg", "vp-b"].sort());
+    expect(ids(overview.lowStockItems)).toEqual(
+      ["simple-low", "thr-boundary", "draft-tracked", "vp-a"].sort(),
+    );
+
+    expect(overview.totalInventoryValue).toBe(
+      50 * 100 + 3 * 200 + 0 * 300 + -2 * 100 +
+      3 * 100 + 5 * 100 + 4 * 100 + 8 * 100 +
+      4 * 150 + 0 * 160 + 60 * 180,
+    );
+
+    expect(overview.currency).toBe("DZD");
+
+    const stray = overview.allItems.find((i) => i.variantId === "stray-1");
+    expect(stray).toBeUndefined();
+    expect(overview.allItems.find((i) => i.variantId === "vp-c")).toBeUndefined();
+    expect(overview.allItems.find((i) => i.variantId === "u-1")).toBeUndefined();
+    expect(overview.allItems.find((i) => i.variantId === "d-1")).toBeUndefined();
+    expect(overview.allItems.find((i) => i.productId === "no-variant-parent")).toBeUndefined();
+    expect(overview.allItems.find((i) => i.productId === "untracked")).toBeUndefined();
+    expect(overview.allItems.find((i) => i.productId === "soft-deleted")).toBeUndefined();
+  });
+
+  it("threshold=0 disables low-stock for in-stock items (not out-of-stock)", async () => {
+    const overview = await getStockOverview(db);
+
+    const thrZero = overview.allItems.find((i) => i.productId === "thr-zero")!;
+    expect(thrZero.inventory).toBe(3);
+    expect(thrZero.lowStockThreshold).toBe(0);
+    expect(overview.lowStockItems.find((i) => i.productId === "thr-zero")).toBeUndefined();
+  });
+
+  it("negative inventory counts as out-of-stock", async () => {
+    const overview = await getStockOverview(db);
+    const neg = overview.allItems.find((i) => i.productId === "simple-neg")!;
+    expect(neg.isOutOfStock).toBe(true);
+  });
+
+  it("orders allItems: out-of-stock first, then inventory ascending", async () => {
+    const overview = await getStockOverview(db);
+
+    const inventories = overview.allItems.map((i) => i.inventory);
+    const firstInStock = inventories.findIndex((inv) => inv > 0);
+    expect(inventories.slice(0, firstInStock).every((inv) => inv <= 0)).toBe(true);
+    expect(inventories.slice(firstInStock)).toEqual(
+      [...inventories.slice(firstInStock)].sort((a, b) => a - b),
+    );
+  });
+
+  it("maps variant labels from variations JSON", async () => {
+    const overview = await getStockOverview(db);
+    const vp = overview.allItems.find((i) => i.variantId === "vp-a")!;
+    expect(vp.variantLabel).toBe("Red");
+    expect(vp.productName).toBe("Product variant-parent");
+
+    const simple = overview.allItems.find((i) => i.productId === "simple-ok")!;
+    expect(simple.variantLabel).toBeNull();
+    expect(simple.variantId).toBeNull();
+  });
+
+  it("returns zeros for an empty catalog", async () => {
+    const mf = new Miniflare({
+      script: "export default { fetch() { return new Response('ok'); } }",
+      modules: true,
+      d1Databases: { DB: "empty-db" },
+    });
+    registry.push(mf);
+    const d1 = await mf.getD1Database("DB");
+    const dir = resolve(__dirname, "../../db/migrations");
+    for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql")).sort()) {
+      const statements = readFileSync(`${dir}/${file}`, "utf8")
+        .split("--> statement-breakpoint")
+        .flatMap((s) => s.split(/;\s*\n/))
+        .map((s) => s.replace(/;+\s*$/, "").trim())
+        .filter((s) => s.replace(/--[^\n]*/g, "").trim().length > 0);
+      for (const statement of statements) {
+        await d1.prepare(statement).run();
+      }
+    }
+    const emptyDb = drizzle(d1 as unknown as D1Database, { schema }) as unknown as AppDb;
+
+    const overview = await getStockOverview(emptyDb);
+    expect(overview).toMatchObject({
+      totalSkus: 0, outOfStockCount: 0, lowStockCount: 0,
+      totalInventoryValue: 0, currency: "DZD",
+    });
+    expect(overview.allItems).toEqual([]);
+
+    const alerts = await getStockAlerts(emptyDb, { limit: 50, offset: 0 });
+    expect(alerts).toEqual({ items: [], total: 0 });
+  }, 120_000);
+});
+
+describe("getStockAlerts — real D1", () => {
+  it("returns only alert SKUs, ordered, with the exact total", async () => {
+    const result = await getStockAlerts(db, { limit: 100, offset: 0 });
+
+    expect(result.total).toBe(7);
+    const keys = result.items.map((i) => i.variantId ?? i.productId);
+    expect(keys.sort()).toEqual(
+      ["simple-out", "simple-neg", "simple-low", "thr-boundary", "draft-tracked", "vp-a", "vp-b"].sort(),
+    );
+
+    const inventories = result.items.map((i) => i.inventory);
+    const firstInStock = inventories.findIndex((inv) => inv > 0);
+    expect(inventories.slice(0, firstInStock).every((inv) => inv <= 0)).toBe(true);
+    expect(inventories.slice(firstInStock)).toEqual(
+      [...inventories.slice(firstInStock)].sort((a, b) => a - b),
+    );
+  });
+
+  it("excludes threshold=0 in-stock items from alerts", async () => {
+    const result = await getStockAlerts(db, { limit: 100, offset: 0 });
+    expect(result.items.find((i) => i.productId === "thr-zero")).toBeUndefined();
+  });
+
+  it("paginates consecutively and keeps the total stable across pages", async () => {
+    const pages = await Promise.all([
+      getStockAlerts(db, { limit: 2, offset: 0 }),
+      getStockAlerts(db, { limit: 2, offset: 2 }),
+      getStockAlerts(db, { limit: 2, offset: 4 }),
+      getStockAlerts(db, { limit: 2, offset: 6 }),
+    ]);
+
+    expect(pages.every((p) => p.total === 7)).toBe(true);
+    expect(pages.map((p) => p.items.length)).toEqual([2, 2, 2, 1]);
+
+    const full = await getStockAlerts(db, { limit: 100, offset: 0 });
+    const concatenated = pages.flatMap((p) => p.items.map((i) => i.variantId ?? i.productId));
+    expect(concatenated).toEqual(full.items.map((i) => i.variantId ?? i.productId));
+
+    const beyond = await getStockAlerts(db, { limit: 50, offset: 500 });
+    expect(beyond.items).toEqual([]);
+    expect(beyond.total).toBe(7);
+  });
+});

--- a/cod-server/src/endpoints/stock/stock.overview-queries.test.ts
+++ b/cod-server/src/endpoints/stock/stock.overview-queries.test.ts
@@ -1,0 +1,134 @@
+/**
+ * getStockOverview + getStockAlerts — Slice 6 mock-queue coverage.
+ *
+ * Call shape post-Slice 6:
+ *   • getStockOverview — ONE raw UNION ALL query (simple products +
+ *     tracked variants), SQL-side ordering; buckets derived in one pass
+ *   • getStockAlerts — ONE filtered UNION query (page) + ONE count query
+ *
+ * WHERE/aggregation/ordering semantics are verified against real D1 in
+ * stock.overview-e2e.test.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+import { makeMockDb, a, f } from "@/test-utils/mock-db";
+import { getStockOverview, getStockAlerts } from "../../../../cod-shared/queries/stock";
+
+function skuRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    product_id: "prod_1",
+    variant_id: null,
+    product_name: "T-Shirt",
+    variations: null,
+    inventory: 2,
+    low_stock_threshold: 5,
+    inventory_value: 3000,
+    is_out_of_stock: 0,
+    ...overrides,
+  };
+}
+
+describe("getStockOverview", () => {
+  it("buckets rows from one query: out-of-stock, low, healthy", async () => {
+    const db = makeMockDb([
+      a([
+        skuRow({ product_id: "p-out", inventory: 0, is_out_of_stock: 1, inventory_value: 0 }),
+        skuRow({ product_id: "p-neg", inventory: -2, is_out_of_stock: 1, inventory_value: -3000 }),
+        skuRow({ product_id: "p-low", inventory: 3 }),
+        skuRow({ product_id: "p-ok", inventory: 50, inventory_value: 75000 }),
+        skuRow({
+          product_id: "p-v",
+          variant_id: "var_1",
+          variations: '{"Color":"Red","Size":"M"}',
+          inventory: 4,
+          inventory_value: 6000,
+        }),
+      ]),
+    ]);
+
+    const overview = await getStockOverview(db);
+
+    expect(overview.totalSkus).toBe(5);
+    expect(overview.outOfStockCount).toBe(2);
+    expect(overview.lowStockCount).toBe(2);
+    expect(overview.totalInventoryValue).toBe(-3000 + 3000 + 75000 + 6000);
+    expect(overview.currency).toBe("DZD");
+
+    expect(overview.outOfStockItems.map((i) => i.productId)).toEqual(["p-out", "p-neg"]);
+    expect(overview.lowStockItems.map((i) => i.productId)).toEqual(["p-low", "p-v"]);
+    expect(overview.allItems).toHaveLength(5);
+    expect(new Set(overview.allItems.map((i) => i.inventory))).toEqual(
+      new Set([0, -2, 3, 50, 4]),
+    );
+  });
+
+  it("parses the variant label from variations JSON", async () => {
+    const db = makeMockDb([
+      a([
+        skuRow({
+          variant_id: "var_1",
+          variations: '{"اللون":"أحمر","المقاس":"M"}',
+        }),
+      ]),
+    ]);
+
+    const overview = await getStockOverview(db);
+
+    expect(overview.allItems[0].variantLabel).toBe("أحمر / M");
+    expect(overview.allItems[0].variantId).toBe("var_1");
+  });
+
+  it("maps a null-variant row to variantLabel null", async () => {
+    const db = makeMockDb([a([skuRow()])]);
+
+    const overview = await getStockOverview(db);
+
+    expect(overview.allItems[0].variantLabel).toBeNull();
+    expect(overview.allItems[0].variantId).toBeNull();
+  });
+
+  it("returns zeros and empty lists for an empty catalog", async () => {
+    const db = makeMockDb([a([])]);
+
+    const overview = await getStockOverview(db);
+
+    expect(overview).toMatchObject({
+      totalSkus: 0,
+      outOfStockCount: 0,
+      lowStockCount: 0,
+      totalInventoryValue: 0,
+      currency: "DZD",
+    });
+    expect(overview.allItems).toEqual([]);
+    expect(overview.outOfStockItems).toEqual([]);
+    expect(overview.lowStockItems).toEqual([]);
+  });
+});
+
+describe("getStockAlerts", () => {
+  it("pages the alert union and returns the total from the count query", async () => {
+    const db = makeMockDb([
+      a([
+        skuRow({ product_id: "p-out", inventory: 0, is_out_of_stock: 1 }),
+        skuRow({ product_id: "p-low", inventory: 2 }),
+      ]),
+      f({ total: 7 }),
+    ]);
+
+    const result = await getStockAlerts(db, { limit: 2, offset: 0 });
+
+    expect(result.items.map((i) => i.productId)).toEqual(["p-out", "p-low"]);
+    expect(result.items[0].isOutOfStock).toBe(true);
+    expect(result.items[1].isOutOfStock).toBe(false);
+    expect(result.total).toBe(7);
+  });
+
+  it("returns an empty page with the correct total beyond the end", async () => {
+    const db = makeMockDb([a([]), f({ total: 7 })]);
+
+    const result = await getStockAlerts(db, { limit: 50, offset: 500 });
+
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(7);
+  });
+});

--- a/cod-server/src/endpoints/store/store.products-list-queries.test.ts
+++ b/cod-server/src/endpoints/store/store.products-list-queries.test.ts
@@ -1,0 +1,96 @@
+/**
+ * getStoreProducts — Slice 5 mock-queue coverage.
+ *
+ * Call shape: ONE main select (products + review subqueries), then ONE read
+ * batch containing the cover-image select(s) and active-variant inventory
+ * aggregate(s). No per-row queries.
+ */
+
+import { describe, it, expect } from "vitest";
+import { makeMockDb, a, productRow } from "@/test-utils/mock-db";
+import { getStoreProducts } from "../../../../cod-shared/queries/store";
+
+describe("getStoreProducts", () => {
+  it("maps cover image, variant inventory, and review stats from one batch", async () => {
+    const db = makeMockDb([
+      a([
+        {
+          ...productRow({ has_variants: 1, inventory: 999 }),
+          avg_rating: 4.7,
+          review_count: 12,
+        },
+      ]),
+      a([{ id: "img_1", product_id: "prod_1", src: "cover.jpg", position: 2 }]),
+      a([{ productId: "prod_1", total: 14 }]),
+    ]);
+
+    const rows = await getStoreProducts(db, {});
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "prod_1",
+      inventory: 14,
+      reviewStats: { avgRating: 4.7, reviewCount: 12 },
+    });
+    expect(rows[0].coverImage).toMatchObject({ id: "img_1", src: "cover.jpg" });
+  });
+
+  it("picks the first cover image by position within a product", async () => {
+    const db = makeMockDb([
+      a([{ ...productRow(), avg_rating: null, review_count: 0 }]),
+      a([
+        { id: "img_b", product_id: "prod_1", src: "first.jpg", position: 1 },
+        { id: "img_a", product_id: "prod_1", src: "second.jpg", position: 2 },
+      ]),
+      a([]),
+    ]);
+
+    const rows = await getStoreProducts(db, {});
+
+    expect(rows[0].coverImage).toMatchObject({ id: "img_b", src: "first.jpg" });
+  });
+
+  it("simple product inventory comes from the product row (no variant sum)", async () => {
+    const db = makeMockDb([
+      a([{ ...productRow({ inventory: 42, has_variants: 0 }), avg_rating: null, review_count: 0 }]),
+      a([]),
+      a([]),
+    ]);
+
+    const rows = await getStoreProducts(db, {});
+
+    expect(rows[0]).toMatchObject({ inventory: 42, coverImage: null });
+  });
+
+  it("variant product with no active variants maps inventory 0", async () => {
+    const db = makeMockDb([
+      a([{ ...productRow({ has_variants: 1, inventory: 999 }), avg_rating: null, review_count: 0 }]),
+      a([]),
+      a([]),
+    ]);
+
+    const rows = await getStoreProducts(db, {});
+
+    expect(rows[0]).toMatchObject({ inventory: 0 });
+  });
+
+  it("null reviewStats when no approved reviews", async () => {
+    const db = makeMockDb([
+      a([{ ...productRow(), avg_rating: null, review_count: 0 }]),
+      a([]),
+      a([]),
+    ]);
+
+    const rows = await getStoreProducts(db, {});
+
+    expect(rows[0].reviewStats).toBeNull();
+  });
+
+  it("returns [] for an empty page without the follow-up batch", async () => {
+    const db = makeMockDb([a([])]);
+
+    const rows = await getStoreProducts(db, {});
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/cod-server/src/endpoints/store/store.queries-e2e.test.ts
+++ b/cod-server/src/endpoints/store/store.queries-e2e.test.ts
@@ -1,0 +1,249 @@
+/**
+ * createStoreOrder + findOrCreateCustomer — Slice 3 real-D1 E2E.
+ *
+ * Runs the real migrations on an in-memory miniflare D1 and proves:
+ *   • findOrCreateCustomer: concurrent same-phone calls converge to ONE row
+ *     (UNIQUE index + ON CONFLICT), stats never split
+ *   • createStoreOrder: one atomic batch — order + lines + history + customer
+ *     stats + deduction movements all land together
+ *   • guarded deduction: inventory goes down by exactly the ordered qty,
+ *     movement log carries correct qtyBefore/qtyAfter
+ *   • BC-2 oversell: when inventory can't cover the order, the guarded
+ *     UPDATE writes 0 rows and the order is rejected whole (no partial writes)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Miniflare } from "miniflare";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { drizzle } from "drizzle-orm/d1";
+import { eq } from "drizzle-orm";
+import * as schema from "@/db/schema";
+import type { AppDb } from "@/db";
+import {
+  findOrCreateCustomer,
+  createStoreOrder,
+} from "../../../../cod-shared/queries/store";
+
+const registry: Miniflare[] = [];
+let db: AppDb;
+
+beforeAll(async () => {
+  const mf = new Miniflare({
+    script: "export default { fetch() { return new Response('ok'); } }",
+    modules: true,
+    d1Databases: { DB: "test-db" },
+  });
+  registry.push(mf);
+  const d1 = await mf.getD1Database("DB");
+  const dir = resolve(__dirname, "../../db/migrations");
+  for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql")).sort()) {
+    const statements = readFileSync(`${dir}/${file}`, "utf8")
+      .split("--> statement-breakpoint")
+      .flatMap((s) => s.split(/;\s*\n/))
+      .map((s) => s.replace(/;+\s*$/, "").trim())
+      .filter((s) => s.replace(/--[^\n]*/g, "").trim().length > 0);
+    for (const statement of statements) {
+      await d1.prepare(statement).run();
+    }
+  }
+  db = drizzle(d1 as unknown as D1Database, { schema }) as unknown as AppDb;
+}, 120_000);
+
+afterAll(async () => {
+  for (const mf of registry) await mf.dispose();
+});
+
+describe("findOrCreateCustomer — race-free upsert (BC-1)", () => {
+  it("converges concurrent same-phone calls to one customer row", async () => {
+    const rows = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        findOrCreateCustomer(db, {
+          phone: "0777000001",
+          name: "Race Tester",
+          wilayaId: 16,
+        }),
+      ),
+    );
+
+    const all = await db
+      .select()
+      .from(schema.customers)
+      .where(eq(schema.customers.phone, "0777000001"))
+      .all();
+    expect(all).toHaveLength(1);
+    expect(new Set(rows.map((r) => r.id)).size).toBe(1);
+    expect(rows[0]).toMatchObject({ phone: "0777000001", name: "Race Tester" });
+  });
+
+  it("updates the name on an existing phone but keeps stats", async () => {
+    const first = await findOrCreateCustomer(db, {
+      phone: "0777000002",
+      name: "Original Name",
+      wilayaId: 16,
+    });
+    await db
+      .update(schema.customers)
+      .set({ totalOrders: 5, totalSpent: 9000 })
+      .where(eq(schema.customers.id, first.id));
+
+    const second = await findOrCreateCustomer(db, {
+      phone: "0777000002",
+      name: "Updated Name",
+      wilayaId: 16,
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(second.name).toBe("Updated Name");
+    expect(second.totalOrders).toBe(5);
+  });
+});
+
+describe("createStoreOrder — atomic commit + guarded deduction (BC-2)", () => {
+  const phone = "0661234567";
+
+  async function seedTrackedProduct(overrides: Partial<typeof schema.products.$inferInsert> = {}) {
+    const id = `prod-${crypto.randomUUID().slice(0, 8)}`;
+    const now = new Date().toISOString();
+    await db.insert(schema.products).values({
+      id,
+      name: "E2E Product",
+      handle: `e2e-${id}`,
+      price: 1500,
+      hasVariants: false,
+      inventory: 10,
+      trackInventory: true,
+      lowStockThreshold: 2,
+      status: "ACTIVE",
+      visibility: true,
+      showInStore: true,
+      storeFeatured: false,
+      createdAt: now,
+      updatedAt: now,
+      ...overrides,
+    });
+    return id;
+  }
+
+  async function seedCustomer(p: string) {
+    return findOrCreateCustomer(db, {
+      phone: p,
+      name: "E2E Buyer",
+      wilayaId: 16,
+    });
+  }
+
+  it("commits order + line + history + stats + deduction in one batch", async () => {
+    const productId = await seedTrackedProduct();
+    const customer = await seedCustomer(phone);
+
+    const result = await createStoreOrder(db, {
+      customerName: customer.name,
+      phone,
+      wilayaId: 16,
+      communeId: "c-16-001",
+      deliveryType: "home",
+      productId,
+      productName: "E2E Product",
+      quantity: 3,
+      pricePerUnit: 1500,
+      customerId: customer.id,
+      deliveryFee: 400,
+    });
+
+    expect(result.price).toBe(4500);
+    expect(result.deliveryFee).toBe(400);
+    expect(result.orderNumber).toMatch(/^ORD-\d{8}-\d{4}$/);
+
+    const order = await db.select().from(schema.orders).where(eq(schema.orders.id, result.id)).get();
+    expect(order).toMatchObject({
+      status: "new",
+      codAmount: 4900,
+      customerId: customer.id,
+    });
+
+    const lines = await db
+      .select()
+      .from(schema.orderProducts)
+      .where(eq(schema.orderProducts.orderId, result.id))
+      .all();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({ quantity: 3, lineTotal: 4500 });
+
+    const history = await db
+      .select()
+      .from(schema.orderStatusHistory)
+      .where(eq(schema.orderStatusHistory.orderId, result.id))
+      .all();
+    expect(history).toHaveLength(1);
+    expect(history[0].status).toBe("new");
+
+    const cust = await db.select().from(schema.customers).where(eq(schema.customers.id, customer.id)).get();
+    expect(cust?.totalOrders).toBe(1);
+    expect(cust?.totalSpent).toBe(4500);
+
+    const product = await db.select().from(schema.products).where(eq(schema.products.id, productId)).get();
+    expect(product?.inventory).toBe(7);
+
+    const movements = await db
+      .select()
+      .from(schema.stockMovements)
+      .where(eq(schema.stockMovements.reference, result.id))
+      .all();
+    expect(movements).toHaveLength(1);
+    expect(movements[0]).toMatchObject({
+      type: "ORDER_DEDUCTED",
+      delta: -3,
+      qtyBefore: 10,
+      qtyAfter: 7,
+    });
+  });
+
+  it("rejects the whole order when inventory cannot cover it (no partial writes)", async () => {
+    const productId = await seedTrackedProduct({ inventory: 1 });
+    const customer = await seedCustomer("0661234599");
+
+    const ordersBefore = await db.select({ id: schema.orders.id }).from(schema.orders).all();
+    const movementsBefore = await db
+      .select({ id: schema.stockMovements.id })
+      .from(schema.stockMovements)
+      .all();
+
+    let failed = false;
+    try {
+      await createStoreOrder(db, {
+        customerName: customer.name,
+        phone: "0661234599",
+        wilayaId: 16,
+        communeId: "c-16-001",
+        deliveryType: "home",
+        productId,
+        productName: "E2E Product",
+        quantity: 3,
+        pricePerUnit: 1500,
+        customerId: customer.id,
+        deliveryFee: 400,
+      });
+    } catch {
+      failed = true;
+    }
+
+    expect(failed).toBe(true);
+
+    const ordersAfter = await db.select({ id: schema.orders.id }).from(schema.orders).all();
+    expect(ordersAfter.length).toBe(ordersBefore.length);
+
+    const movementsAfter = await db
+      .select({ id: schema.stockMovements.id })
+      .from(schema.stockMovements)
+      .all();
+    expect(movementsAfter.length).toBe(movementsBefore.length);
+
+    const product = await db.select().from(schema.products).where(eq(schema.products.id, productId)).get();
+    expect(product?.inventory).toBe(1);
+
+    const cust = await db.select().from(schema.customers).where(eq(schema.customers.id, customer.id)).get();
+    expect(cust?.totalOrders).toBe(0);
+    expect(cust?.totalSpent).toBe(0);
+  });
+});

--- a/cod-server/src/endpoints/store/store.queries.test.ts
+++ b/cod-server/src/endpoints/store/store.queries.test.ts
@@ -1,0 +1,231 @@
+/**
+ * findOrCreateCustomer + createStoreOrder — Slice 3 mock-queue coverage.
+ *
+ * findOrCreateCustomer contract (post-Slice 3):
+ *   • resolves wilaya/commune names, then ONE upsert statement:
+ *     INSERT ... ON CONFLICT(phone) DO UPDATE ... RETURNING
+ *   • returns the RETURNING row — new or existing, race-free
+ *
+ * createStoreOrder contract (post-Slice 3):
+ *   • resolve phase: offer select, SKU selects, trackInventory select,
+ *     inventory reads for each deduction
+ *   • commit phase: ONE db.batch() — order insert, line inserts, history,
+ *     customer stats update, guarded deduction updates + movement inserts
+ */
+
+import { describe, it, expect } from "vitest";
+import { makeMockDb, f, a, offerRow } from "@/test-utils/mock-db";
+import {
+  findOrCreateCustomer,
+  createStoreOrder,
+} from "../../../../cod-shared/queries/store";
+
+const baseOrder = {
+  customerName: "Fatima Zahra",
+  phone: "0661234567",
+  wilayaId: 16,
+  communeId: "c-16-001",
+  address: "Rue des Lilas",
+  deliveryType: "home" as const,
+  productId: "prod_1",
+  productName: "T-Shirt",
+  quantity: 2,
+  pricePerUnit: 1500,
+  notes: "call before delivery",
+};
+
+describe("findOrCreateCustomer", () => {
+  it("upserts by phone and returns the RETURNING row", async () => {
+    const db = makeMockDb([
+      f({ name_ar: "الجزائر" }),
+      f({ name_ar: "باب الزوار" }),
+      a([{ id: "cust_1", name: "Fatima Zahra", phone: "0661234567", wilaya: "الجزائر" }]),
+    ]);
+
+    const row = await findOrCreateCustomer(db, {
+      phone: "0661234567",
+      name: "Fatima Zahra",
+      wilayaId: 16,
+      communeId: "c-16-001",
+    });
+
+    expect(row).toMatchObject({ id: "cust_1", phone: "0661234567" });
+  });
+
+  it("handles a missing commune (null lookup skipped)", async () => {
+    const db = makeMockDb([
+      f({ name_ar: "الجزائر" }),
+      a([{ id: "cust_1", name: "N", phone: "05", wilaya: "الجزائر" }]),
+    ]);
+
+    const row = await findOrCreateCustomer(db, {
+      phone: "05",
+      name: "N",
+      wilayaId: 16,
+    });
+
+    expect(row).toMatchObject({ id: "cust_1" });
+  });
+
+  it("falls back to a generated wilaya label when the wilaya is unknown", async () => {
+    const db = makeMockDb([
+      f(null),
+      a([{ id: "cust_2", name: "N", phone: "07", wilaya: "ولاية 16" }]),
+    ]);
+
+    const row = await findOrCreateCustomer(db, {
+      phone: "07",
+      name: "N",
+      wilayaId: 16,
+    });
+
+    expect(row).toMatchObject({ id: "cust_2" });
+  });
+});
+
+describe("createStoreOrder", () => {
+  it("commits a simple tracked order in one batch", async () => {
+    const db = makeMockDb([
+      a([]),                             // selectApplicableOffer — no candidates
+      f({ sku: "TS-001" }),              // product SKU select
+      f({ track_inventory: 1 }),         // trackInventory select
+      f({ inventory: 10 }),              // readInventoryForDeduct
+    ]);
+
+    const result = await createStoreOrder(db, {
+      ...baseOrder,
+      variantId: undefined,
+      customerId: "cust_1",
+      customerName: "Fatima Zahra",
+      deliveryFee: 400,
+    });
+
+    expect(result).toMatchObject({ price: 3000, deliveryFee: 400 });
+    expect(result.orderNumber).toMatch(/^ORD-\d{8}-\d{4}$/);
+    expect(result.id).toBeTruthy();
+  });
+
+  it("commits a variant-selection order with grouped deductions", async () => {
+    const db = makeMockDb([
+      a([]),                             // offers
+      f({ sku: "TS-RED" }),              // variant SKU (group 1)
+      f({ sku: "TS-BLUE" }),             // variant SKU (group 2)
+      f({ track_inventory: 1 }),         // trackInventory
+      f({ inventory: 4 }),               // inventory variant 1
+      f({ inventory: 2 }),               // inventory variant 2
+    ]);
+
+    const result = await createStoreOrder(db, {
+      ...baseOrder,
+      variantSelections: [
+        { variantId: "var_1", variantLabel: "Red" },
+        { variantId: "var_1", variantLabel: "Red" },
+        { variantId: "var_2", variantLabel: "Blue" },
+      ],
+      customerId: "cust_1",
+      customerName: "Fatima Zahra",
+      deliveryFee: 400,
+    });
+
+    expect(result).toMatchObject({ price: 3000 });
+  });
+
+  it("skips deduction entirely for untracked products", async () => {
+    const db = makeMockDb([
+      a([]),                             // offers
+      f({ sku: "TS-001" }),              // SKU
+      f({ track_inventory: 0 }),         // trackInventory — false
+    ]);
+
+    const result = await createStoreOrder(db, {
+      ...baseOrder,
+      customerId: "cust_1",
+      customerName: "Fatima Zahra",
+      deliveryFee: 400,
+    });
+
+    expect(result).toMatchObject({ price: 3000 });
+  });
+
+  it("applies a free-shipping offer (no reward line, fee zeroed)", async () => {
+    const offer = offerRow({
+      id: "offer_fs",
+      discount_type: "free_shipping",
+      reward_product_id: null,
+    });
+    const db = makeMockDb([
+      f(offer),                          // explicit offerId select
+      f({ sku: "TS-001" }),              // SKU
+      f({ track_inventory: 1 }),         // trackInventory
+      f({ inventory: 10 }),              // inventory
+    ]);
+
+    const result = await createStoreOrder(db, {
+      ...baseOrder,
+      offerId: "offer_fs",
+      customerId: "cust_1",
+      customerName: "Fatima Zahra",
+      deliveryFee: 400,
+    });
+
+    expect(result).toMatchObject({ deliveryFee: 0, price: 3000 });
+  });
+
+  it("adds the reward line and reward deduction for a free-product offer", async () => {
+    const offer = offerRow({
+      id: "offer_b2g1",
+      reward_product_id: "prod_2",
+      reward_variant_id: "var_9",
+    });
+    const db = makeMockDb([
+      f(offer),                          // explicit offer select
+      f({ sku: "TS-001" }),              // order line SKU
+      f({ variations: '{"Color":"Green"}' }), // reward variant variations
+      f({ name: "Socks", track_inventory: 1 }), // reward product
+      f({ inventory: 5 }),               // reward variant inventory (in stock)
+      f({ sku: "SOCK-G" }),              // reward SKU
+      f({ track_inventory: 1 }),         // main product trackInventory
+      f({ inventory: 10 }),              // main product inventory
+      f({ inventory: 5 }),               // reward inventory for deduction
+    ]);
+
+    const result = await createStoreOrder(db, {
+      ...baseOrder,
+      quantity: 2,
+      offerId: "offer_b2g1",
+      customerId: "cust_1",
+      customerName: "Fatima Zahra",
+      deliveryFee: 400,
+    });
+
+    expect(result).toMatchObject({ price: 3000, deliveryFee: 400 });
+  });
+
+  it("skips the reward line when the reward is out of stock", async () => {
+    const offer = offerRow({
+      id: "offer_b2g1",
+      reward_product_id: "prod_2",
+      reward_variant_id: "var_9",
+    });
+    const db = makeMockDb([
+      f(offer),                          // offer
+      f({ sku: "TS-001" }),              // SKU
+      f({ variations: '{"Color":"Green"}' }), // reward variations
+      f({ name: "Socks", track_inventory: 1 }), // reward product
+      f({ inventory: 0 }),               // reward inventory — OUT OF STOCK
+      f({ track_inventory: 1 }),         // main product
+      f({ inventory: 10 }),              // main inventory
+    ]);
+
+    const result = await createStoreOrder(db, {
+      ...baseOrder,
+      quantity: 2,
+      offerId: "offer_b2g1",
+      customerId: "cust_1",
+      customerName: "Fatima Zahra",
+      deliveryFee: 400,
+    });
+
+    expect(result).toMatchObject({ price: 3000 });
+  });
+});

--- a/cod-server/src/test-utils/mock-db.ts
+++ b/cod-server/src/test-utils/mock-db.ts
@@ -9,6 +9,10 @@
  *   f(value)  — next SELECT…get() call returns this row (or null if not found)
  *   a(values) — next SELECT…all() call returns this array
  *
+ * Batch support: statements inside db.batch([...]) that are SELECTs consume
+ * the queue exactly like sequential reads (in statement order); write
+ * statements never consume.
+ *
  * How it works:
  *   Drizzle ORM always routes reads through D1's raw() method (never first()
  *   or all()). raw() must return T[][] — an array of value-arrays, where each
@@ -46,18 +50,33 @@ export const a = (v: Record<string, unknown>[]): Q => ({ _: "a", v });
 export function makeMockDb(queue: Q[] = []): AppDb {
   let idx = 0;
 
-  function makeStmt(): D1PreparedStatement {
-    const stmt: D1PreparedStatement = {
-      bind: (..._args: unknown[]) => makeStmt(),
+  function consume(): Record<string, unknown>[] {
+    const entry = queue[idx++];
+    if (!entry) return [];
+    if (entry._ === "f") return entry.v ? [entry.v] : [];
+    return entry.v;
+  }
 
-      // Drizzle D1 never calls first() or all() for standard queries —
-      // it always goes through values() → raw(). These are kept for
-      // type-compatibility only and do NOT consume from the queue.
+  function makeStmt(sqlText: string): D1PreparedStatement {
+    const stmt: D1PreparedStatement = {
+      bind: (..._args: unknown[]) => makeStmt(sqlText),
+
+      // Drizzle D1 never calls first() for standard or raw queries — kept
+      // for type-compatibility only; does NOT consume from the queue.
       first: <T = unknown>(_colName?: string) => Promise.resolve(null as T | null),
 
-      all: <T = unknown>() =>
-        Promise.resolve({
-          results: [] as T[],
+      // Drizzle D1 never calls all() for standard queries — it goes through
+      // values() → raw(). Raw sql`` templates, however, route through all()
+      // (objects, not value-arrays) and db.get(sql) lands here too via
+      // results[0]. Consume the queue for those.
+      all: <T = unknown>() => {
+        const entry = queue[idx++];
+        let rows: unknown[] = [];
+        if (entry) {
+          rows = entry._ === "f" ? (entry.v ? [entry.v] : []) : entry.v;
+        }
+        return Promise.resolve({
+          results: rows as T[],
           success: true,
           meta: {
             changed_db: false,
@@ -66,10 +85,11 @@ export function makeMockDb(queue: Q[] = []): AppDb {
             served_by: "mock",
             duration: 0,
             size_after: 0,
-            rows_read: 0,
+            rows_read: rows.length,
             rows_written: 0,
           },
-        } as D1Result<T>),
+        } as D1Result<T>);
+      },
 
       run: <T = Record<string, unknown>>() =>
         Promise.resolve({
@@ -93,23 +113,43 @@ export function makeMockDb(queue: Q[] = []): AppDb {
       // must match the Drizzle fieldsList order (schema definition order for
       // full selects, or select-clause order for partial selects).
       raw: ((..._args: unknown[]) => {
-        const entry = queue[idx++];
-        if (!entry) return Promise.resolve([]);
-        if (entry._ === "f") {
-          if (!entry.v) return Promise.resolve([]);
-          return Promise.resolve([Object.values(entry.v)]);
-        }
-        // a() entry — map each row to a value array
-        return Promise.resolve(entry.v.map((r) => Object.values(r)));
+        const rows = consume();
+        return Promise.resolve(rows.map((r) => Object.values(r)));
       }) as D1PreparedStatement["raw"],
     };
+    (stmt as D1PreparedStatement & { __sql: string }).__sql = sqlText;
     return stmt;
   }
 
   const d1 = {
-    prepare: (_sql: string) => makeStmt(),
+    prepare: (sqlText: string) => makeStmt(sqlText),
     dump: () => Promise.resolve(new ArrayBuffer(0)),
-    batch: () => Promise.resolve([] as any),
+    // Drizzle's session.batch() hands us the built statements. SELECT
+    // statements consume one queue entry each (f → single row, a → rows);
+    // writes return an empty result and never touch the queue — same
+    // consumption model as sequential reads, in statement order.
+    batch: (stmts: D1PreparedStatement[]) => {
+      const results = stmts.map((stmt) => {
+        const sqlText = (stmt as D1PreparedStatement & { __sql?: string }).__sql ?? "";
+        const isSelect = /^\s*(select|with)\b/i.test(sqlText.trim());
+        const rows = isSelect ? consume() : [];
+        return {
+          success: true,
+          results: rows,
+          meta: {
+            changed_db: !isSelect,
+            changes: isSelect ? 0 : 1,
+            last_row_id: 0,
+            served_by: "mock",
+            duration: 0,
+            size_after: 0,
+            rows_read: rows.length,
+            rows_written: isSelect ? 0 : 1,
+          },
+        };
+      });
+      return Promise.resolve(results);
+    },
     exec: () => Promise.resolve({ count: 0, duration: 0 } as D1ExecResult),
   } as unknown as D1Database;
 
@@ -177,6 +217,10 @@ export function orderRow(overrides: Record<string, unknown> = {}): Record<string
     photos: null,
     cod_payment_id: null,
     fee_payment_id: null,
+    fbc: null,
+    fbp: null,
+    ip_address: null,
+    user_agent: null,
     created_at: NOW,
     updated_at: NOW,
     ...overrides,

--- a/cod-shared/queries/abandoned-orders.ts
+++ b/cod-shared/queries/abandoned-orders.ts
@@ -5,6 +5,7 @@
 import { eq, and, desc, lt, sql, like, or } from "drizzle-orm";
 import { abandonedOrders, wilayas, communes } from "../db/schema";
 import type { AppDb } from "../db/client";
+import { safeLikeTerm } from "./search";
 
 export interface UpsertAbandonedOrderData {
   sessionId: string;
@@ -154,17 +155,18 @@ export async function listAbandonedOrders(
   }
 
   if (search) {
+    const term = `%${safeLikeTerm(search)}%`;
     conditions.push(
       or(
-        like(abandonedOrders.customerName, `%${search}%`),
-        like(abandonedOrders.phone, `%${search}%`)
+        like(abandonedOrders.customerName, term),
+        like(abandonedOrders.phone, term)
       )
     );
   }
 
   const where = conditions.length > 0 ? and(...conditions) : undefined;
 
-  const [rows, countResult] = await Promise.all([
+  const [rows, countRows] = await db.batch([
     db
       .select()
       .from(abandonedOrders)
@@ -172,17 +174,14 @@ export async function listAbandonedOrders(
       .orderBy(desc(abandonedOrders.createdAt))
       .limit(limit)
       .offset(offset),
-    db
-      .select({ count: sql<number>`count(*)` })
-      .from(abandonedOrders)
-      .where(where),
+    db.select({ count: sql<number>`count(*)` }).from(abandonedOrders).where(where),
   ]);
 
-  return { rows, total: countResult[0]?.count ?? 0 };
+  return { rows, total: countRows[0]?.count ?? 0 };
 }
 
 export async function getAbandonedOrderStats(db: AppDb) {
-  const [totalRow, convertedRow, revenueRow] = await Promise.all([
+  const [totalRows, convertedRows, revenueRows] = await db.batch([
     db
       .select({ count: sql<number>`count(*)` })
       .from(abandonedOrders)
@@ -197,12 +196,12 @@ export async function getAbandonedOrderStats(db: AppDb) {
       .where(eq(abandonedOrders.status, "abandoned")),
   ]);
 
-  const totalAbandoned = totalRow[0]?.count ?? 0;
-  const totalConverted = convertedRow[0]?.count ?? 0;
+  const totalAbandoned = totalRows[0]?.count ?? 0;
+  const totalConverted = convertedRows[0]?.count ?? 0;
   const totalAttempted = totalAbandoned + totalConverted;
   const conversionRate =
     totalAttempted > 0 ? Math.round((totalConverted / totalAttempted) * 100) : 0;
-  const estimatedLostRevenue = revenueRow[0]?.total ?? 0;
+  const estimatedLostRevenue = revenueRows[0]?.total ?? 0;
 
   return { totalAbandoned, totalConverted, conversionRate, estimatedLostRevenue };
 }

--- a/cod-shared/queries/customers.ts
+++ b/cod-shared/queries/customers.ts
@@ -4,7 +4,7 @@
  * deleteCustomer stays in cod-server because it raises BusinessLogicError.
  */
 
-import { eq, and, like, or, inArray, desc } from "drizzle-orm";
+import { eq, and, like, or, desc, exists, sql } from "drizzle-orm";
 import {
   customers,
   orders,
@@ -17,6 +17,7 @@ import {
   communes,
 } from "../db/schema";
 import type { AppDb } from "../db/client";
+import { safeLikeTerm } from "./search";
 
 export interface CustomerFilters {
   wilayaId?: number;
@@ -53,40 +54,49 @@ export async function getAllCustomers(db: AppDb, filters?: CustomerFilters) {
   }
 
   if (filters?.search) {
+    const term = `%${safeLikeTerm(filters.search)}%`;
     conditions.push(
       or(
-        like(customers.name, `%${filters.search}%`),
-        like(customers.phone, `%${filters.search}%`),
+        like(customers.name, term),
+        like(customers.phone, term),
+      ),
+    );
+  }
+
+  if (filters?.groupId) {
+    conditions.push(
+      exists(
+        db
+          .select({ one: sql`1` })
+          .from(customerGroupMembers)
+          .where(
+            and(
+              eq(customerGroupMembers.customerId, customers.id),
+              eq(customerGroupMembers.groupId, filters.groupId),
+            ),
+          ),
+      ),
+    );
+  }
+
+  if (filters?.tagId) {
+    conditions.push(
+      exists(
+        db
+          .select({ one: sql`1` })
+          .from(customerTagAssignments)
+          .where(
+            and(
+              eq(customerTagAssignments.customerId, customers.id),
+              eq(customerTagAssignments.tagId, filters.tagId),
+            ),
+          ),
       ),
     );
   }
 
   const limit = filters?.limit || 50;
   const offset = filters?.offset || 0;
-
-  if (filters?.groupId) {
-    const members = await db
-      .select({ customerId: customerGroupMembers.customerId })
-      .from(customerGroupMembers)
-      .where(eq(customerGroupMembers.groupId, filters.groupId))
-      .all();
-
-    const memberIds = members.map((m) => m.customerId);
-    if (memberIds.length === 0) return [];
-    conditions.push(inArray(customers.id, memberIds));
-  }
-
-  if (filters?.tagId) {
-    const assigned = await db
-      .select({ customerId: customerTagAssignments.customerId })
-      .from(customerTagAssignments)
-      .where(eq(customerTagAssignments.tagId, filters.tagId))
-      .all();
-
-    const assignedIds = assigned.map((a) => a.customerId);
-    if (assignedIds.length === 0) return [];
-    conditions.push(inArray(customers.id, assignedIds));
-  }
 
   if (conditions.length > 0) {
     return await db

--- a/cod-shared/queries/drivers.ts
+++ b/cod-shared/queries/drivers.ts
@@ -9,9 +9,10 @@
  * deleteDriver stays in cod-server because it raises ConflictError.
  */
 
-import { eq, and, like, or, count, sql, inArray, desc } from "drizzle-orm";
+import { eq, and, like, or, count, sql, desc, exists, inArray } from "drizzle-orm";
 import { drivers, driverCompensations, wilayas, orders } from "../db/schema";
 import type { AppDb } from "../db/client";
+import { safeLikeTerm } from "./search";
 
 export interface DriverFilters {
   wilayaId?: number;
@@ -53,26 +54,30 @@ export async function getAllDrivers(db: AppDb, filters?: DriverFilters) {
   }
 
   if (filters?.search) {
+    const term = `%${safeLikeTerm(filters.search)}%`;
     conditions.push(
       or(
-        like(drivers.firstName, `%${filters.search}%`),
-        like(drivers.lastName, `%${filters.search}%`),
-        like(drivers.phone, `%${filters.search}%`),
+        like(drivers.firstName, term),
+        like(drivers.lastName, term),
+        like(drivers.phone, term),
       ),
     );
   }
 
   if (filters?.wilayaId) {
-    const coveringDriverIds = await db
-      .select({ driverId: driverCompensations.driverId })
-      .from(driverCompensations)
-      .where(eq(driverCompensations.wilayaId, filters.wilayaId))
-      .all();
-
-    const ids = [...new Set(coveringDriverIds.map((r) => r.driverId))];
-    if (ids.length === 0) return [];
-
-    conditions.push(inArray(drivers.id, ids));
+    conditions.push(
+      exists(
+        db
+          .select({ one: sql`1` })
+          .from(driverCompensations)
+          .where(
+            and(
+              eq(driverCompensations.driverId, drivers.id),
+              eq(driverCompensations.wilayaId, filters.wilayaId),
+            ),
+          ),
+      ),
+    );
   }
 
   const limit = filters?.limit ?? 50;

--- a/cod-shared/queries/orders.ts
+++ b/cod-shared/queries/orders.ts
@@ -34,12 +34,44 @@ import {
 
 const driversAlias = aliasedTable(drivers, "d");
 
+import { safeLikeTerm } from "./search";
+
 export interface OrderFilters {
   status?: (typeof orders.$inferSelect)["status"] | "all";
   wilayaId?: number;
   search?: string;
   limit?: number;
   offset?: number;
+  /**
+   * Opaque keyset cursor (encodeOrderCursor output): return rows strictly
+   * before (createdAt, id). Takes precedence over offset when set.
+   */
+  cursor?: string;
+}
+
+export function encodeOrderCursor(createdAt: string, id: string): string {
+  return btoa(`${createdAt}|${id}`)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export function parseOrderCursor(
+  cursor: string,
+): { createdAt: string; id: string } | null {
+  try {
+    const b64 = cursor.replace(/-/g, "+").replace(/_/g, "/");
+    const decoded = atob(b64);
+    const sep = decoded.lastIndexOf("|");
+    if (sep <= 0) return null;
+    const createdAt = decoded.slice(0, sep);
+    const id = decoded.slice(sep + 1);
+    if (!id) return null;
+    if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(createdAt)) return null;
+    return { createdAt, id };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -58,13 +90,25 @@ export async function getAllOrders(db: AppDb, filters: OrderFilters = {}) {
   }
 
   if (filters.search) {
+    const term = `%${safeLikeTerm(filters.search)}%`;
     conditions.push(
       or(
-        like(orders.orderNumber, `%${filters.search}%`),
-        like(orders.customerName, `%${filters.search}%`),
-        like(orders.phone, `%${filters.search}%`),
+        like(orders.orderNumber, term),
+        like(orders.customerName, term),
+        like(orders.phone, term),
       ),
     );
+  }
+
+  let offset = filters.offset ?? 0;
+  if (filters.cursor) {
+    const after = parseOrderCursor(filters.cursor);
+    if (after) {
+      conditions.push(
+        sql`(orders.created_at, orders.id) < (${after.createdAt}, ${after.id})`,
+      );
+      offset = 0;
+    }
   }
 
   return db
@@ -75,7 +119,7 @@ export async function getAllOrders(db: AppDb, filters: OrderFilters = {}) {
       driverName: sql<
         string | null
       >`CASE WHEN ${driversAlias.firstName} IS NOT NULL THEN ${driversAlias.firstName} || ' ' || ${driversAlias.lastName} ELSE NULL END`,
-      hasReview: sql<number>`(SELECT count(*) FROM reviews WHERE reviews.order_id = orders.id)`,
+      hasReview: sql<number>`EXISTS (SELECT 1 FROM reviews WHERE reviews.order_id = orders.id)`,
       lastUpdatedBy: sql<
         string | null
       >`(SELECT by FROM order_status_history WHERE order_id = orders.id ORDER BY timestamp DESC LIMIT 1)`,
@@ -85,19 +129,35 @@ export async function getAllOrders(db: AppDb, filters: OrderFilters = {}) {
     .leftJoin(communes, eq(orders.communeId, communes.id))
     .leftJoin(driversAlias, eq(orders.driverId, driversAlias.id))
     .where(conditions.length > 0 ? and(...conditions) : undefined)
-    .orderBy(desc(orders.createdAt))
+    .orderBy(desc(orders.createdAt), desc(orders.id))
     .limit(filters.limit ?? 50)
-    .offset(filters.offset ?? 0)
+    .offset(offset)
     .all();
 }
 
 export async function getOrderById(db: AppDb, orderId: string) {
-  const order = await db.select().from(orders).where(eq(orders.id, orderId)).get();
+  const order = await db
+    .select({
+      ...getTableColumns(orders),
+      wilaya: wilayas.nameAr,
+      commune: communes.nameAr,
+      driverName: sql<
+        string | null
+      >`CASE WHEN ${driversAlias.firstName} IS NOT NULL THEN ${driversAlias.firstName} || ' ' || ${driversAlias.lastName} ELSE NULL END`,
+      labelUrl: companyShipments.labelUrl,
+    })
+    .from(orders)
+    .leftJoin(wilayas, eq(orders.wilayaId, wilayas.id))
+    .leftJoin(communes, eq(orders.communeId, communes.id))
+    .leftJoin(driversAlias, eq(orders.driverId, driversAlias.id))
+    .leftJoin(companyShipments, eq(companyShipments.orderId, orders.id))
+    .where(eq(orders.id, orderId))
+    .get();
 
   if (!order) return null;
 
-  const [orderProductsList, historyRows, shipmentRow] = await Promise.all([
-    db.select().from(orderProducts).where(eq(orderProducts.orderId, orderId)).all(),
+  const [orderProductsList, historyRows] = await db.batch([
+    db.select().from(orderProducts).where(eq(orderProducts.orderId, orderId)),
     db
       .select({
         id: orderStatusHistory.id,
@@ -110,48 +170,11 @@ export async function getOrderById(db: AppDb, orderId: string) {
       .from(orderStatusHistory)
       .leftJoin(users, eq(orderStatusHistory.by, users.id))
       .where(eq(orderStatusHistory.orderId, orderId))
-      .orderBy(desc(orderStatusHistory.timestamp))
-      .all(),
-    db
-      .select({ labelUrl: companyShipments.labelUrl })
-      .from(companyShipments)
-      .where(eq(companyShipments.orderId, orderId))
-      .get(),
-  ]);
-
-  let driverName: string | null = null;
-  if (order.driverId) {
-    const driver = await db
-      .select({ firstName: drivers.firstName, lastName: drivers.lastName })
-      .from(drivers)
-      .where(eq(drivers.id, order.driverId))
-      .get();
-    if (driver) driverName = `${driver.firstName} ${driver.lastName}`.trim();
-  }
-
-  const [wilayaRow, communeRow] = await Promise.all([
-    order.wilayaId
-      ? db
-          .select({ nameAr: wilayas.nameAr })
-          .from(wilayas)
-          .where(eq(wilayas.id, order.wilayaId))
-          .get()
-      : undefined,
-    order.communeId
-      ? db
-          .select({ nameAr: communes.nameAr })
-          .from(communes)
-          .where(eq(communes.id, order.communeId))
-          .get()
-      : undefined,
+      .orderBy(desc(orderStatusHistory.timestamp)),
   ]);
 
   return {
     ...order,
-    wilaya: wilayaRow?.nameAr ?? null,
-    commune: communeRow?.nameAr ?? null,
-    driverName,
-    labelUrl: shipmentRow?.labelUrl ?? null,
     products: orderProductsList,
     statusHistory: historyRows.map((h) => ({
       id: h.id,
@@ -828,6 +851,131 @@ const STATUS_RANK: Record<string, number> = {
   cancelled: 6,
 };
 
+interface RestockLine {
+  lineId: string;
+  productId: string;
+  variantId: string | null;
+  remaining: number;
+}
+
+interface RestockResolved extends RestockLine {
+  qtyBefore: number;
+}
+
+async function resolveRestockLines(
+  db: AppDb,
+  orderId: string,
+): Promise<RestockLine[]> {
+  const ordProductRows = await db
+    .select({
+      id: orderProducts.id,
+      productId: orderProducts.productId,
+      variantId: orderProducts.variantId,
+      quantity: orderProducts.quantity,
+      returnedQuantity: orderProducts.returnedQuantity,
+    })
+    .from(orderProducts)
+    .where(eq(orderProducts.orderId, orderId))
+    .all();
+
+  const lines: RestockLine[] = [];
+  for (const op of ordProductRows) {
+    const remaining = op.quantity - (op.returnedQuantity ?? 0);
+    if (remaining <= 0) continue;
+
+    const productRow = await db
+      .select({ trackInventory: products.trackInventory })
+      .from(products)
+      .where(eq(products.id, op.productId))
+      .get();
+
+    if (!productRow?.trackInventory) continue;
+
+    lines.push({
+      lineId: op.id,
+      productId: op.productId,
+      variantId: op.variantId,
+      remaining,
+    });
+  }
+  return lines;
+}
+
+async function readCurrentInventories(
+  db: AppDb,
+  lines: RestockLine[],
+): Promise<RestockResolved[]> {
+  const resolved: RestockResolved[] = [];
+  for (const line of lines) {
+    const row = await db
+      .select({ inventory: line.variantId ? productVariants.inventory : products.inventory })
+      .from(line.variantId ? productVariants : products)
+      .where(eq(line.variantId ? productVariants.id : products.id, line.variantId ?? line.productId))
+      .get();
+    resolved.push({ ...line, qtyBefore: row?.inventory ?? 0 });
+  }
+  return resolved;
+}
+
+type BatchStatement = Parameters<AppDb["batch"]>[0][number];
+
+function buildRestockStatements(
+  db: AppDb,
+  resolved: RestockResolved[],
+  movementType: "ORDER_CANCELLED" | "ORDER_RETURNED",
+  orderId: string,
+  source: string,
+  now: string,
+): BatchStatement[] {
+  const built: BatchStatement[] = [];
+
+  for (const line of resolved) {
+    const qtyAfter = line.qtyBefore + line.remaining;
+
+    if (line.variantId) {
+      built.push(
+        db
+          .update(productVariants)
+          .set({ inventory: sql`${productVariants.inventory} + ${line.remaining}`, updatedAt: now })
+          .where(eq(productVariants.id, line.variantId)),
+      );
+    } else {
+      built.push(
+        db
+          .update(products)
+          .set({ inventory: sql`${products.inventory} + ${line.remaining}`, updatedAt: now })
+          .where(eq(products.id, line.productId)),
+      );
+    }
+
+    built.push(
+      db.insert(stockMovements).values({
+        id: crypto.randomUUID(),
+        productId: line.productId,
+        variantId: line.variantId,
+        type: movementType,
+        delta: line.remaining,
+        qtyBefore: line.qtyBefore,
+        qtyAfter,
+        reason: null,
+        reference: orderId,
+        createdBy: source,
+        createdByName: source,
+        createdAt: now,
+      }),
+    );
+
+    built.push(
+      db
+        .update(orderProducts)
+        .set({ status: "returned", returnedQuantity: sql`${orderProducts.quantity}` })
+        .where(eq(orderProducts.id, line.lineId)),
+    );
+  }
+
+  return built;
+}
+
 export async function updateOrderStatusWebhook(
   db: AppDb,
   orderId: string,
@@ -855,150 +1003,50 @@ export async function updateOrderStatusWebhook(
     updateFields.deliveryTime = now;
   }
 
-  await db.update(orders).set(updateFields).where(eq(orders.id, orderId));
-
-  await db.insert(orderStatusHistory).values({
-    id: crypto.randomUUID(),
-    orderId,
-    status: newStatus,
-    timestamp: now,
-    by: source,
-  });
+  const statements: BatchStatement[] = [
+    db.update(orders).set(updateFields).where(eq(orders.id, orderId)),
+    db.insert(orderStatusHistory).values({
+      id: crypto.randomUUID(),
+      orderId,
+      status: newStatus,
+      timestamp: now,
+      by: source,
+    }),
+  ];
 
   if (newStatus === "delivered" && order.driverId) {
-    await db
-      .update(drivers)
-      .set({
-        totalDelivered: sql`${drivers.totalDelivered} + 1`,
-        totalEarnings: sql`${drivers.totalEarnings} + ${order.driverFee ?? 0}`,
-        pendingCash: sql`${drivers.pendingCash} + ${order.codAmount ?? 0}`,
-        updatedAt: now,
-      })
-      .where(eq(drivers.id, order.driverId));
+    statements.push(
+      db
+        .update(drivers)
+        .set({
+          totalDelivered: sql`${drivers.totalDelivered} + 1`,
+          totalEarnings: sql`${drivers.totalEarnings} + ${order.driverFee ?? 0}`,
+          pendingCash: sql`${drivers.pendingCash} + ${order.codAmount ?? 0}`,
+          updatedAt: now,
+        })
+        .where(eq(drivers.id, order.driverId)),
+    );
   }
 
   if (newStatus === "cancelled" || newStatus === "returned") {
-    // Update customer totalSpent when order is cancelled/returned via webhook
-    await db
-      .update(customers)
-      .set({
-        totalSpent: sql`MAX(0, ${customers.totalSpent} - ${order.price ?? 0})`,
-      })
-      .where(eq(customers.id, order.customerId));
+    statements.push(
+      db
+        .update(customers)
+        .set({
+          totalSpent: sql`MAX(0, ${customers.totalSpent} - ${order.price ?? 0})`,
+        })
+        .where(eq(customers.id, order.customerId)),
+    );
 
     const movementType =
       newStatus === "cancelled" ? "ORDER_CANCELLED" : "ORDER_RETURNED";
 
-    const ordProductRows = await db
-      .select({
-        id: orderProducts.id,
-        productId: orderProducts.productId,
-        variantId: orderProducts.variantId,
-        quantity: orderProducts.quantity,
-        returnedQuantity: orderProducts.returnedQuantity,
-      })
-      .from(orderProducts)
-      .where(eq(orderProducts.orderId, orderId))
-      .all();
-
-    for (const op of ordProductRows) {
-      const remaining = op.quantity - (op.returnedQuantity ?? 0);
-      if (remaining <= 0) continue;
-
-      const productRow = await db
-        .select({ trackInventory: products.trackInventory })
-        .from(products)
-        .where(eq(products.id, op.productId))
-        .get();
-
-      if (!productRow?.trackInventory) continue;
-
-      if (op.variantId) {
-        const variantRow = await db
-          .select({ inventory: productVariants.inventory })
-          .from(productVariants)
-          .where(eq(productVariants.id, op.variantId))
-          .get();
-
-        const qtyBefore = variantRow?.inventory ?? 0;
-        const qtyAfter = qtyBefore + remaining;
-
-        await db
-          .update(productVariants)
-          .set({ inventory: qtyAfter, updatedAt: now })
-          .where(eq(productVariants.id, op.variantId));
-
-        await db
-          .insert(stockMovements)
-          .values({
-            id: crypto.randomUUID(),
-            productId: op.productId,
-            variantId: op.variantId,
-            type: movementType,
-            delta: remaining,
-            qtyBefore,
-            qtyAfter,
-            reason: null,
-            reference: orderId,
-            createdBy: source,
-            createdByName: source,
-            createdAt: now,
-          })
-          .catch((err) =>
-            console.error(
-              "[webhook][stock] Failed to log",
-              movementType,
-              "movement:",
-              err,
-            ),
-          );
-      } else {
-        const productInventoryRow = await db
-          .select({ inventory: products.inventory })
-          .from(products)
-          .where(eq(products.id, op.productId))
-          .get();
-
-        const qtyBefore = productInventoryRow?.inventory ?? 0;
-        const qtyAfter = qtyBefore + remaining;
-
-        await db
-          .update(products)
-          .set({ inventory: qtyAfter, updatedAt: now })
-          .where(eq(products.id, op.productId));
-
-        await db
-          .insert(stockMovements)
-          .values({
-            id: crypto.randomUUID(),
-            productId: op.productId,
-            variantId: null,
-            type: movementType,
-            delta: remaining,
-            qtyBefore,
-            qtyAfter,
-            reason: null,
-            reference: orderId,
-            createdBy: source,
-            createdByName: source,
-            createdAt: now,
-          })
-          .catch((err) =>
-            console.error(
-              "[webhook][stock] Failed to log",
-              movementType,
-              "movement:",
-              err,
-            ),
-          );
-      }
-
-      await db
-        .update(orderProducts)
-        .set({ status: "returned", returnedQuantity: op.quantity })
-        .where(eq(orderProducts.id, op.id));
-    }
+    const lines = await resolveRestockLines(db, orderId);
+    const resolved = await readCurrentInventories(db, lines);
+    statements.push(...buildRestockStatements(db, resolved, movementType, orderId, source, now));
   }
+
+  await db.batch(statements as [BatchStatement, ...BatchStatement[]]);
 
   return { updated: true };
 }

--- a/cod-shared/queries/products.ts
+++ b/cod-shared/queries/products.ts
@@ -1,6 +1,7 @@
-import { eq, and, like, or, count, sum, isNull, sql } from "drizzle-orm";
+import { eq, and, like, or, sum, isNull, sql, inArray, getTableColumns } from "drizzle-orm";
 import { products, productCategories, productVariants, productImages, reviews } from "../db/schema";
 import type { AppDb } from "../db/client";
+import { safeLikeTerm } from "./search";
 
 export interface VariantOption {
   name: string;
@@ -103,6 +104,17 @@ async function buildProductDetail(db: AppDb, productId: string) {
   };
 }
 
+const MAX_IN_ARRAY_IDS = 90;
+
+function chunkIds(ids: string[]): string[][] {
+  if (ids.length === 0) return [];
+  const chunks: string[][] = [];
+  for (let i = 0; i < ids.length; i += MAX_IN_ARRAY_IDS) {
+    chunks.push(ids.slice(i, i + MAX_IN_ARRAY_IDS));
+  }
+  return chunks;
+}
+
 export async function getAllProducts(db: AppDb, filters?: ProductFilters) {
   const conditions: ReturnType<typeof eq>[] = [];
   conditions.push(isNull(products.deletedAt) as any);
@@ -111,42 +123,69 @@ export async function getAllProducts(db: AppDb, filters?: ProductFilters) {
   if (filters?.status) conditions.push(eq(products.status, filters.status) as any);
   if (filters?.visibility !== undefined) conditions.push(eq(products.visibility, filters.visibility) as any);
   if (filters?.search) {
+    const term = `%${safeLikeTerm(filters.search)}%`;
     conditions.push(or(
-      like(products.name, `%${filters.search}%`),
-      like(products.handle, `%${filters.search}%`),
-      like(products.description, `%${filters.search}%`),
+      like(products.name, term),
+      like(products.handle, term),
     ) as any);
   }
 
   const rows = await db
-    .select()
+    .select({
+      ...getTableColumns(products),
+      reviewCount: sql<number>`(SELECT COUNT(*) FROM reviews WHERE reviews.product_id = products.id AND reviews.status = 'approved')`,
+      avgRating: sql<number | null>`(SELECT ROUND(AVG(r.rating), 1) FROM reviews r WHERE r.product_id = products.id AND r.status = 'approved')`,
+      primaryImageSrc: sql<string | null>`(SELECT src FROM product_images WHERE product_images.product_id = products.id ORDER BY product_images.position LIMIT 1)`,
+    })
     .from(products)
     .where(conditions.length ? and(...conditions) : undefined)
     .limit(filters?.limit ?? 50)
     .offset(filters?.offset ?? 0)
     .all();
 
-  return Promise.all(rows.map(async (p) => {
-    const [variantsCountRow, totalInventoryRow, imagesRow, variantRows, reviewCountRow, avgRatingRow] = await Promise.all([
-      db.select({ count: count() }).from(productVariants).where(eq(productVariants.productId, p.id)).get(),
-      db.select({ total: sum(productVariants.inventory) }).from(productVariants).where(eq(productVariants.productId, p.id)).get(),
-      db.select({ src: productImages.src }).from(productImages).where(eq(productImages.productId, p.id)).orderBy(productImages.position).limit(1).get(),
-      db.select().from(productVariants).where(eq(productVariants.productId, p.id)).orderBy(productVariants.position).all(),
-      db.select({ count: count() }).from(reviews).where(and(eq(reviews.productId, p.id), eq(reviews.status, "approved"))).get(),
-      db.select({ avg: sql<number | null>`ROUND(AVG(${reviews.rating}), 1)` }).from(reviews).where(and(eq(reviews.productId, p.id), eq(reviews.status, "approved"))).get(),
-    ]);
+  if (rows.length === 0) return [];
+
+  const variantRows: (typeof productVariants.$inferSelect)[] = [];
+  for (const chunk of chunkIds(rows.map((p) => p.id))) {
+    const chunkRows = await db
+      .select()
+      .from(productVariants)
+      .where(inArray(productVariants.productId, chunk))
+      .orderBy(productVariants.productId, productVariants.position)
+      .all();
+    variantRows.push(...chunkRows);
+  }
+
+  const variantsByProduct = new Map<string, (typeof productVariants.$inferSelect)[]>();
+  for (const v of variantRows) {
+    const list = variantsByProduct.get(v.productId);
+    if (list) {
+      list.push(v);
+    } else {
+      variantsByProduct.set(v.productId, [v]);
+    }
+  }
+
+  return rows.map((p) => {
+    const { reviewCount, avgRating, primaryImageSrc, ...productData } = p;
+    const variants = variantsByProduct.get(p.id) ?? [];
+    const totalInventory =
+      variants.length > 0
+        ? variants.reduce((sumTotal, v) => sumTotal + v.inventory, 0)
+        : p.inventory;
+
     return {
-      ...p,
+      ...productData,
       variantOptions: p.variantOptions ? JSON.parse(p.variantOptions) : null,
       tags: p.tags ? JSON.parse(p.tags) : [],
-      variantsCount: variantsCountRow?.count ?? 0,
-      totalInventory: Number(totalInventoryRow?.total ?? p.inventory),
-      primaryImageSrc: imagesRow?.src ?? null,
-      variants: variantRows.map((v) => ({ ...v, variations: JSON.parse(v.variations) as Record<string, string> })),
-      reviewCount: reviewCountRow?.count ?? 0,
-      avgRating: avgRatingRow?.avg ?? null,
+      variantsCount: variants.length,
+      totalInventory,
+      primaryImageSrc,
+      variants: variants.map((v) => ({ ...v, variations: JSON.parse(v.variations) as Record<string, string> })),
+      reviewCount,
+      avgRating,
     };
-  }));
+  });
 }
 
 export async function getProductById(db: AppDb, productId: string) {

--- a/cod-shared/queries/reviews.ts
+++ b/cod-shared/queries/reviews.ts
@@ -17,47 +17,43 @@ export async function getAllReviews(db: AppDb, filters: ReviewFilters) {
   if (filters.status) conditions.push(eq(reviews.status, filters.status));
   if (filters.productId) conditions.push(eq(reviews.productId, filters.productId));
 
-  const rows = await db
-    .select({
-      id: reviews.id,
-      storeId: reviews.storeId,
-      productId: reviews.productId,
-      orderId: reviews.orderId,
-      orderNumber: reviews.orderNumber,
-      customerName: reviews.customerName,
-      rating: reviews.rating,
-      title: reviews.title,
-      body: reviews.body,
-      status: reviews.status,
-      helpfulCount: reviews.helpfulCount,
-      createdAt: reviews.createdAt,
-      updatedAt: reviews.updatedAt,
-      productName: products.name,
-    })
-    .from(reviews)
-    .leftJoin(products, eq(reviews.productId, products.id))
-    .where(conditions.length > 0 ? and(...conditions) : undefined)
-    .orderBy(desc(reviews.createdAt))
-    .limit(filters.limit)
-    .offset(filters.offset)
-    .all();
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
 
-  const totalResult = await db
-    .select({ count: sql<number>`count(*)` })
-    .from(reviews)
-    .where(conditions.length > 0 ? and(...conditions) : undefined)
-    .get();
-
-  const pendingResult = await db
-    .select({ count: sql<number>`count(*)` })
-    .from(reviews)
-    .where(eq(reviews.status, "pending"))
-    .get();
+  const [rows, totalRows, pendingRows] = await db.batch([
+    db
+      .select({
+        id: reviews.id,
+        storeId: reviews.storeId,
+        productId: reviews.productId,
+        orderId: reviews.orderId,
+        orderNumber: reviews.orderNumber,
+        customerName: reviews.customerName,
+        rating: reviews.rating,
+        title: reviews.title,
+        body: reviews.body,
+        status: reviews.status,
+        helpfulCount: reviews.helpfulCount,
+        createdAt: reviews.createdAt,
+        updatedAt: reviews.updatedAt,
+        productName: products.name,
+      })
+      .from(reviews)
+      .leftJoin(products, eq(reviews.productId, products.id))
+      .where(where)
+      .orderBy(desc(reviews.createdAt))
+      .limit(filters.limit)
+      .offset(filters.offset),
+    db.select({ count: sql<number>`count(*)` }).from(reviews).where(where),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(reviews)
+      .where(eq(reviews.status, "pending")),
+  ]);
 
   return {
     rows,
-    total: totalResult?.count ?? 0,
-    pendingCount: pendingResult?.count ?? 0,
+    total: totalRows[0]?.count ?? 0,
+    pendingCount: pendingRows[0]?.count ?? 0,
   };
 }
 

--- a/cod-shared/queries/search.ts
+++ b/cod-shared/queries/search.ts
@@ -1,0 +1,28 @@
+/**
+ * Search helpers shared by list queries.
+ *
+ * D1 caps a LIKE/GLOB pattern at 50 bytes (verified: longer patterns fail
+ * with "LIKE or GLOB pattern too complex"). Dashboard searches wrap user
+ * input as `%term%`, so the term itself must stay ≤ 48 bytes. Truncation is
+ * UTF-8-boundary-safe — a cut mid multi-byte character would produce an
+ * invalid pattern string.
+ */
+
+const LIKE_PATTERN_MAX_BYTES = 50;
+const WILDCARD_BYTES = 2;
+
+export function safeLikeTerm(term: string): string {
+  const maxTermBytes = LIKE_PATTERN_MAX_BYTES - WILDCARD_BYTES;
+  const encoder = new TextEncoder();
+  if (encoder.encode(term).length <= maxTermBytes) return term;
+
+  let out = "";
+  let bytes = 0;
+  for (const ch of term) {
+    const chBytes = encoder.encode(ch).length;
+    if (bytes + chBytes > maxTermBytes) break;
+    out += ch;
+    bytes += chBytes;
+  }
+  return out;
+}

--- a/cod-shared/queries/stock.ts
+++ b/cod-shared/queries/stock.ts
@@ -89,125 +89,110 @@ export async function getStockHistory(
 
   const whereClause = and(...conditions)!;
 
-  const [rows, countRow] = await Promise.all([
+  const [rows, countRows] = await db.batch([
     db
       .select()
       .from(stockMovements)
       .where(whereClause)
       .orderBy(desc(stockMovements.createdAt))
       .limit(filters.limit)
-      .offset(filters.offset)
-      .all(),
+      .offset(filters.offset),
     db
       .select({ count: sql<number>`count(*)` })
       .from(stockMovements)
-      .where(whereClause)
-      .get(),
+      .where(whereClause),
   ]);
 
   return {
     movements: rows,
-    total: countRow?.count ?? 0,
+    total: countRows[0]?.count ?? 0,
   };
 }
 
 // ─── Stock Overview ───────────────────────────────────────────────────────────
 
-export async function getStockOverview(db: AppDb): Promise<StockOverview> {
-  const simpleProducts = await db
-    .select({
-      productId: products.id,
-      productName: products.name,
-      inventory: products.inventory,
-      lowStockThreshold: products.lowStockThreshold,
-      price: products.price,
-    })
-    .from(products)
-    .where(
-      and(
-        eq(products.hasVariants, false),
-        eq(products.trackInventory, true),
-        isNull(products.deletedAt),
-      ),
-    )
-    .all();
+interface TrackedSkuRow {
+  product_id: string;
+  variant_id: string | null;
+  product_name: string;
+  variations: string | null;
+  inventory: number;
+  low_stock_threshold: number;
+  inventory_value: number;
+  is_out_of_stock: number;
+}
 
-  const variantRows = await db
-    .select({
-      productId: products.id,
-      productName: products.name,
-      variantId: productVariants.id,
-      variations: productVariants.variations,
-      inventory: productVariants.inventory,
-      lowStockThreshold: productVariants.lowStockThreshold,
-      price: productVariants.price,
-    })
-    .from(productVariants)
-    .innerJoin(products, eq(productVariants.productId, products.id))
-    .where(
-      and(
-        eq(products.hasVariants, true),
-        eq(products.trackInventory, true),
-        isNull(products.deletedAt),
-        eq(productVariants.active, true),
-      ),
-    )
-    .all();
+/**
+ * One UNION ALL over tracked simple products and tracked active variants.
+ * Mirrors the pre-Slice-6 semantics exactly: no status/visibility filter
+ * (untracked, soft-deleted, inactive variants, and variants of
+ * non-variant products are excluded).
+ */
+function trackedSkuSql(alertsOnly: boolean) {
+  const simpleAlertFilter = alertsOnly
+    ? sql` AND (products.inventory <= 0 OR (products.inventory > 0 AND products.inventory <= products.low_stock_threshold))`
+    : sql``;
+  const variantAlertFilter = alertsOnly
+    ? sql` AND (product_variants.inventory <= 0 OR (product_variants.inventory > 0 AND product_variants.inventory <= product_variants.low_stock_threshold))`
+    : sql``;
+
+  return sql`
+    SELECT products.id AS product_id, NULL AS variant_id, products.name AS product_name,
+           NULL AS variations, products.inventory AS inventory,
+           products.low_stock_threshold AS low_stock_threshold,
+           products.inventory * products.price AS inventory_value,
+           products.inventory <= 0 AS is_out_of_stock
+    FROM products
+    WHERE products.has_variants = 0 AND products.track_inventory = 1 AND products.deleted_at IS NULL${simpleAlertFilter}
+    UNION ALL
+    SELECT product_variants.product_id, product_variants.id, products.name,
+           product_variants.variations, product_variants.inventory,
+           product_variants.low_stock_threshold,
+           product_variants.inventory * product_variants.price,
+           product_variants.inventory <= 0
+    FROM product_variants
+    INNER JOIN products ON products.id = product_variants.product_id
+    WHERE products.has_variants = 1 AND products.track_inventory = 1 AND products.deleted_at IS NULL
+      AND product_variants.active = 1${variantAlertFilter}
+  `;
+}
+
+function toAlertItem(row: TrackedSkuRow): StockAlertItem {
+  return {
+    productId: row.product_id,
+    variantId: row.variant_id,
+    productName: row.product_name,
+    variantLabel: row.variations
+      ? Object.values(JSON.parse(row.variations) as Record<string, string>).join(" / ")
+      : null,
+    inventory: row.inventory,
+    lowStockThreshold: row.low_stock_threshold,
+    isOutOfStock: Boolean(row.is_out_of_stock),
+  };
+}
+
+const SKU_ORDER = sql` ORDER BY is_out_of_stock DESC, inventory ASC, product_id ASC, variant_id ASC`;
+
+export async function getStockOverview(db: AppDb): Promise<StockOverview> {
+  const rows = await db.all<TrackedSkuRow>(
+    sql`${trackedSkuSql(false)}${SKU_ORDER}`,
+  );
 
   const outOfStockItems: StockAlertItem[] = [];
   const lowStockItems: StockAlertItem[] = [];
   const allItems: StockAlertItem[] = [];
   let totalInventoryValue = 0;
-  let totalSkus = 0;
 
-  for (const p of simpleProducts) {
-    totalSkus++;
-    totalInventoryValue += p.inventory * p.price;
-
-    const item: StockAlertItem = {
-      productId: p.productId,
-      variantId: null,
-      productName: p.productName,
-      variantLabel: null,
-      inventory: p.inventory,
-      lowStockThreshold: p.lowStockThreshold,
-      isOutOfStock: p.inventory <= 0,
-    };
-
+  for (const row of rows) {
+    const item = toAlertItem(row);
+    totalInventoryValue += row.inventory_value;
     allItems.push(item);
-    if (p.inventory <= 0) outOfStockItems.push(item);
-    else if (p.inventory <= p.lowStockThreshold) lowStockItems.push(item);
+    if (item.isOutOfStock) outOfStockItems.push(item);
+    else if (item.inventory <= item.lowStockThreshold) lowStockItems.push(item);
   }
-
-  for (const v of variantRows) {
-    totalSkus++;
-    totalInventoryValue += v.inventory * v.price;
-
-    const variations = JSON.parse(v.variations) as Record<string, string>;
-    const variantLabel = Object.values(variations).join(" / ");
-
-    const item: StockAlertItem = {
-      productId: v.productId,
-      variantId: v.variantId,
-      productName: v.productName,
-      variantLabel,
-      inventory: v.inventory,
-      lowStockThreshold: v.lowStockThreshold,
-      isOutOfStock: v.inventory <= 0,
-    };
-
-    allItems.push(item);
-    if (v.inventory <= 0) outOfStockItems.push(item);
-    else if (v.inventory <= v.lowStockThreshold) lowStockItems.push(item);
-  }
-
-  allItems.sort((a, b) => {
-    if (a.isOutOfStock !== b.isOutOfStock) return a.isOutOfStock ? -1 : 1;
-    return a.inventory - b.inventory;
-  });
 
   return {
-    totalSkus,
+    totalSkus: allItems.length,
     outOfStockCount: outOfStockItems.length,
     lowStockCount: lowStockItems.length,
     totalInventoryValue,
@@ -224,16 +209,17 @@ export async function getStockAlerts(
   db: AppDb,
   filters: StockAlertsFilters,
 ): Promise<{ items: StockAlertItem[]; total: number }> {
-  const overview = await getStockOverview(db);
-  const all = [...overview.outOfStockItems, ...overview.lowStockItems];
-  all.sort((a, b) => {
-    if (a.isOutOfStock !== b.isOutOfStock) return a.isOutOfStock ? -1 : 1;
-    return a.inventory - b.inventory;
-  });
+  const rows = await db.all<TrackedSkuRow>(
+    sql`${trackedSkuSql(true)}${SKU_ORDER} LIMIT ${filters.limit} OFFSET ${filters.offset}`,
+  );
+  const totalRow = await db.get<{ total: number }>(
+    sql`SELECT COUNT(*) AS total FROM (${trackedSkuSql(true)})`,
+  );
 
-  const total = all.length;
-  const items = all.slice(filters.offset, filters.offset + filters.limit);
-  return { items, total };
+  return {
+    items: rows.map(toAlertItem),
+    total: Number(totalRow?.total ?? 0),
+  };
 }
 
 // ─── Update Threshold ─────────────────────────────────────────────────────────

--- a/cod-shared/queries/store.ts
+++ b/cod-shared/queries/store.ts
@@ -16,6 +16,7 @@ import {
   gte,
   or,
   asc,
+  inArray,
 } from "drizzle-orm";
 import {
   products,
@@ -83,6 +84,17 @@ export async function getStoreConfig(db: AppDb, storeId: string) {
   };
 }
 
+const MAX_IN_ARRAY_IDS = 90;
+
+function chunkIds(ids: string[]): string[][] {
+  if (ids.length === 0) return [];
+  const chunks: string[][] = [];
+  for (let i = 0; i < ids.length; i += MAX_IN_ARRAY_IDS) {
+    chunks.push(ids.slice(i, i + MAX_IN_ARRAY_IDS));
+  }
+  return chunks;
+}
+
 export async function getStoreProducts(
   db: AppDb,
   params: { featured?: boolean; categoryId?: string; limit?: number },
@@ -109,43 +121,64 @@ export async function getStoreProducts(
     .limit(params.limit ?? 24)
     .all();
 
-  return Promise.all(
-    rows.map(async (p) => {
-      const { avgRating, reviewCount, ...productData } = p;
-      const [image, variantInventoryRow] = await Promise.all([
-        db
-          .select()
-          .from(productImages)
-          .where(eq(productImages.productId, p.id))
-          .orderBy(productImages.position)
-          .get(),
-        productData.hasVariants
-          ? db
-              .select({
-                total: sql<number>`COALESCE(SUM(${productVariants.inventory}), 0)`,
-              })
-              .from(productVariants)
-              .where(
-                and(
-                  eq(productVariants.productId, p.id),
-                  eq(productVariants.active, true),
-                ),
-              )
-              .get()
-          : null,
-      ]);
-      const inventory = productData.hasVariants
-        ? variantInventoryRow?.total ?? 0
-        : productData.inventory;
-      return {
-        ...productData,
-        inventory,
-        coverImage: image ?? null,
-        reviewStats:
-          reviewCount > 0 ? { avgRating: avgRating ?? 0, reviewCount } : null,
-      };
-    }),
+  if (rows.length === 0) return [];
+
+  const ids = rows.map((p) => p.id);
+
+  const imageStatements = chunkIds(ids).map((chunk) =>
+    db
+      .select()
+      .from(productImages)
+      .where(inArray(productImages.productId, chunk))
+      .orderBy(productImages.productId, productImages.position),
   );
+  const inventoryStatements = chunkIds(ids).map((chunk) =>
+    db
+      .select({
+        productId: productVariants.productId,
+        total: sql<number>`COALESCE(SUM(${productVariants.inventory}), 0)`,
+      })
+      .from(productVariants)
+      .where(and(inArray(productVariants.productId, chunk), eq(productVariants.active, true)))
+      .groupBy(productVariants.productId),
+  );
+
+  type ImageRow = typeof productImages.$inferSelect;
+  type InventoryRow = { productId: string; total: number };
+  type BatchStatement = Parameters<AppDb["batch"]>[0][number];
+
+  const statements: BatchStatement[] = [...imageStatements, ...inventoryStatements];
+  const batchResults = (await db.batch(
+    statements as [BatchStatement, ...BatchStatement[]],
+  )) as unknown as Array<Array<ImageRow | InventoryRow>>;
+
+  const imageRows = batchResults.slice(0, imageStatements.length).flat() as ImageRow[];
+  const inventoryRows = batchResults.slice(imageStatements.length).flat() as InventoryRow[];
+
+  const coverImageByProduct = new Map<string, typeof productImages.$inferSelect>();
+  for (const image of imageRows) {
+    if (!coverImageByProduct.has(image.productId)) {
+      coverImageByProduct.set(image.productId, image);
+    }
+  }
+  const variantInventoryByProduct = new Map<string, number>();
+  for (const row of inventoryRows) {
+    variantInventoryByProduct.set(row.productId, Number(row.total));
+  }
+
+  return rows.map((p) => {
+    const { avgRating, reviewCount, ...productData } = p;
+    const inventory = productData.hasVariants
+      ? variantInventoryByProduct.get(p.id) ?? 0
+      : productData.inventory;
+    return {
+      ...productData,
+      inventory,
+      coverImage: coverImageByProduct.get(p.id) ?? null,
+      reviewStats:
+        reviewCount > 0 ? { avgRating: avgRating ?? 0, reviewCount } : null,
+    };
+  });
 }
 
 export async function getStoreProductByHandle(db: AppDb, handle: string) {
@@ -291,14 +324,6 @@ export async function findOrCreateCustomer(
   db: AppDb,
   data: { phone: string; name: string; wilayaId: number; communeId?: string },
 ) {
-  const existing = await db
-    .select()
-    .from(customers)
-    .where(eq(customers.phone, data.phone))
-    .get();
-
-  if (existing) return existing;
-
   const [wilayaRecord, communeRecord] = await Promise.all([
     db
       .select({ nameAr: wilayas.nameAr })
@@ -316,19 +341,34 @@ export async function findOrCreateCustomer(
 
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
+  const wilayaName = wilayaRecord?.nameAr ?? `ولاية ${data.wilayaId}`;
+  const communeName = communeRecord?.nameAr ?? null;
 
-  await db.insert(customers).values({
-    id,
-    name: data.name,
-    phone: data.phone,
-    wilayaId: data.wilayaId,
-    communeId: data.communeId ?? null,
-    wilaya: wilayaRecord?.nameAr ?? `ولاية ${data.wilayaId}`,
-    commune: communeRecord?.nameAr ?? null,
-    createdAt: now,
-  });
+  const [row] = await db
+    .insert(customers)
+    .values({
+      id,
+      name: data.name,
+      phone: data.phone,
+      wilayaId: data.wilayaId,
+      communeId: data.communeId ?? null,
+      wilaya: wilayaName,
+      commune: communeName,
+      createdAt: now,
+    })
+    .onConflictDoUpdate({
+      target: customers.phone,
+      set: {
+        name: data.name,
+        wilayaId: data.wilayaId,
+        communeId: data.communeId ?? null,
+        wilaya: wilayaName,
+        commune: communeName,
+      },
+    })
+    .returning();
 
-  return (await db.select().from(customers).where(eq(customers.id, id)).get())!;
+  return row;
 }
 
 export async function getDeliveryFee(
@@ -507,66 +547,80 @@ export async function checkStoreOrderStock(
 
 // ─── Stock deduction + movement log ──────────────────────────────────────────
 
-async function deductStockWithLog(
+interface DeductStockInput {
+  productId: string;
+  variantId: string | null;
+  quantity: number;
+  orderId: string;
+  customerId: string;
+  customerName: string;
+  now: string;
+}
+
+type BatchStatement = Parameters<AppDb["batch"]>[0][number];
+
+/**
+ * Build the write pair (movement log + atomic deduction) for a batch.
+ *
+ * The guard lives in the movement INSERT, not just the UPDATE: qtyBefore and
+ * qtyAfter are subselects with the availability predicate
+ * `inventory >= quantity` baked in. When stock cannot cover the deduction,
+ * the subselects return NULL, the NOT NULL constraint on stock_movements
+ * fails, and D1 rolls back the ENTIRE batch — order, lines, stats, and all.
+ * One round trip, race-free, and the movement log values come from the
+ * database itself rather than a racy pre-read.
+ */
+function buildDeductStatements(
   db: AppDb,
-  {
-    productId,
-    variantId,
-    quantity,
-    orderId,
-    customerId,
-    customerName,
-    now,
-  }: {
-    productId: string;
-    variantId: string | null;
-    quantity: number;
-    orderId: string;
-    customerId: string;
-    customerName: string;
-    now: string;
-  },
-) {
-  let qtyBefore: number;
+  input: DeductStockInput,
+): BatchStatement[] {
+  const { productId, variantId, quantity, orderId, customerId, customerName, now } = input;
 
-  if (variantId) {
-    const row = await db
-      .select({ inventory: productVariants.inventory })
-      .from(productVariants)
-      .where(eq(productVariants.id, variantId))
-      .get();
-    qtyBefore = row?.inventory ?? 0;
-    await db
-      .update(productVariants)
-      .set({ inventory: sql`${productVariants.inventory} - ${quantity}` })
-      .where(eq(productVariants.id, variantId));
-  } else {
-    const row = await db
-      .select({ inventory: products.inventory })
-      .from(products)
-      .where(eq(products.id, productId))
-      .get();
-    qtyBefore = row?.inventory ?? 0;
-    await db
-      .update(products)
-      .set({ inventory: sql`${products.inventory} - ${quantity}` })
-      .where(eq(products.id, productId));
-  }
+  const guard =
+    variantId !== null
+      ? sql`FROM ${productVariants} WHERE ${productVariants.id} = ${variantId} AND ${productVariants.inventory} >= ${quantity}`
+      : sql`FROM ${products} WHERE ${products.id} = ${productId} AND ${products.inventory} >= ${quantity}`;
+  const inventoryColumn =
+    variantId !== null ? productVariants.inventory : products.inventory;
 
-  await db.insert(stockMovements).values({
-    id: crypto.randomUUID(),
-    productId,
-    variantId,
-    type: "ORDER_DEDUCTED",
-    delta: -quantity,
-    qtyBefore,
-    qtyAfter: qtyBefore - quantity,
-    reason: null,
-    reference: orderId,
-    createdBy: customerId,
-    createdByName: customerName,
-    createdAt: now,
-  });
+  const guardedUpdate =
+    variantId !== null
+      ? db
+          .update(productVariants)
+          .set({ inventory: sql`${productVariants.inventory} - ${quantity}`, updatedAt: now })
+          .where(
+            and(
+              eq(productVariants.id, variantId),
+              sql`${productVariants.inventory} >= ${quantity}`,
+            ),
+          )
+      : db
+          .update(products)
+          .set({ inventory: sql`${products.inventory} - ${quantity}`, updatedAt: now })
+          .where(
+            and(
+              eq(products.id, productId),
+              sql`${products.inventory} >= ${quantity}`,
+            ),
+          );
+
+  return [
+    db.insert(stockMovements).values({
+      id: crypto.randomUUID(),
+      productId,
+      variantId,
+      type: "ORDER_DEDUCTED",
+      delta: -quantity,
+      qtyBefore: sql`(SELECT ${inventoryColumn} ${guard})`,
+      qtyAfter: sql`(SELECT ${inventoryColumn} - ${quantity} ${guard})`,
+      reason: null,
+      reference: orderId,
+      createdBy: customerId,
+      createdByName: customerName,
+      createdAt: now,
+    }),
+    guardedUpdate,
+  ];
 }
 
 export async function createStoreOrder(
@@ -594,6 +648,8 @@ export async function createStoreOrder(
       ? data.variantSelections[0].variantLabel ?? null
       : data.variantLabel ?? null;
 
+  // ── Resolve phase (reads — no writes yet) ────────────────────────────────
+
   const activeOffer = await selectApplicableOffer(
     db,
     data.productId,
@@ -607,42 +663,16 @@ export async function createStoreOrder(
 
   const price = data.quantity * data.pricePerUnit;
 
-  await db.insert(orders).values({
-    id,
-    orderNumber,
-    customerId: data.customerId,
-    customerName: data.customerName,
-    phone: data.phone,
-    wilayaId: data.wilayaId,
-    communeId: data.communeId,
-    address: data.address ?? null,
-    price,
-    notes: data.notes ?? null,
-    status: "new",
-    orderType: "online",
-    deliveryMethod: "driver",
-    deliveryType: data.deliveryType,
-    deliveryFee: finalDeliveryFee,
-    driverFee: 0,
-    codAmount: price + finalDeliveryFee,
-    fbc: data.fbc ?? null,
-    fbp: data.fbp ?? null,
-    ipAddress: data.ipAddress ?? null,
-    userAgent: data.userAgent ?? null,
-    createdAt: now,
-    updatedAt: now,
-  });
+  const lineRows: Array<typeof orderProducts.$inferInsert> = [];
 
   if (data.variantSelections && data.variantSelections.length > 0) {
-    const groups = groupVariantSelections(data.variantSelections);
-    for (const group of groups) {
+    for (const group of groupVariantSelections(data.variantSelections)) {
       const varSkuRow = await db
         .select({ sku: productVariants.sku })
         .from(productVariants)
         .where(eq(productVariants.id, group.variantId))
         .get();
-      const groupLineTotal = group.count * data.pricePerUnit;
-      await db.insert(orderProducts).values({
+      lineRows.push({
         id: crypto.randomUUID(),
         orderId: id,
         productId: data.productId,
@@ -652,7 +682,7 @@ export async function createStoreOrder(
         sku: varSkuRow?.sku ?? null,
         quantity: group.count,
         pricePerUnit: data.pricePerUnit,
-        lineTotal: groupLineTotal,
+        lineTotal: group.count * data.pricePerUnit,
         createdAt: now,
       });
     }
@@ -673,7 +703,7 @@ export async function createStoreOrder(
         .get();
       itemSku = prodSkuRow?.sku ?? null;
     }
-    await db.insert(orderProducts).values({
+    lineRows.push({
       id: crypto.randomUUID(),
       orderId: id,
       productId: data.productId,
@@ -688,142 +718,124 @@ export async function createStoreOrder(
     });
   }
 
-  if (activeOffer) {
-    if (activeOffer.discountType === "free_shipping") {
-      // Delivery fee already set to 0 above — nothing more to insert.
-    } else {
-      let resolvedRewardVariantId: string | null = activeOffer.rewardVariantId ?? null;
-      let resolvedRewardVariantLabel: string | null = null;
+  let rewardLine: typeof orderProducts.$inferInsert | null = null;
+  let rewardDeduct: DeductStockInput | null = null;
 
-      if (!resolvedRewardVariantId && activeOffer.rewardProductId === data.productId) {
-        resolvedRewardVariantId = primaryVariantId;
-        resolvedRewardVariantLabel = primaryVariantLabel;
-      } else if (
-        !resolvedRewardVariantId &&
-        activeOffer.rewardProductId &&
-        activeOffer.rewardProductId !== data.productId
-      ) {
-        const defaultVariant = await db
-          .select({ id: productVariants.id, variations: productVariants.variations })
-          .from(productVariants)
-          .where(
-            and(
-              eq(productVariants.productId, activeOffer.rewardProductId),
-              eq(productVariants.active, true),
-            ),
-          )
-          .orderBy(asc(productVariants.position))
-          .get();
-        if (defaultVariant) {
-          resolvedRewardVariantId = defaultVariant.id;
-          resolvedRewardVariantLabel = Object.values(
-            JSON.parse(defaultVariant.variations) as Record<string, string>,
-          ).join(" / ");
-        }
-      } else if (resolvedRewardVariantId) {
-        const rewardVariantRow = await db
-          .select({ variations: productVariants.variations })
-          .from(productVariants)
-          .where(eq(productVariants.id, resolvedRewardVariantId))
-          .get();
-        if (rewardVariantRow) {
-          resolvedRewardVariantLabel = Object.values(
-            JSON.parse(rewardVariantRow.variations) as Record<string, string>,
-          ).join(" / ");
+  if (activeOffer && activeOffer.discountType !== "free_shipping") {
+    let resolvedRewardVariantId: string | null = activeOffer.rewardVariantId ?? null;
+    let resolvedRewardVariantLabel: string | null = null;
+
+    if (!resolvedRewardVariantId && activeOffer.rewardProductId === data.productId) {
+      resolvedRewardVariantId = primaryVariantId;
+      resolvedRewardVariantLabel = primaryVariantLabel;
+    } else if (
+      !resolvedRewardVariantId &&
+      activeOffer.rewardProductId &&
+      activeOffer.rewardProductId !== data.productId
+    ) {
+      const defaultVariant = await db
+        .select({ id: productVariants.id, variations: productVariants.variations })
+        .from(productVariants)
+        .where(
+          and(
+            eq(productVariants.productId, activeOffer.rewardProductId),
+            eq(productVariants.active, true),
+          ),
+        )
+        .orderBy(asc(productVariants.position))
+        .get();
+      if (defaultVariant) {
+        resolvedRewardVariantId = defaultVariant.id;
+        resolvedRewardVariantLabel = Object.values(
+          JSON.parse(defaultVariant.variations) as Record<string, string>,
+        ).join(" / ");
+      }
+    } else if (resolvedRewardVariantId) {
+      const rewardVariantRow = await db
+        .select({ variations: productVariants.variations })
+        .from(productVariants)
+        .where(eq(productVariants.id, resolvedRewardVariantId))
+        .get();
+      if (rewardVariantRow) {
+        resolvedRewardVariantLabel = Object.values(
+          JSON.parse(rewardVariantRow.variations) as Record<string, string>,
+        ).join(" / ");
+      }
+    }
+
+    if (activeOffer.rewardProductId) {
+      const rewardProductRow = await db
+        .select({ name: products.name, trackInventory: products.trackInventory })
+        .from(products)
+        .where(eq(products.id, activeOffer.rewardProductId))
+        .get();
+
+      let rewardInStock = true;
+      if (rewardProductRow?.trackInventory) {
+        if (resolvedRewardVariantId) {
+          const rv = await db
+            .select({ inventory: productVariants.inventory })
+            .from(productVariants)
+            .where(eq(productVariants.id, resolvedRewardVariantId))
+            .get();
+          rewardInStock = (rv?.inventory ?? 0) >= activeOffer.rewardQuantity;
+        } else {
+          const rp = await db
+            .select({ inventory: products.inventory })
+            .from(products)
+            .where(eq(products.id, activeOffer.rewardProductId))
+            .get();
+          rewardInStock = (rp?.inventory ?? 0) >= activeOffer.rewardQuantity;
         }
       }
 
-      if (activeOffer.rewardProductId) {
-        const rewardProductRow = await db
-          .select({ name: products.name, trackInventory: products.trackInventory })
-          .from(products)
-          .where(eq(products.id, activeOffer.rewardProductId))
-          .get();
-
-        let rewardInStock = true;
-        if (rewardProductRow?.trackInventory) {
-          if (resolvedRewardVariantId) {
-            const rv = await db
-              .select({ inventory: productVariants.inventory })
-              .from(productVariants)
-              .where(eq(productVariants.id, resolvedRewardVariantId))
-              .get();
-            rewardInStock = (rv?.inventory ?? 0) >= activeOffer.rewardQuantity;
-          } else {
-            const rp = await db
-              .select({ inventory: products.inventory })
-              .from(products)
-              .where(eq(products.id, activeOffer.rewardProductId))
-              .get();
-            rewardInStock = (rp?.inventory ?? 0) >= activeOffer.rewardQuantity;
-          }
+      if (rewardInStock && rewardProductRow) {
+        let rewardSku: string | null = null;
+        if (resolvedRewardVariantId) {
+          const rv = await db
+            .select({ sku: productVariants.sku })
+            .from(productVariants)
+            .where(eq(productVariants.id, resolvedRewardVariantId))
+            .get();
+          rewardSku = rv?.sku ?? null;
+        } else if (activeOffer.rewardProductId) {
+          const rp = await db
+            .select({ sku: products.sku })
+            .from(products)
+            .where(eq(products.id, activeOffer.rewardProductId))
+            .get();
+          rewardSku = rp?.sku ?? null;
         }
+        rewardLine = {
+          id: crypto.randomUUID(),
+          orderId: id,
+          productId: activeOffer.rewardProductId,
+          productName: rewardProductRow.name,
+          variantId: resolvedRewardVariantId,
+          variantLabel: resolvedRewardVariantLabel
+            ? `${resolvedRewardVariantLabel} — 🎁 مجاني`
+            : "🎁 مجاني",
+          sku: rewardSku,
+          quantity: activeOffer.rewardQuantity,
+          pricePerUnit: 0,
+          lineTotal: 0,
+          createdAt: now,
+        };
 
-        if (rewardInStock && rewardProductRow) {
-          let rewardSku: string | null = null;
-          if (resolvedRewardVariantId) {
-            const rv = await db
-              .select({ sku: productVariants.sku })
-              .from(productVariants)
-              .where(eq(productVariants.id, resolvedRewardVariantId))
-              .get();
-            rewardSku = rv?.sku ?? null;
-          } else if (activeOffer.rewardProductId) {
-            const rp = await db
-              .select({ sku: products.sku })
-              .from(products)
-              .where(eq(products.id, activeOffer.rewardProductId))
-              .get();
-            rewardSku = rp?.sku ?? null;
-          }
-          await db.insert(orderProducts).values({
-            id: crypto.randomUUID(),
-            orderId: id,
+        if (rewardProductRow.trackInventory) {
+          rewardDeduct = {
             productId: activeOffer.rewardProductId,
-            productName: rewardProductRow.name,
             variantId: resolvedRewardVariantId,
-            variantLabel: resolvedRewardVariantLabel
-              ? `${resolvedRewardVariantLabel} — 🎁 مجاني`
-              : "🎁 مجاني",
-            sku: rewardSku,
             quantity: activeOffer.rewardQuantity,
-            pricePerUnit: 0,
-            lineTotal: 0,
-            createdAt: now,
-          });
-
-          if (rewardProductRow.trackInventory) {
-            await deductStockWithLog(db, {
-              productId: activeOffer.rewardProductId,
-              variantId: resolvedRewardVariantId,
-              quantity: activeOffer.rewardQuantity,
-              orderId: id,
-              customerId: data.customerId,
-              customerName: data.customerName,
-              now,
-            });
-          }
+            orderId: id,
+            customerId: data.customerId,
+            customerName: data.customerName,
+            now,
+          };
         }
       }
     }
   }
-
-  await db.insert(orderStatusHistory).values({
-    id: crypto.randomUUID(),
-    orderId: id,
-    status: "new",
-    timestamp: now,
-    by: null,
-  });
-
-  await db
-    .update(customers)
-    .set({
-      totalOrders: sql`${customers.totalOrders} + 1`,
-      totalSpent: sql`${customers.totalSpent} + ${price}`,
-      lastOrderAt: now,
-    })
-    .where(eq(customers.id, data.customerId));
 
   const productRow = await db
     .select({ trackInventory: products.trackInventory })
@@ -831,11 +843,11 @@ export async function createStoreOrder(
     .where(eq(products.id, data.productId))
     .get();
 
+  const deductions: DeductStockInput[] = [];
   if (productRow?.trackInventory) {
     if (data.variantSelections && data.variantSelections.length > 0) {
-      const groups = groupVariantSelections(data.variantSelections);
-      for (const group of groups) {
-        await deductStockWithLog(db, {
+      for (const group of groupVariantSelections(data.variantSelections)) {
+        deductions.push({
           productId: data.productId,
           variantId: group.variantId,
           quantity: group.count,
@@ -845,20 +857,10 @@ export async function createStoreOrder(
           now,
         });
       }
-    } else if (data.variantId) {
-      await deductStockWithLog(db, {
-        productId: data.productId,
-        variantId: data.variantId,
-        quantity: data.quantity,
-        orderId: id,
-        customerId: data.customerId,
-        customerName: data.customerName,
-        now,
-      });
     } else {
-      await deductStockWithLog(db, {
+      deductions.push({
         productId: data.productId,
-        variantId: null,
+        variantId: data.variantId ?? null,
         quantity: data.quantity,
         orderId: id,
         customerId: data.customerId,
@@ -867,6 +869,68 @@ export async function createStoreOrder(
       });
     }
   }
+  if (rewardDeduct) deductions.push(rewardDeduct);
+
+  // ── Commit phase (one atomic batch) ──────────────────────────────────────
+
+  const statements: BatchStatement[] = [
+    db.insert(orders).values({
+      id,
+      orderNumber,
+      customerId: data.customerId,
+      customerName: data.customerName,
+      phone: data.phone,
+      wilayaId: data.wilayaId,
+      communeId: data.communeId,
+      address: data.address ?? null,
+      price,
+      notes: data.notes ?? null,
+      status: "new",
+      orderType: "online",
+      deliveryMethod: "driver",
+      deliveryType: data.deliveryType,
+      deliveryFee: finalDeliveryFee,
+      driverFee: 0,
+      codAmount: price + finalDeliveryFee,
+      fbc: data.fbc ?? null,
+      fbp: data.fbp ?? null,
+      ipAddress: data.ipAddress ?? null,
+      userAgent: data.userAgent ?? null,
+      createdAt: now,
+      updatedAt: now,
+    }),
+  ];
+
+  for (const line of lineRows) {
+    statements.push(db.insert(orderProducts).values(line));
+  }
+  if (rewardLine) {
+    statements.push(db.insert(orderProducts).values(rewardLine));
+  }
+
+  statements.push(
+    db.insert(orderStatusHistory).values({
+      id: crypto.randomUUID(),
+      orderId: id,
+      status: "new",
+      timestamp: now,
+      by: null,
+    }),
+    db
+      .update(customers)
+      .set({
+        totalOrders: sql`${customers.totalOrders} + 1`,
+        totalSpent: sql`${customers.totalSpent} + ${price}`,
+        lastOrderAt: now,
+      })
+      .where(eq(customers.id, data.customerId)),
+  );
+
+  for (const input of deductions) {
+    statements.push(...buildDeductStatements(db, input));
+  }
+
+  await db.batch(statements as [BatchStatement, ...BatchStatement[]]);
 
   return { id, orderNumber, price, deliveryFee: finalDeliveryFee };
 }
@@ -880,34 +944,24 @@ export async function getApprovedProductReviews(
   limit = 20,
   offset = 0,
 ) {
-  const rows = await db
-    .select()
-    .from(reviews)
-    .where(
-      and(
-        eq(reviews.storeId, storeId),
-        eq(reviews.productId, productId),
-        eq(reviews.status, "approved"),
-      ),
-    )
-    .orderBy(desc(reviews.createdAt))
-    .limit(limit)
-    .offset(offset)
-    .all();
+  const approvedWhere = and(
+    eq(reviews.storeId, storeId),
+    eq(reviews.productId, productId),
+    eq(reviews.status, "approved"),
+  );
 
-  const totalResult = await db
-    .select({ count: sql<number>`count(*)` })
-    .from(reviews)
-    .where(
-      and(
-        eq(reviews.storeId, storeId),
-        eq(reviews.productId, productId),
-        eq(reviews.status, "approved"),
-      ),
-    )
-    .get();
+  const [rows, countRows] = await db.batch([
+    db
+      .select()
+      .from(reviews)
+      .where(approvedWhere)
+      .orderBy(desc(reviews.createdAt))
+      .limit(limit)
+      .offset(offset),
+    db.select({ count: sql<number>`count(*)` }).from(reviews).where(approvedWhere),
+  ]);
 
-  return { rows, total: totalResult?.count ?? 0 };
+  return { rows, total: countRows[0]?.count ?? 0 };
 }
 
 /**


### PR DESCRIPTION
## Summary

Optimizes the cod-shared query layer and D1 schema per Cloudflare's documented best practices so stores keep performing as `orders`, `customers`, and `stock_movements` grow. Nine focused slices: schema indexes first, then write paths, then reads. **Nothing here changes what the API returns — only how it gets there.**

## What changed

**Migrations (append-only, `IF NOT EXISTS`)**
| Migration | Content |
|---|---|
| `0014_add_indexes` | 21 indexes across all core business tables (they previously had zero) |
| `0015_customers_phone_unique` | `UNIQUE(phone)` — closes the duplicate-customer race |
| `0016_variants_product_position` | composite for the batched variant fetch (was SCAN + temp B-tree) |
| `0017_orders_keyset_indexes` | `(created_at DESC, id DESC)` + extended status composite |

Every hot query was verified with `EXPLAIN QUERY PLAN` before/after — full `SCAN` → `SEARCH ... USING INDEX` on local and **production** D1.

**Write paths (atomic)**
- `createStoreOrder` (~15-25 sequential writes) and `updateOrderStatusWebhook` → resolve reads, then ONE `db.batch()` transaction. No partial state on failure; the `.catch(console.error)` movement-log gaps are gone.
- Oversell guard: stock deduction lives inside the movement INSERT via `inventory >= qty` subselects — insufficient stock fails the NOT NULL constraint and rolls back the whole order.
- `findOrCreateCustomer` → single `INSERT ... ON CONFLICT(phone) DO UPDATE ... RETURNING`.

**Read paths (constant query counts)**
- `getAllProducts` ~301 queries/page → 2 · `getStoreProducts` ~49 → 2 · `getOrderById` 7 → 2 · stock overview whole-catalog load → one UNION ALL · list+count pairs → one batch.
- `inArray` → `EXISTS` for customer group/tag + driver wilaya filters — removes the latent **500 on any group with >100 members** (D1's bound-param limit).
- Keyset cursor pagination on orders (offset still works; cursor takes precedence) — deep pages stay index-served, and the `(createdAt, id)` tie-breaker makes pagination deterministic.
- LIKE guard (`safeLikeTerm`): D1 caps LIKE patterns at 50 bytes — longer staff searches previously **crashed the endpoint**; now truncated on UTF-8 boundaries.

## Intentional behavior changes (2)

1. **BC-1**: concurrent same-phone signups converge to one customer row (was: silent duplicate rows with split stats). Remote duplicate-phone audit ran before migration: **0 rows**.
2. **BC-2**: an order that would oversell stock is rejected whole with the existing out-of-stock error (was: silent clamp to 0).

## Verification

- `npm run typecheck` + `npm test` + build: green in **cod-server** (108 files / **1608 tests**), **cod-client-astro** (142 tests, build), **theme01** (`astro check` 0 errors, 10 tests, build).
- +152 new tests: mock-queue shape tests and **real-D1 E2E on miniflare running the actual migrations** — atomicity rollback proof, oversell rejection with zero partial writes, 150-member-group crash case, same-timestamp pagination equivalence, crash-case searches.
- Real bugs caught by that E2E along the way: drizzle's bare-column rendering breaking correlated subqueries on single-table selects, and the 50-byte LIKE cap.

## Deployment note

Migrations 0014-0017 are **already applied to production D1** and the worker is already deployed (`https://api.codflow.store`, version `156757db`, `/health` 200, EXPLAIN proofs re-run against prod). This PR brings the code into the repository; merge order does not affect the live system.

`report-md/` working documents are intentionally not part of this PR.