### PR TITLE
docs: align setup skill, docs and security suite with unified .env cloud config (#100 follow-up)

### DIFF
--- a/.agents/skills/codflow-setup/SKILL.md
+++ b/.agents/skills/codflow-setup/SKILL.md
@@ -143,6 +143,8 @@ the migration wrapper (`cod-server/scripts/d1.mjs`) and the R2 setup all read
 ```bash
 cp .env.example .env      # at the repo root
 # COD_DB_NAME=<your database name>
+# COD_SERVER_URL=https://<your api domain>  # required BEFORE theme01 deploy —
+#   npm run deploy refuses a localhost value (the default) without --force-local
 ```
 
 The `database_name` / `database_id` in each `wrangler.toml` still has to match
@@ -168,9 +170,9 @@ While editing, also replace the example domains in `[vars]` /
 `[env.production.vars]` (`WORKER_URL`, `BETTER_AUTH_URL`, `WORKER_SELF_URL`,
 `PUBLIC_APP_URL`, `PUBLIC_API_URL`, `PUBLIC_TRUSTED_ORIGINS`) with the
 developer's real URLs when they are known; localhost defaults are correct for
-local runs. In `cod-astro/theme01/wrangler.jsonc`, set `COD_SERVER_URL` to the
-cod-server public URL before deploying the storefront (localhost default is
-correct for local dev only).
+local runs. The storefront's `COD_SERVER_URL` is NOT set in
+`cod-astro/theme01/wrangler.jsonc` — it is injected at deploy time by
+`npm run deploy` from `COD_SERVER_URL` in the root `.env`.
 
 Also create the dashboard's build-time client env:
 
@@ -376,10 +378,11 @@ cd ../cod-astro/theme01 && env -u CLOUDFLARE_ACCOUNT_ID npm run deploy     # ast
 redeploy:** Once workers are live, set `PUBLIC_APP_URL` /
 `PUBLIC_API_URL` / `PUBLIC_TRUSTED_ORIGINS` (cod-client-astro wrangler.toml
 `[vars]`), `WORKER_URL`, `WORKER_SELF_URL`, `BETTER_AUTH_URL` (cod-server
-wrangler.toml `[vars]`), and `COD_SERVER_URL` (theme01 wrangler.jsonc) to the
-actual deployed URLs, then redeploy affected workers. For the dashboard also
-update `.env` (`PUBLIC_API_URL`) and **rebuild** — it is baked into the client
-bundle at build time. Skipping this causes browser sign-in failures (R6/R7).
+wrangler.toml `[vars]`), and `COD_SERVER_URL` (root `.env` — the theme01
+deploy script reads it) to the actual deployed URLs, then redeploy affected
+workers. For the dashboard also update `.env` (`PUBLIC_API_URL`) and
+**rebuild** — it is baked into the client bundle at build time. Skipping this
+causes browser sign-in failures (R6/R7).
 
 Smoke-test after each deploy; do not continue past a failing check:
 
@@ -410,6 +413,29 @@ workers.dev cannot load products from a cod-server also on workers.dev. For a
 production storefront, put cod-server on a custom domain/route and point
 `COD_SERVER_URL` at it (or wire a Service Binding), then re-deploy theme01 and
 confirm `/products` shows the seeded catalog. Local development is unaffected.
+
+## Step 6b — Optional: Transactional Email (Sendili)
+
+Offer this to the developer after the smoke tests pass; skip entirely if they
+decline — the feature is inert by default (no `store_email_config` row).
+
+1. Ask the developer to: create a [sendili.com](https://sendili.com) account,
+   buy credits, **verify their sending domain** (DNS records in the Sendili
+   dashboard), and create an API key (`sk_live_…`).
+2. In the deployed dashboard: sign in as admin → **Settings → Email Sending** →
+   paste the key (domains auto-load) → set the from address by typing the
+   local part (`support`, `notify`…) and picking the verified domain →
+   toggle **Enable email sending** → **Save**.
+3. Verify: **Test connection** shows `Connection OK` with the domain listed;
+   then invite a team member with an email the developer can check and
+   confirm the invite email arrives (sign-in link + temporary password), and
+   that the invited member can sign in.
+4. Docs: `docs/EMAIL-SENDING.md` (feature guide) and
+   `docs/adr/0001-sendili-key-at-rest.md` (key storage decision).
+
+No wrangler secrets, no worker config — the key lives in D1
+(`store_email_config`, applied by migration `0013` in Step 5) and is masked
+in every API response.
 
 ## Step 7 — Closing Summary (Mandatory)
 

--- a/.agents/skills/whatsapp-otp/PLAN.md
+++ b/.agents/skills/whatsapp-otp/PLAN.md
@@ -286,7 +286,7 @@ the dzverify key enters only via the dashboard → D1.
 
 ## Production rollout checklist (human steps)
 
-1. `cd cod-server && npx wrangler d1 migrations apply codflow-os-db --remote`
+1. `cd cod-server && npm run db:migrate:remote`
 2. Deploy cod-server (`npx wrangler deploy --env production`)
 3. Build + deploy theme01 (`npm run build` + `wrangler deploy`) and
    cod-client-astro (`npm run build` + `npx wrangler deploy`)

--- a/.opencode/skills/codflow-setup/SKILL.md
+++ b/.opencode/skills/codflow-setup/SKILL.md
@@ -143,6 +143,8 @@ the migration wrapper (`cod-server/scripts/d1.mjs`) and the R2 setup all read
 ```bash
 cp .env.example .env      # at the repo root
 # COD_DB_NAME=<your database name>
+# COD_SERVER_URL=https://<your api domain>  # required BEFORE theme01 deploy —
+#   npm run deploy refuses a localhost value (the default) without --force-local
 ```
 
 The `database_name` / `database_id` in each `wrangler.toml` still has to match
@@ -168,9 +170,9 @@ While editing, also replace the example domains in `[vars]` /
 `[env.production.vars]` (`WORKER_URL`, `BETTER_AUTH_URL`, `WORKER_SELF_URL`,
 `PUBLIC_APP_URL`, `PUBLIC_API_URL`, `PUBLIC_TRUSTED_ORIGINS`) with the
 developer's real URLs when they are known; localhost defaults are correct for
-local runs. In `cod-astro/theme01/wrangler.jsonc`, set `COD_SERVER_URL` to the
-cod-server public URL before deploying the storefront (localhost default is
-correct for local dev only).
+local runs. The storefront's `COD_SERVER_URL` is NOT set in
+`cod-astro/theme01/wrangler.jsonc` — it is injected at deploy time by
+`npm run deploy` from `COD_SERVER_URL` in the root `.env`.
 
 Also create the dashboard's build-time client env:
 
@@ -376,10 +378,11 @@ cd ../cod-astro/theme01 && env -u CLOUDFLARE_ACCOUNT_ID npm run deploy     # ast
 redeploy:** Once workers are live, set `PUBLIC_APP_URL` /
 `PUBLIC_API_URL` / `PUBLIC_TRUSTED_ORIGINS` (cod-client-astro wrangler.toml
 `[vars]`), `WORKER_URL`, `WORKER_SELF_URL`, `BETTER_AUTH_URL` (cod-server
-wrangler.toml `[vars]`), and `COD_SERVER_URL` (theme01 wrangler.jsonc) to the
-actual deployed URLs, then redeploy affected workers. For the dashboard also
-update `.env` (`PUBLIC_API_URL`) and **rebuild** — it is baked into the client
-bundle at build time. Skipping this causes browser sign-in failures (R6/R7).
+wrangler.toml `[vars]`), and `COD_SERVER_URL` (root `.env` — the theme01
+deploy script reads it) to the actual deployed URLs, then redeploy affected
+workers. For the dashboard also update `.env` (`PUBLIC_API_URL`) and
+**rebuild** — it is baked into the client bundle at build time. Skipping this
+causes browser sign-in failures (R6/R7).
 
 Smoke-test after each deploy; do not continue past a failing check:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,8 +113,8 @@ npm ci
 
 ```bash
 wrangler login
-wrangler d1 create codflow-os-db
-wrangler r2 bucket create codflow-images
+wrangler d1 create <your-db-name>       # set COD_DB_NAME in the root .env
+wrangler r2 bucket create <your-bucket> # set COD_R2_BUCKET_NAME in the root .env
 wrangler kv namespace create RATE_LIMIT
 wrangler kv namespace create OAUTH_KV
 ```
@@ -179,7 +179,8 @@ Open **three terminals**, one per package (D1 state is shared through
 | 3 | `cd cod-astro/theme01 && npm run dev`       | Storefront on `http://localhost:4321` — run `astro dev --port 4322` when the dashboard is up |
 
 Inspect the shared DB any time:
-`wrangler d1 execute codflow-os-db --local --persist-to ../.wrangler-shared --command "…"`
+`cd cod-server && node scripts/d1.mjs execute --local --persist-to ../.wrangler-shared --command "…"`
+(DB name comes from `COD_DB_NAME` in the root `.env`)
 
 ---
 

--- a/cod-astro/theme01/AGENTS.md
+++ b/cod-astro/theme01/AGENTS.md
@@ -51,7 +51,10 @@ tests for cod-server, cod-client-astro, and the legacy cod-client).
   load-bearing: it keeps a single Vite major across astro/vitest/plugins.
   Removing it reintroduces a dev-server boot crash; bump it together with
   astro's Vite major. `npm ls vite` must show one version.
-- `wrangler.jsonc` ships a local `COD_SERVER_URL` var. Real secrets go in
-  `.dev.vars` (gitignored) or `wrangler secret put` — never in `wrangler.jsonc`.
+- `COD_SERVER_URL` is never set in `wrangler.jsonc` — `npm run deploy`
+  (scripts/deploy.mjs) injects it at deploy time from the repo-root `.env`
+  and refuses a localhost value without `--force-local`. Local dev reads it
+  from this package's `.dev.vars`. Real secrets go in `.dev.vars` (gitignored)
+  or `wrangler secret put` — never in `wrangler.jsonc`.
 - `MEDIA_DOMAIN` is optional; unset, the image optimizer passes URLs through
   unchanged.

--- a/cod-server/README.md
+++ b/cod-server/README.md
@@ -43,8 +43,8 @@ database, and bucket is a placeholder you replace with your own resources.
 
    ```bash
    wrangler login
-   wrangler d1 create codflow-os-db       # → copy the returned database_id into wrangler.toml
-   wrangler r2 bucket create codflow-images # → match bucket_name in wrangler.toml
+   wrangler d1 create <your-db-name>   # → copy the returned database_id into wrangler.toml, set COD_DB_NAME in the root .env
+   wrangler r2 bucket create <your-bucket> # → match bucket_name in wrangler.toml, set COD_R2_BUCKET_NAME in the root .env
    wrangler kv namespace create RATE_LIMIT  # → kv id
    wrangler kv namespace create OAUTH_KV    # → kv id (MCP OAuth provider)
    ```

--- a/cod-server/scripts/security/lib/common.sh
+++ b/cod-server/scripts/security/lib/common.sh
@@ -10,10 +10,15 @@
 #   admin                   → any non-40x
 
 BASE_URL="${BASE_URL:-http://localhost:8787}"
-DB_NAME="codflow-os-db"
-PARALLEL="${PARALLEL:-12}"
+# D1 database name from the unified root .env (COD_DB_NAME) — override with
+# DB_NAME=<name> if needed. See cod-server/scripts/cloud-env.mjs.
 SEC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SERVER_DIR="$SEC_DIR/../.."
+if [[ -z "${DB_NAME:-}" ]]; then
+  DB_NAME="$(node -e "import('$SERVER_DIR/scripts/cloud-env.mjs').then(m => process.stdout.write(m.getCloudEnv().dbName))")" \
+    || DB_NAME="codflow-os-db"
+fi
+PARALLEL="${PARALLEL:-12}"
 KEYS_CACHE="/tmp/codflow-sectest-keys.${DB_NAME}.txt"
 EP_FILE=""
 OUT_FILE=""

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -140,13 +140,14 @@ BETTER_AUTH_SECRET=<your-generated-secret>
 
 ### wrangler.jsonc
 
+No `COD_SERVER_URL` here — `npm run deploy` (scripts/deploy.mjs) injects it
+at deploy time from the repo-root `.env`. Deploy refuses a localhost value
+unless `--force-local` is passed. Only set the worker `name` in this file.
+
 ```jsonc
 {
   "name": "mystore-store",
-  "compatibility_date": "2025-01-21",
-  "vars": {
-    "COD_SERVER_URL": "https://api.yourdomain.com"
-  }
+  "compatibility_date": "2025-01-21"
 }
 ```
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -136,7 +136,7 @@ cd ../cod-astro/theme01 && npm run build && npm run deploy
    - `PUBLIC_APP_URL` + `PUBLIC_TRUSTED_ORIGINS` (cod-client-astro wrangler.toml) → your dashboard URL
    - `.env` `PUBLIC_API_URL` (cod-client-astro) → your API URL — then **rebuild** (it is baked into the client bundle)
    - `WORKER_URL`, `BETTER_AUTH_URL`, `WORKER_SELF_URL` (cod-server wrangler.toml) → your API + dashboard URLs
-   - `COD_SERVER_URL` (cod-astro/theme01/wrangler.jsonc) → your API URL
+   - `COD_SERVER_URL` (repo-root `.env`) → your API URL — the theme01 deploy script injects it at deploy time (never in wrangler.jsonc)
 3. Redeploy affected workers
 
 ---

--- a/docs/EMAIL-SENDING.md
+++ b/docs/EMAIL-SENDING.md
@@ -155,7 +155,9 @@ account, key, and credits are untouched; re-enabling is instant.
 
 - **One-time setup:** apply migration `0013_store_email_config.sql` to the
   remote D1 before the feature can be configured in production
-  (`npx wrangler d1 migrations apply codflow-os-db --remote` in `cod-server`).
+  (`npx wrangler d1 migrations apply <your-db-name> --remote` in `cod-server`;
+  the DB name comes from `COD_DB_NAME` in the root `.env` — or use
+  `npm run db:migrate:remote`).
 - The Sendili key is stored per-store in D1 (`store_email_config`), never in
   wrangler secrets, and never sent to the browser — it is merchant
   integration config, the same as carrier tokens and the dzverify key.

--- a/docs/WHATSAPP-OTP-VERIFICATION.md
+++ b/docs/WHATSAPP-OTP-VERIFICATION.md
@@ -159,7 +159,9 @@ reversible by re-enabling.
 
 - **One-time setup:** apply migration `0012_store_otp_config.sql` to the
   remote D1 before the feature can be configured in production
-  (`npx wrangler d1 migrations apply codflow-os-db --remote` in `cod-server`).
+  (`npx wrangler d1 migrations apply <your-db-name> --remote` in `cod-server`;
+  the DB name comes from `COD_DB_NAME` in the root `.env` — or use
+  `npm run db:migrate:remote`).
 - The dzverify key is stored per-store in D1 (`store_otp_config`), never in
   wrangler secrets, and never sent to the browser — it is merchant integration
   config, the same as carrier tokens and the Meta pixel token.


### PR DESCRIPTION
Follow-up to #100 (merged). The code was verified and merged; this closes the docs/config drift it left behind.

## What

- **Setup skill (both `.agents` and `.opencode` copies)**: removed stale instructions to set `COD_SERVER_URL` in `cod-astro/theme01/wrangler.jsonc` (that vars block no longer exists); documented that `COD_SERVER_URL` is set in the root `..env` and that `npm run deploy` refuses a localhost value without `--force-local`. Synced the `.agents` copy, which was also missing the Step 6b Sendili section.
- **`cod-server/scripts/security/lib/common.sh`**: `DB_NAME` now resolves via `cod-server/scripts/cloud-env.mjs` (root `.env` `COD_DB_NAME`), keeping the `DB_NAME=<name>` env override and a safe fallback — this was the one remaining script hardcode and the reason the setup skill's grep gate failed.
- **`docs/DEPLOYMENT.md`, `docs/CONFIGURATION.md`, `cod-astro/theme01/AGENTS.md`**: replaced instructions pointing at the removed `vars` block with the new `.env`-driven deploy flow.
- **De-hardcoded `codflow-os-db`** in example commands: `cod-server/README.md`, `CONTRIBUTING.md`, `docs/EMAIL-SENDING.md`, `docs/WHATSAPP-OTP-VERIFICATION.md`, `.agents/skills/whatsapp-otp/PLAN.md` — commands now reference `COD_DB_NAME` / `npm run db:migrate:remote` / `node scripts/d1.mjs`.

## Verification

- Full cod-server suite: 1832 tests passing
- `common.sh`: `bash -n` + sourced resolution check (`DB_NAME=codflow-os-db` from `.env`, override works)
- Repo grep sweep: no `codflow-os-db` left in scripts/docs (only by-design defaults in `cloud-env.mjs`, `.env.example`, wrangler templates)

Docs-only change except `common.sh`, which is behavior-compatible (same default, now overridable via `.env`).