### PR TITLE
fix(zr-express): production hardening from live API audit + label CORS fix

### DIFF
--- a/.agents/skills/zr-express/CONFORMANCE.md
+++ b/.agents/skills/zr-express/CONFORMANCE.md
@@ -1,0 +1,205 @@
+# ZR Express — Conformance & Live-Audit Report
+
+**Date:** 2026-09-10 · **Environment tested:** Production tenant (fresh sandbox created the same day; credentials held in `/tmp` only).
+**Method:** Read every ZR-related file in `cod-server`, diff it against the official
+swagger (`.agents/skills/zr-express/swagger.json`), then exercise the **live API**
+(`https://api.zrexpress.app/api/v1`) with the endpoints and exact request bodies the
+adapter sends. Credentials were held in `/tmp` only and are **not** part of this report.
+
+> This report only documents findings. **No code was changed, nothing was committed.**
+
+---
+
+## TL;DR — is ZR Express "done for all"?
+
+**No. The happy-path single home-delivery flow works, but three flows are silently
+broken, geo-naming fails outright for 9/58 wilayas (16%) with 10 more resolving only
+via a fragile fallback, and stop-desk (pickup-point) dispatch cannot work as
+implemented.**
+
+| Area | Verdict |
+|---|---|
+| Auth headers (`X-Api-Key` + `X-Tenant`) | ✅ Correct |
+| Create customer / single home parcel / bulk | ✅ Correct (bulk = 207) |
+| GET parcel by id / by tracking number | ✅ Both work |
+| Update amount / update customer | ✅ Works |
+| Update delivery address | ❌ Street-only body **400**; UI still reports success |
+| Get state-history | ❌ Uses tracking number → **404**; only parcel UUID works |
+| Delete parcel | ❌ POST on DELETE-only endpoint → **405**; documented DELETE works |
+| Label generation + PDF proxy | ✅ Works (SAS URL) |
+| Stop-desk / pickup-point dispatch | ❌ Territory UUID as `hubId` → **404 HubNotFound** |
+| `getStopDesks` | ⚠️ Capped territory list, no hub linkage |
+| Webhook registration / secret / delete | ✅ Works |
+| Webhook status mapping | ❌ Defaults don't match real state names (slugs) |
+| Webhook event subscription | ⚠️ Only `parcel.state.updated` subscribed |
+| Wilaya geo resolution | ❌ 9/58 fail; 10 more rely on fragile fallback |
+| Commune geo resolution | ⚠️ Accent failures + silent wrong-commune fallback |
+
+---
+
+## 1. What is RIGHT (live-verified)
+
+| # | Claim | Evidence |
+|---|---|---|
+| 1 | `X-Api-Key` + `X-Tenant` authenticate | `GET /users/profile` → 200 |
+| 2 | `POST /customers/individual` returns `{ id }` | 200 |
+| 3 | `POST /parcels` returns `{ id }`; `stockType:"none"` accepted | 200; echoes `productsStockType:"none"` |
+| 4 | Tracking number only from `GET /parcels/{id}` | format `16-AJXL7ORFOL-ZR` |
+| 5 | `GET /parcels/{trackingNumber}` works | 200 |
+| 6 | `PATCH /parcels/{id}/amount` `{parcelId, amount}` | 200 |
+| 7 | `PATCH /parcels/{id}/customer` `{parcelId, name, phone}` | 200 |
+| 8 | `POST /parcels/bulk` → `successes`/`failures` with 0-based index | 207 |
+| 9 | Label `POST /parcels/labels/individual/pdf` → SAS `fileUrl`; fetching → `application/pdf` | 200/200, `%PDF-1.4`, 122 KB, ~65-min expiry |
+| 10 | Webhook create `{id: ep_…}` + secret `{secret: whsec_…}` + delete | 200 / 200 / 200 |
+| 11 | `DELETE /parcels/bulk/by-tracking-number` | 200 `successCount:1` |
+| 12 | `POST /workflows/search` exposes full state vocabulary | 200, 23 states |
+
+---
+
+## 2. What is WRONG (live-verified, with file references)
+
+### BUG-1 · `getTrackingInfo` always 404s → tracking returns `[]`
+`adapter.ts` calls `GET /api/v1/parcels/{trackingNumber}/state-history`.
+Live: tracking number → **404** (only the parcel UUID works; swagger path param is
+`{parcelId}`). The `catch` swallows it and returns `[]`, so `GET /orders/:id/tracking`
+silently shows *no events* for every ZR order. Fix: resolve the UUID via
+`GET /parcels/{trackingNumber}`, then call `state-history` with the UUID (verified 200).
+
+### BUG-2 · `deleteShipment` uses POST → always 405
+`adapter.ts` posts to `DELETE /api/v1/parcels/bulk/by-tracking-number` (wrong method).
+Live: **POST → 405**, documented **DELETE → 200** (deleted). `capabilities.ts`
+(`canDelete*: false`) is a symptom of this bug, not an API limitation. `cancelShipment`
+also ignores the returned boolean and resets the order to `ready` even when the parcel
+still exists at the carrier — **silent DB/carrier desync**.
+
+### BUG-3 · Address update always 400s and failure is swallowed
+`adapter.ts` sends only `{ street }` in `deliveryAddress`. Live: **400**
+`CityTerritoryId is required` / `DistrictTerritoryId is required`. Sending street +
+`cityTerritoryId` + `districtTerritoryId` → **200**. `updateShipment` catches the error
+and returns `false`; `updateShipmentInfo` ignores the return value and still replies
+"Shipment updated successfully". The dashboard advertises address editing for ZR.
+
+### BUG-4 · Stop-desk dispatch impossible — territory UUID used as `hubId`
+`adapter.ts` sets `hubId = districtId`, and for stop-desk that is the **pickup-point
+territory UUID** (`getStopDesks` → `code: t.id`). Live: `POST /parcels` with a territory
+id as `hubId` → **404 `HubErrors.HubNotFound`**. With a **real hub id**
+(e.g. `614e28bd…` "Hub Baraki 16") → **200**. ZR has 96 hubs (`POST /hubs/search`,
+`isPickupPoint`, each with `address.districtTerritoryId`). The whole stop-desk
+contract (`CONTEXT.md:40` "territory UUID for ZR Express") and the dashboard sync feed
+the wrong identifier into parcel creation.
+
+### BUG-5 · Status-mapper defaults don't match ZR's real state names
+`zr-status-mapper.ts` defaults (`"out for delivery"`, `"in transit"`, `"at hub"`) don't
+exist in the tenant's workflow. The **real default workflow** uses French slugs:
+`commande_recue`, `en_traitement`, `appel_confirmation`, `commande_confirmee`,
+`en_preparation`, `pret_a_expedier`, `confirme_au_bureau`, `confirme_chez_partenaire`,
+`dispatch`, `vers_wilaya`, `en_livraison`, `livre`, `encaisse`, `recouvert`, … .
+Real parcel state observed live: `state.name = "commande_recue"` (slug),
+`state.description = "Commande reçue"`. `delivered`/`returned`/`cancelled` can't map by
+default, so terminal ZR events record as `unmapped` unless admins configure the mapping
+with the actual slug names. Only `parcel.isReturn.updated` (hardcoded) reliably produces
+`returned` — see BUG-6.
+
+### BUG-6 · Webhook registration subscribes to only one event type
+`registerZrWebhook` sends `eventTypes: ["parcel.state.updated"]`, but the handler also
+reacts to `parcel.isReturn.updated` (→ returned) and `parcel.state.situation.created`.
+Existing ZR endpoints in the tenant list register **all three**. If ZR filters by
+`eventTypes`, return signals never arrive. Needs confirmation via a live transition,
+but the registration should subscribe to all three event types the handler understands.
+
+### BUG-7 · Bulk failures collapse multiple errors per parcel
+`createShipmentsBulk` builds `failureByBulkIdx` as a `Map(index → failure)`; a live call
+produced **two errors for the same index** (`Name is required` + `Description is
+required`) and only the last survives. Cosmetic today; keep all messages.
+
+### GEO-1 · Wilaya resolution fails for 9/58 wilayas
+Reproduced `resolveCityId` for all 58 wilayas against the live API:
+- **37/58** resolve on the first (name) search.
+- **10/58** only via the code-string fallback (e.g. `Sétif` → ZR uses `Setif`).
+- **9/58 fail outright**: `Béjaïa`, `Béchar`, `Tébessa`, `Saïda`, `Aïn Témouchent`
+  (ZR strips accents: `Bejaia`, `Bechar`, `Tebessa`, `Saida`, `Ain Temouchent`), and
+  `Illizi` (33), `Tindouf` (37), `Bordj Badji Mokhtar` (50), `Djanet` (56) — **ZR has no
+  wilaya-level territory for these at all** (0 results even accent-free). Parcel
+  creation **throws** for these wilayas.
+- The code-string fallback is pagination-fragile: keyword `"16"` returns 112 hits but
+  **no wilaya in the first page** → Alger depends on the name path.
+
+### GEO-2 · Commune resolution shares the accent problem + silent wrong-commune fallback
+`resolveDistrictId` searches by commune name. Live: `"Bir Mourad Raïs"` → **0 results**
+(ZR: `Bir Mourad Rais`); the fallback `items.find(parentId!=null) ?? items[0]` can pick
+an **unrelated commune**. `"Sidi Bel Abbes"` (no accent) returned no commune row.
+
+### MINOR
+- `VALID_OUR_STATUSES` omits `confirmed`, `unreachable`, `ready`, `dispatched` — the
+  ZR mapping UI can't map to `unreachable` though call-failure situations exist in the
+  default workflow.
+- No `zr-status-mapper.test.ts` exists (the yalidine mapper has one).
+- `getStopDesks` caps at `pageSize:200` of 1573 pickup-capable territories and includes
+  non-stop-desk rows; the stop-desk UI depends on it (see BUG-4).
+
+---
+
+## 3. Live-test evidence summary
+
+| Call | Method/Path | Result |
+|---|---|---|
+| profile | `GET /users/profile` | 200 |
+| territories | `POST /territories/search` (Alger, 16, Alger Centre, pickup) | 200 |
+| customers | `POST /customers/individual` | 200 |
+| parcel | `POST /parcels` (home, `stockType:none`) | 200 |
+| parcel fetch | `GET /parcels/{id}` | 200 (trackingNumber, state slug) |
+| parcel fetch | `GET /parcels/{trackingNumber}` | 200 |
+| state history | `GET /parcels/{trackingNumber}/state-history` | **404** |
+| state history | `GET /parcels/{uuid}/state-history` | 200 |
+| update amount | `PATCH /parcels/{id}/amount` | 200 |
+| update customer | `PATCH /parcels/{id}/customer` | 200 |
+| update address | `PATCH /parcels/{id}/deliveryAddress` (street only) | **400** |
+| update address | `PATCH …` (street + city + district) | 200 |
+| label | `POST /parcels/labels/individual/pdf` | 200 + PDF fetch 200 |
+| delete | `DELETE /parcels/bulk/by-tracking-number` | 200 (deleted) |
+| delete | `POST /parcels/bulk/by-tracking-number` (adapter's method) | **405** |
+| bulk | `POST /parcels/bulk` | 207 (multi-error per index confirmed) |
+| pickup | `POST /parcels` (`pickup-point`, no hubId) | **400** `HubId is required` |
+| pickup | `POST /parcels` (with real hub id) | 200 |
+| hubs | `POST /hubs/search` | 200, 96 hubs, `isPickupPoint` + `address` |
+| workflows | `POST /workflows/search` | 200, 23 states (slug vocabulary) |
+| webhooks | `POST /webhooks/endpoints` + `GET …/{id}/secret` + `DELETE …/{id}` | 200 / 200 (`whsec_…`) / 200 |
+
+---
+
+## 4. What must be fixed next (proposed order)
+
+1. **BUG-4 (stop-desk / hubId) + `getStopDesks` redesign** — resolve the real hub for
+   the pickup point (hubs carry `address.districtTerritoryId`); send the hub id as
+   `hubId` and the hub's district territory in `deliveryAddress`. Until this lands, ZR
+   stop-desk dispatch 404s.
+2. **BUG-2 (delete)** — switch `deleteShipment` to `DELETE`; flip `canDelete*` in
+   `capabilities.ts`; make `cancelShipment` surface failure instead of silently
+   resetting the order.
+3. **BUG-1 (state-history)** — resolve the parcel UUID from the tracking number first;
+   stop swallowing the error.
+4. **BUG-3 (address update)** — send the full `deliveryAddress` (+ `hubId` where
+   needed); check the return value in `updateShipmentInfo`.
+5. **GEO-1 / GEO-2 (geo naming)** — the EcoTrack/Yalidine pattern: seed
+   `carrier_wilayas` / `carrier_communes` for `zr_express` with ZR's canonical names
+   (accent-free: `MSila`, `El Meghaier`, `Setif`, `Ain Temouchent`, …), resolve before
+   dispatch, and normalize accents in `searchTerritories`. Surface the 4 wilayas ZR does
+   not serve (33/37/50/56) as a supported-region limitation.
+6. **BUG-5 + BUG-6 (webhook states)** — seed the mapper defaults with the real
+   default-workflow slugs (or match `description`); subscribe to all three event types;
+   allow `unreachable` in `VALID_OUR_STATUSES`; add a `zr-status-mapper.test.ts` like
+   the yalidine one.
+7. **BUG-7** — keep all bulk error messages per index (minor).
+
+---
+
+## 5. Unverified / needs the ZR dashboard
+- Actual webhook delivery payload for `parcel.state.updated` (slug vs description) —
+  requires a real carrier state transition.
+- Whether `parcel.isReturn.updated` / `parcel.state.situation.created` are delivered
+  when only `parcel.state.updated` is subscribed.
+
+---
+
+*Evidence captured under `/tmp/zrexpress/live/*.json` (key never written to the repo;
+re-run the audit harnesses with a fresh key to reproduce).*

--- a/.agents/skills/zr-express/README.md
+++ b/.agents/skills/zr-express/README.md
@@ -1,0 +1,47 @@
+# ZR Express — Delivery Platform API
+
+Machine-extracted reference for the **ZRExpress.Api (Public)** OpenAPI spec.
+
+| Item | What it is |
+|---|---|
+| `swagger.json` | The **raw, unaltered** spec from `https://api.zrexpress.app/swagger/public-v1/swagger.json` (the source of truth) |
+| `endpoints-index.md` | Master index — all **129 endpoints** across all domains + auth notes |
+| `references/` | One Markdown file per domain, every endpoint verbatim (method, path, operationId, summary, description, params, request/response schema refs) |
+| `schemas/` | The subset of `components.schemas` referenced by each domain (exact JSON, unaltered) |
+
+## How files are organized
+
+| Domain | `references/` file | Endpoints |
+|---|---|---|
+| catalog | `catalog.md` | 17 |
+| claims | `claims.md` | 11 |
+| customers | `customers.md` | 15 |
+| orders | `orders.md` | 50 |
+| delivery-pricing | `delivery-pricing.md` | 5 |
+| hubs | `hubs.md` | 2 |
+| supplier | `supplier.md` | 3 |
+| treasury | `treasury.md` | 15 |
+| users | `users.md` | 4 |
+| webhooks | `webhooks.md` | 7 |
+
+## Rules
+
+- **These files are generated.** Never hand-edit `swagger.json`, `references/*.md`
+  or `schemas/*.json` to "fix" an endpoint — re-run the generator instead.
+- Endpoint paths, methods, summaries, descriptions, parameters, and schema refs are
+  reproduced verbatim from the upstream spec.
+
+## Authentication
+
+Every endpoint accepts `Authorization: Bearer {token}` or `X-Api-Key: {apiKey}`; most
+endpoints also require the `X-Tenant` header. The `version` path parameter defaults to `1`.
+
+## Regenerating
+
+The generator lives at `generate.py` in this folder (reads `swagger.json`, rewrites
+`endpoints-index.md`, `references/*.md` and `schemas/*.json`):
+
+```sh
+curl -sL 'https://api.zrexpress.app/swagger/public-v1/swagger.json' -o .agents/skills/zr-express/swagger.json
+python3 .agents/skills/zr-express/generate.py
+```

--- a/.agents/skills/zr-express/SKILL.md
+++ b/.agents/skills/zr-express/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: zr-express
+description: ZR Express delivery platform integration for CodFlow — all 129 public API endpoints (catalog, claims, customers, orders/parcels, delivery pricing, hubs, supplier, treasury, users, webhooks), organized per domain. Use when connecting ZR Express as a delivery company, auditing or fixing the zr_express adapter in cod-server, verifying behavior against the official API, pulling tracking/state, registering webhooks, or extending ZR Express support.
+---
+
+# ZR Express Delivery Integration
+
+ZR Express is an Algerian cash-on-delivery delivery platform
+(`https://api.zrexpress.app`, dashboard `zrexpress.app`). Its REST API covers the
+full supplier flow: **parcels/orders** (create, bulk, exchange, refund, labels,
+state updates), **catalog** (products, stock, receipts), **customers**
+(individual + company, addresses, imports), **claims**, **delivery pricing**
+(rates per territory), **treasury** (payments, payment requests, balance),
+**users** (profile, API keys), **hubs**, and **webhooks** (programmatic
+registration).
+
+Start at `references/` in this folder — do not guess from the raw swagger.
+**Read `CONFORMANCE.md` before assuming the current adapter behavior is correct** —
+it lists live-verified bugs (tracking 404, delete 405, address update 400, stop-desk
+hub 404, geo naming) that the code comments below may not reflect.
+
+## Reference files (in this skill folder)
+
+| File | What it holds |
+|---|---|
+| `endpoints-index.md` | Master index — all 129 endpoints, per-domain, with auth notes |
+| `CONFORMANCE.md` | **Verified audit (2026-09-10, live-tested): what works / what's broken / fix order** — read before assuming current behavior is correct |
+| `references/catalog.md` | Products, stock movements, receipts, categories, catalog reports (17) |
+| `references/claims.md` | Claim categories, claims, comments, workflows (11) |
+| `references/customers.md` | Individual/company customers, addresses, imports/exports (15) |
+| `references/orders.md` | **Parcels, pickup bags, modification requests, territories, labels, reports (50)** |
+| `references/delivery-pricing.md` | Rates, service pricing, price lists (5) |
+| `references/hubs.md` | Hubs (2) |
+| `references/supplier.md` | Supplier profile, blocking, price-list assignments (3) |
+| `references/treasury.md` | Supplier payments, payment requests, treasury reports (15) |
+| `references/users.md` | Profile, API-key management (4) |
+| `references/webhooks.md` | Webhook endpoint CRUD (7) |
+| `schemas/*.json` | Full request/response schemas per domain (verbatim from swagger) |
+
+Path prefix is `/api/v1/…` (`version` defaults to `1`). Read the domain
+reference + its `schemas/{domain}.json` before writing adapter code.
+
+## Codebase
+
+- `cod-server/src/endpoints/delivery-companies/providers/zr_express/` — the adapter
+  (`adapter.ts`, `types.ts`, `capabilities.ts`) implementing the
+  `DeliveryProvider` interface used by `dispatch.ts`.
+- `cod-server/src/endpoints/delivery-companies/providers/registry.ts` — routes
+  company code `zr_express` to the adapter; `apiToken` = ZR API key,
+  `apiUserGuid` = ZR **tenant Id**.
+- `cod-server/src/endpoints/delivery-companies/webhook-handlers.ts` — programmatic
+  webhook registration (`registerZrWebhook`) against `/api/v1/webhooks/endpoints`.
+- `cod-server/src/endpoints/webhooks/zr-status-mapper.ts` — maps ZR state names
+  to CodFlow statuses.
+
+## Auth
+
+- Headers: `X-Api-Key: {secretKey}` **+** `X-Tenant: {tenantId}`
+  (the adapter uses these consistently; the swagger also lists `Bearer`).
+- Every request also carries `Accept`/`Content-Type` `application/json`.
+
+## Gotchas (verified against the live integration)
+
+1. **No separate validation step** — ZR auto-activates parcels on creation;
+   `validateShipment` is a no-op.
+2. **Single create returns a parcel UUID**; the tracking number only comes back from
+   `GET /parcels/{id}`. **Bulk create** (`POST /parcels/bulk`) returns the
+   tracking number directly. `maxBulkCreate` = 100.
+3. **Territories are UUIDs** (city + district), not `wilaya_id`/commune strings —
+   resolve them via `POST /territories/search` and cache the city per wilaya.
+4. **Auth is `X-Api-Key` + `X-Tenant`** — do not switch to `Authorization: Bearer`
+   just because examples show it; the stored `apiToken` is an API key.
+5. **State names are free text** (`data.state.name`), not a fixed enum: only
+   `"Out for Delivery"`, `"In Transit"` and `"At Hub"` are documented defaults.
+   Unknown names must surface as `unmapped` — never guessed into a status.
+6. **Label URLs expire (~1 hour, SAS-token based)** — from create you get a
+   deferred label token (CodFlow uses `DEFERRED_LABEL_MARKER`); serve labels
+   server-side, never expose a signed URL to the browser.
+7. **Update semantics** — `PATCH /parcels/{id}/amount`, `/customer` and
+  `/deliveryAddress` apply while `canUpdateAfterValidation: true`.
+8. **Delete is unreliable** (HTTP 405 in tests) — `canDeleteBeforeValidation`/
+   `AfterValidation` are both false; prefer state updates/refund flows.
+9. **Webhook registration is API-driven** — `POST /webhooks/endpoints` with
+   `X-Api-Key` + `X-Tenant`; the registered URL is CodFlow's `/webhooks/zr_express`.
+10. All IDs (parcel, customer, address, claim, etc.) are **UUIDs** — any other
+    format is an error or a legacy/alias field.
+
+## Workflow A — Connect ZR Express
+
+1. Create the delivery company with `code: "zr_express"`, `apiToken` = ZR API key,
+   `apiUserGuid` = ZR **tenant Id**.
+2. Verify: token check → create a test parcel (`POST /parcels`,
+   `POST /customers/individual` first) → `GET /parcels/{id}` returns the tracking
+   number → `POST /parcels/labels/individual` → tracking pull
+   (`GET /parcels/{id}/state-history`).
+3. Register the webhook (`registerZrWebhook` → `POST /webhooks/endpoints`) and
+   configure `webhook_status_mapping` for any non-default state names.
+
+## Workflow B — Audit / fix the integration
+
+1. Read the relevant `references/{domain}.md` + `schemas/{domain}.json`.
+2. Diff `adapter.ts` / `types.ts` endpoint-by-endpoint against the reference.
+3. Keep every header name, path, query param, and body field **exactly** as the
+   reference spells them (the generated files are verbatim from swagger).
+
+## Security
+
+Never commit ZR API keys or tenant IDs. They live in `wrangler secrets` /
+`.dev.vars` only (repo convention).

--- a/.agents/skills/zr-express/endpoints-index.md
+++ b/.agents/skills/zr-express/endpoints-index.md
@@ -1,0 +1,194 @@
+# ZR Express — API Endpoints Index
+
+Source: `https://api.zrexpress.app/swagger/public-v1/swagger.json`
+OpenAPI `3.0.4` · `ZRExpress.Api (Public)` v1
+> Do not alter. Machine-generated verbatim from `swagger.json`. Fetched 2026-09-10.
+
+- **129 unique endpoints** · **116 paths** · **313 component schemas**
+- Base URL: `https://api.zrexpress.app` (path prefix `/api/v1/…`)
+- Auth: `X-Api-Key: {apiKey}` + `X-Tenant: {tenantId}` headers (bearer also accepted)
+
+| Domain | File | Endpoints |
+|--------|------|-----------|
+| catalog | `references/catalog.md` | 17 |
+| claims | `references/claims.md` | 11 |
+| customers | `references/customers.md` | 15 |
+| orders | `references/orders.md` | 50 |
+| delivery-pricing | `references/delivery-pricing.md` | 5 |
+| hubs | `references/hubs.md` | 2 |
+| supplier | `references/supplier.md` | 3 |
+| treasury | `references/treasury.md` | 15 |
+| users | `references/users.md` | 4 |
+| webhooks | `references/webhooks.md` | 7 |
+| **total** | | **129** |
+
+## Auth
+
+| Scheme | Where | Value |
+|--------|-------|-------|
+| `bearerAuth` | `Authorization: Bearer {token}` | JWT bearer token |
+| `apiKey` | `X-Api-Key: {apiKey}` | API key |
+
+Most endpoints **also require the `X-Tenant` header** (tenant/supplier Id). The `version` path parameter defaults to `1`.
+
+## Endpoint inventory by domain
+
+### catalog
+
+- `POST   /api/v{version}/catalog/reports/search`
+- `POST   /api/v{version}/catalog/reports/{reportId}/download`
+- `POST   /api/v{version}/categories/search`
+- `POST   /api/v{version}/products`
+- `POST   /api/v{version}/products/export`
+- `POST   /api/v{version}/products/import`
+- `GET    /api/v{version}/products/import/template`
+- `PATCH  /api/v{version}/products/product/{productId}/local-stock`
+- `POST   /api/v{version}/products/search`
+- `POST   /api/v{version}/products/{id}`
+- `PUT    /api/v{version}/products/{id}`
+- `DELETE /api/v{version}/products/{id}`
+- `PATCH  /api/v{version}/products/{id}/discount`
+- `PATCH  /api/v{version}/products/{id}/price`
+- `POST   /api/v{version}/receipts/search`
+- `GET    /api/v{version}/receipts/{id}`
+- `POST   /api/v{version}/stock-movements/product/warehouse-stock/user`
+
+### claims
+
+- `POST   /api/v{version}/claim-categories/search`
+- `GET    /api/v{version}/claim-categories/{id}`
+- `PATCH  /api/v{version}/claim-comments/{claimId}`
+- `POST   /api/v{version}/claim-comments/{claimId}/search`
+- `POST   /api/v{version}/claim-workflows/search`
+- `POST   /api/v{version}/claims`
+- `POST   /api/v{version}/claims/search`
+- `POST   /api/v{version}/claims/{claimId}`
+- `PATCH  /api/v{version}/claims/{claimId}`
+- `DELETE /api/v{version}/claims/{id}`
+- `GET    /api/v{version}/claims/{id}/state-histories`
+
+### customers
+
+- `POST   /api/v{version}/customers/company`
+- `POST   /api/v{version}/customers/export`
+- `GET    /api/v{version}/customers/global/search`
+- `POST   /api/v{version}/customers/import/individual`
+- `GET    /api/v{version}/customers/import/individual/template`
+- `POST   /api/v{version}/customers/individual`
+- `PUT    /api/v{version}/customers/individual/{id}`
+- `POST   /api/v{version}/customers/reports/search`
+- `POST   /api/v{version}/customers/reports/{reportId}/download`
+- `POST   /api/v{version}/customers/search`
+- `POST   /api/v{version}/customers/{customerId}/address`
+- `PUT    /api/v{version}/customers/{customerId}/address/{addressId}`
+- `DELETE /api/v{version}/customers/{customerId}/address/{addressId}`
+- `GET    /api/v{version}/customers/{id}`
+- `DELETE /api/v{version}/customers/{id}`
+
+### delivery-pricing
+
+- `GET    /api/v{version}/delivery-pricing/price-lists/{id}`
+- `GET    /api/v{version}/delivery-pricing/rates`
+- `GET    /api/v{version}/delivery-pricing/rates/{toTerritoryId}`
+- `GET    /api/v{version}/delivery-pricing/service-pricing`
+- `GET    /api/v{version}/delivery-pricing/supplier-specific-prices/{supplierId}`
+
+### hubs
+
+- `POST   /api/v{version}/hubs/search`
+- `POST   /api/v{version}/hubs/{id}`
+
+### orders
+
+- `POST   /api/v{version}/orders/reports/search`
+- `POST   /api/v{version}/orders/reports/{reportId}/download`
+- `POST   /api/v{version}/parcel-modification-requests`
+- `POST   /api/v{version}/parcel-modification-requests/phone`
+- `POST   /api/v{version}/parcel-modification-requests/search`
+- `GET    /api/v{version}/parcel-modification-requests/{id}`
+- `DELETE /api/v{version}/parcel-modification-requests/{id}`
+- `POST   /api/v{version}/parcel-modification-requests/{parcelId}`
+- `PATCH  /api/v{version}/parcel-modification-requests/{requestId}`
+- `POST   /api/v{version}/parcels`
+- `POST   /api/v{version}/parcels/bulk`
+- `DELETE /api/v{version}/parcels/bulk`
+- `POST   /api/v{version}/parcels/bulk-exchange`
+- `POST   /api/v{version}/parcels/bulk-refund`
+- `DELETE /api/v{version}/parcels/bulk/by-tracking-number`
+- `POST   /api/v{version}/parcels/exchange`
+- `POST   /api/v{version}/parcels/export`
+- `POST   /api/v{version}/parcels/import-parcels`
+- `GET    /api/v{version}/parcels/import-parcels/template`
+- `POST   /api/v{version}/parcels/labels/individual`
+- `POST   /api/v{version}/parcels/labels/individual/pdf`
+- `POST   /api/v{version}/parcels/labels/multiple`
+- `POST   /api/v{version}/parcels/labels/multiple/pdf`
+- `POST   /api/v{version}/parcels/refund`
+- `POST   /api/v{version}/parcels/search`
+- `GET    /api/v{version}/parcels/search/global`
+- `GET    /api/v{version}/parcels/stats/workflow/{workflowId}/state/{stateId}`
+- `GET    /api/v{version}/parcels/stats/{workflowId}`
+- `GET    /api/v{version}/parcels/{id}`
+- `DELETE /api/v{version}/parcels/{id}`
+- `PATCH  /api/v{version}/parcels/{id}/amount`
+- `PATCH  /api/v{version}/parcels/{id}/customer`
+- `PATCH  /api/v{version}/parcels/{id}/deliveryAddress`
+- `PATCH  /api/v{version}/parcels/{parcelId}/products`
+- `PATCH  /api/v{version}/parcels/{parcelId}/state`
+- `GET    /api/v{version}/parcels/{parcelId}/state-history`
+- `POST   /api/v{version}/parcels/{parcelId}/state-history/{parcelStateHistoryId}/workflow/{workflowId}/situation-history`
+- `PATCH  /api/v{version}/parcels/{parcelId}/state/refund`
+- `GET    /api/v{version}/parcels/{trackingNumber}`
+- `POST   /api/v{version}/pickup-bags`
+- `POST   /api/v{version}/pickup-bags/labels/pdf`
+- `POST   /api/v{version}/pickup-bags/search`
+- `PATCH  /api/v{version}/pickup-bags/{bagId}/add-parcel`
+- `PATCH  /api/v{version}/pickup-bags/{bagId}/remove-parcel`
+- `GET    /api/v{version}/pickup-bags/{id}`
+- `DELETE /api/v{version}/pickup-bags/{id}`
+- `GET    /api/v{version}/pickup-bags/{trackingNumber}`
+- `POST   /api/v{version}/pickup-bags/{trackingNumber}/parcels/search`
+- `POST   /api/v{version}/territories/search`
+- `POST   /api/v{version}/workflows/search`
+
+### supplier
+
+- `GET    /api/v{version}/supplier/supplier-price-list-assignments/{supplierId}`
+- `POST   /api/v{version}/supplier/{supplierId}`
+- `PATCH  /api/v{version}/supplier/{supplierId}/blocked`
+
+### treasury
+
+- `POST   /api/v{version}/payment-request`
+- `POST   /api/v{version}/payment-request/search`
+- `GET    /api/v{version}/payment-request/{id}`
+- `DELETE /api/v{version}/payment-request/{id}`
+- `PATCH  /api/v{version}/payment-request/{id}/date`
+- `POST   /api/v{version}/supplier-payment/export`
+- `POST   /api/v{version}/supplier-payment/search`
+- `GET    /api/v{version}/supplier-payment/stats/current-supplier`
+- `GET    /api/v{version}/supplier-payment/supplier-balance`
+- `POST   /api/v{version}/supplier-payment/{id}/details`
+- `PUT    /api/v{version}/supplier-payment/{referenceId}`
+- `PUT    /api/v{version}/supplier-payment/{supplierPaymentId}`
+- `POST   /api/v{version}/treasury-transactions/search/supplier-payment/by-supplier-payment/{supplierPaymentId}`
+- `POST   /api/v{version}/treasury/reports/search`
+- `POST   /api/v{version}/treasury/reports/{reportId}/download`
+
+### users
+
+- `POST   /api/v{version}/users/keys`
+- `POST   /api/v{version}/users/keys/search`
+- `DELETE /api/v{version}/users/keys/{id}`
+- `GET    /api/v{version}/users/profile`
+
+### webhooks
+
+- `POST   /api/v{version}/webhooks/endpoints`
+- `GET    /api/v{version}/webhooks/endpoints`
+- `PUT    /api/v{version}/webhooks/endpoints/{endpointId}`
+- `GET    /api/v{version}/webhooks/endpoints/{endpointId}`
+- `DELETE /api/v{version}/webhooks/endpoints/{endpointId}`
+- `GET    /api/v{version}/webhooks/endpoints/{endpointId}/headers`
+- `GET    /api/v{version}/webhooks/endpoints/{endpointId}/secret`
+

--- a/.agents/skills/zr-express/generate.py
+++ b/.agents/skills/zr-express/generate.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Generate organized ZR Express API reference tree for the zr-express skill.
+Reads the downloaded swagger.json and re-emits every operation VERBATIM,
+grouped per domain. No endpoint data is altered."""
+import json, os, shutil, datetime
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = os.path.join(HERE, "swagger.json")
+OUT = HERE
+
+d = json.load(open(SRC))
+schemas = d.get("components", {}).get("schemas", {})
+
+DOMAINS = {
+    "catalog":         ["catalog"],
+    "claims":          ["claims"],
+    "customers":       ["customers"],
+    "orders":          ["orders"],
+    "delivery-pricing": ["delivery-pricing", "rates", "service-pricing", "specific-prices", "deprecated"],
+    "hubs":            ["hubs"],
+    "supplier":        ["supplier"],
+    "treasury":        ["treasury", "treasury-transactions"],
+    "users":           ["users"],
+    "webhooks":        ["webhooks"],
+}
+TAG_TO_DOMAIN = {t: dom for dom, tags in DOMAINS.items() for t in tags}
+
+def schema_summary(s):
+    if not isinstance(s, dict):
+        return ""
+    t = s.get("type", "")
+    fmt = f" ({s['format']})" if s.get("format") else ""
+    enum = f" enum={s['enum']}" if s.get("enum") else ""
+    items = s.get("items")
+    if items:
+        if "$ref" in items:
+            return f"{t}{fmt} of {items['$ref'].split('/')[-1]}{enum}"
+        return f"{t}{fmt} of {items.get('type','?')}{enum}"
+    return f"{t}{fmt}{enum}"
+
+def param_repr(p):
+    parts = []
+    if p.get("description"):
+        parts.append(p["description"].strip().replace("\n", " "))
+    base = p.get("schema", {})
+    s = schema_summary(base)
+    if s:
+        parts.append(f"`{s}`")
+    if base.get("default") is not None:
+        parts.append(f"default=`{base['default']}`")
+    return " — ".join(parts)
+
+def media_schema_refs(content):
+    refs = []
+    for mt, c in (content or {}).items():
+        sch = c.get("schema", {})
+        if "$ref" in sch:
+            refs.append(sch["$ref"].split("/")[-1])
+        else:
+            refs.append(f"(inline {schema_summary(sch) or json.dumps(sch)})")
+    return refs
+
+def op_markdown(method, path, op):
+    lines = []
+    lines.append(f"### `{method.upper()} {path}`")
+    lines.append("")
+    lines.append(f"**operationId:** `{op.get('operationId','')}`")
+    lines.append("")
+    tags = ", ".join(f"`{t}`" for t in op.get("tags", []))
+    lines.append(f"**tags:** {tags}")
+    lines.append("")
+    if op.get("summary"):
+        lines.append(f"**summary:** {op['summary']}")
+        lines.append("")
+    if op.get("description"):
+        lines.append("**description:**")
+        lines.append(f"> {op['description'].strip()}")
+        lines.append("")
+    params = op.get("parameters", [])
+    if params:
+        lines.append("**parameters:**")
+        lines.append("")
+        lines.append("| # | name | in | required | description / schema |")
+        lines.append("|---|------|----|----------|----------------------|")
+        for i, p in enumerate(params, 1):
+            req = "yes" if p.get("required") else "no"
+            lines.append(f"| {i} | `{p.get('name','')}` | {p.get('in','')} | {req} | {param_repr(p)} |")
+        lines.append("")
+    rb = op.get("requestBody")
+    if rb:
+        lines.append("**requestBody:**")
+        lines.append("")
+        rb_refs = media_schema_refs(rb.get("content"))
+        for mt in rb.get("content", {}):
+            lines.append(f"- `{mt}` → schema `{rb_refs[0] if rb_refs else '?'}`")
+        if rb.get("required"):
+            lines.append("- **required**")
+        lines.append("")
+    resps = op.get("responses", {})
+    if resps:
+        lines.append("**responses:**")
+        lines.append("")
+        lines.append("| status | description | schema |")
+        lines.append("|--------|-------------|--------|")
+        for code in sorted(resps):
+            r = resps[code]
+            refs = media_schema_refs(r.get("content"))
+            refs_s = ", ".join(f"`{x}`" for x in refs) if refs else "-"
+            lines.append(f"| {code} | {r.get('description','').strip()} | {refs_s} |")
+        lines.append("")
+    sec = op.get("security")
+    if sec is not None:
+        lines.append(f"**security (override):** `{json.dumps(sec)}`")
+        lines.append("")
+    return "\n".join(lines)
+
+def collect_op(dom, path, method, op):
+    body = op_markdown(method, path, op)
+    refs = set()
+    for p in op.get("parameters", []):
+        s = p.get("schema", {})
+        if "$ref" in s:
+            refs.add(s["$ref"].split("/")[-1])
+    for c in op.get("requestBody", {}).get("content", {}).values():
+        if "$ref" in c.get("schema", {}):
+            refs.add(c["schema"]["$ref"].split("/")[-1])
+    for r in op.get("responses", {}).values():
+        for c in (r.get("content") or {}).values():
+            if "$ref" in c.get("schema", {}):
+                refs.add(c["schema"]["$ref"].split("/")[-1])
+    return body, refs
+
+
+# Build per-domain operations (dedupe multi-tag ops by first tag matching domain)
+seen = set()
+dom_ops = {k: [] for k in DOMAINS}
+dom_refs = {k: set() for k in DOMAINS}
+for path, ops in d["paths"].items():
+    for method, op in ops.items():
+        key = (path, method)
+        if key in seen:
+            continue
+        seen.add(key)
+        primary_tag = (op.get("tags") or [None])[0]
+        dom = TAG_TO_DOMAIN.get(primary_tag)
+        if not dom:
+            print("WARN unknown tag", primary_tag, path)
+            continue
+        md, refs = collect_op(dom, path, method, op)
+        dom_ops[dom].append((method.upper(), path, md))
+        dom_refs[dom].update(refs)
+
+
+def sort_key(item):
+    method, path, _ = item
+    mrank = {"POST": 0, "PATCH": 1, "PUT": 2, "GET": 3, "DELETE": 4}.get(method, 5)
+    return (path.replace("/{version}", ""), mrank)
+
+
+os.makedirs(os.path.join(OUT, "references"), exist_ok=True)
+os.makedirs(os.path.join(OUT, "schemas"), exist_ok=True)
+if os.path.abspath(SRC) != os.path.abspath(os.path.join(OUT, "swagger.json")):
+    shutil.copyfile(SRC, os.path.join(OUT, "swagger.json"))
+
+from datetime import date
+DATE = date.today().isoformat()
+RULE = "> Do not alter. Machine-generated verbatim from "
+
+
+def resolve_schemas(ref_names, schemas):
+    out = {}
+    stack = list(ref_names)
+    while stack:
+        n = stack.pop()
+        if n in out or n not in schemas:
+            continue
+        out[n] = schemas[n]
+
+        def walk(o):
+            if isinstance(o, dict):
+                if "$ref" in o:
+                    stack.append(o["$ref"].split("/")[-1])
+                for v in o.values():
+                    walk(v)
+            elif isinstance(o, list):
+                for v in o:
+                    walk(v)
+
+        walk(schemas[n])
+    return out
+
+
+index_lines = []
+index_lines.append("# ZR Express — API Endpoints Index")
+index_lines.append("")
+index_lines.append("Source: `https://api.zrexpress.app/swagger/public-v1/swagger.json`")
+index_lines.append(f"OpenAPI `{d.get('openapi')}` · `{d.get('info',{}).get('title','')}` v{d.get('info',{}).get('version','')}")
+index_lines.append(RULE + f"`swagger.json`. Fetched {DATE}.")
+index_lines.append("")
+index_lines.append(f"- **{len(seen)} unique endpoints** · **{len(d['paths'])} paths** · **{len(schemas)} component schemas**")
+index_lines.append("- Base URL: `https://api.zrexpress.app` (path prefix `/api/v1/…`)")
+index_lines.append("- Auth: `X-Api-Key: {apiKey}` + `X-Tenant: {tenantId}` headers (bearer also accepted)")
+index_lines.append("")
+index_lines.append("| Domain | File | Endpoints |")
+index_lines.append("|--------|------|-----------|")
+total = 0
+for dom, items in dom_ops.items():
+    total += len(items)
+    index_lines.append(f"| {dom} | `references/{dom}.md` | {len(items)} |")
+index_lines.append(f"| **total** | | **{total}** |")
+index_lines.append("")
+index_lines.append("## Auth")
+index_lines.append("")
+index_lines.append("| Scheme | Where | Value |")
+index_lines.append("|--------|-------|-------|")
+index_lines.append("| `bearerAuth` | `Authorization: Bearer {token}` | JWT bearer token |")
+index_lines.append("| `apiKey` | `X-Api-Key: {apiKey}` | API key |")
+index_lines.append("")
+index_lines.append("Most endpoints **also require the `X-Tenant` header** (tenant/supplier Id). The `version` path parameter defaults to `1`.")
+index_lines.append("")
+index_lines.append("## Endpoint inventory by domain")
+index_lines.append("")
+for dom in sorted(dom_ops):
+    items = sorted(dom_ops[dom], key=sort_key)
+    index_lines.append(f"### {dom}")
+    index_lines.append("")
+    for method, path, _ in items:
+        index_lines.append(f"- `{method:6s} {path}`")
+    index_lines.append("")
+
+with open(os.path.join(OUT, "endpoints-index.md"), "w") as f:
+    f.write("\n".join(index_lines) + "\n")
+
+for dom, items in dom_ops.items():
+    items = sorted(items, key=sort_key)
+    lines = []
+    lines.append(f"# ZR Express API — `{dom}`")
+    lines.append("")
+    lines.append(RULE + f"`swagger.json`. Re-run the generator to refresh.")
+    lines.append("")
+    lines.append("Source spec: `swagger.json` (raw) · Index: `endpoints-index.md`")
+    lines.append(f"Full request/response shapes: `../schemas/{dom}.json`")
+    lines.append("")
+    lines.append(f"Endpoints in this domain: **{len(items)}**")
+    lines.append("")
+    lines.append("| Method | Path | Summary |")
+    lines.append("|--------|------|---------|")
+    md_by_key = {}
+    orig_by_key = {}
+    for method, path, md in items:
+        orig = ""
+        for p, ops in d["paths"].items():
+            if p == path:
+                for m, op in ops.items():
+                    if m.upper() == method:
+                        orig = op.get("summary", "")
+        md_by_key[(method, path)] = md
+        orig_by_key[(method, path)] = orig
+        lines.append(f"| `{method}` | `{path}` | {orig} |")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    for method, path, _ in items:
+        lines.append(md_by_key[(method, path)])
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+    with open(os.path.join(OUT, "references", f"{dom}.md"), "w") as f:
+        f.write("\n".join(lines))
+
+    subset = resolve_schemas(dom_refs[dom], schemas)
+    with open(os.path.join(OUT, "schemas", f"{dom}.json"), "w") as f:
+        json.dump(subset, f, indent=2, ensure_ascii=False)
+
+print("Wrote", len(dom_ops), "domain files;", total, "endpoints total.")
+print("Domains:", json.dumps({k: len(v) for k, v in dom_ops.items()}))

--- a/.agents/skills/zr-express/references/catalog.md
+++ b/.agents/skills/zr-express/references/catalog.md
@@ -1,0 +1,563 @@
+# ZR Express API — `catalog`
+
+> Do not alter. Machine-generated verbatim from `swagger.json`. Re-run the generator to refresh.
+
+Source spec: `swagger.json` (raw) · Index: `endpoints-index.md`
+Full request/response shapes: `../schemas/catalog.json`
+
+Endpoints in this domain: **17**
+
+| Method | Path | Summary |
+|--------|------|---------|
+| `POST` | `/api/v{version}/catalog/reports/search` | Gets a list of product export reports |
+| `POST` | `/api/v{version}/catalog/reports/{reportId}/download` | Download a product export report file by ID |
+| `POST` | `/api/v{version}/categories/search` | Gets a list of categories |
+| `POST` | `/api/v{version}/products` | Creates a product |
+| `POST` | `/api/v{version}/products/export` | Export a list of products |
+| `POST` | `/api/v{version}/products/import` | Imports products from an Excel file |
+| `GET` | `/api/v{version}/products/import/template` | Download template for importing bulk catalog products |
+| `PATCH` | `/api/v{version}/products/product/{productId}/local-stock` | Update local Stock |
+| `POST` | `/api/v{version}/products/search` | Gets a list of products |
+| `POST` | `/api/v{version}/products/{id}` | Get product details |
+| `PUT` | `/api/v{version}/products/{id}` | Update a product |
+| `DELETE` | `/api/v{version}/products/{id}` | Deletes a product |
+| `PATCH` | `/api/v{version}/products/{id}/discount` | Update product's discount  |
+| `PATCH` | `/api/v{version}/products/{id}/price` | Update product's price  |
+| `POST` | `/api/v{version}/receipts/search` | Gets a list of receipts |
+| `GET` | `/api/v{version}/receipts/{id}` | Get Receipt details |
+| `POST` | `/api/v{version}/stock-movements/product/warehouse-stock/user` | Creates a Stock movement by user |
+
+---
+
+### `POST /api/v{version}/catalog/reports/search`
+
+**operationId:** `SearchProductsReportsEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Gets a list of product export reports
+
+**description:**
+> Gets a list of product export reports with pagination and filtering support. Permissions required: SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchProductsReportsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_SearchProductsReportsResponse` |
+
+
+---
+
+### `POST /api/v{version}/catalog/reports/{reportId}/download`
+
+**operationId:** `DownloadProductsReportEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Download a product export report file by ID
+
+**description:**
+> Returns a SAS URL to download the product export report file by its ID. Permissions required: SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `reportId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `DownloadProductsReportResponse` |
+
+
+---
+
+### `POST /api/v{version}/categories/search`
+
+**operationId:** `SearchCategoriesEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Gets a list of categories
+
+**description:**
+> Gets a list of categories with pagination and filtering support. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchCategoriesRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_CategoryResponse` |
+
+
+---
+
+### `POST /api/v{version}/products`
+
+**operationId:** `CreateProductEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Creates a product
+
+**description:**
+> Creates a product. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateProductRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `CreateProductResponse` |
+
+
+---
+
+### `POST /api/v{version}/products/export`
+
+**operationId:** `ExportProductsEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Export a list of products
+
+**description:**
+> Export a list of products to a CSV file. The export is processed asynchronously and returns a report ID. Permissions required: SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `ExportProductsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `(inline string (uuid))` |
+
+
+---
+
+### `POST /api/v{version}/products/import`
+
+**operationId:** `ImportProductEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Imports products from an Excel file
+
+**description:**
+> Imports products using an Excel file. Supports two formats: 1) multipart/form-data with 'file' field (recommended, more efficient), 2) JSON body with 'excelFileBase64' (legacy). Optionally provide a dictionary of columns and their matching propertyNames.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `multipart/form-data` → schema `ImportProductFormData`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `ProductImportResult` |
+| 400 | Bad Request | `ProblemDetails` |
+
+
+---
+
+### `GET /api/v{version}/products/import/template`
+
+**operationId:** `DownloadTemplateBulkCatalogProductsEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Download template for importing bulk catalog products
+
+**description:**
+> Returns an Excel template file for bulk importing catalog products.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | - |
+
+
+---
+
+### `PATCH /api/v{version}/products/product/{productId}/local-stock`
+
+**operationId:** `UpdateProductLocalStockEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Update local Stock
+
+**description:**
+> Update local Stock.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `productId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateProductLocalStockRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `UpdateProductLocalStockResponse` |
+
+
+---
+
+### `POST /api/v{version}/products/search`
+
+**operationId:** `SearchSupplierProductsEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Gets a list of products
+
+**description:**
+> Gets a list of products with pagination and filtering support. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchProductsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_SearchProductResponse` |
+
+
+---
+
+### `POST /api/v{version}/products/{id}`
+
+**operationId:** `GetSupplierProductEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Get product details
+
+**description:**
+> Get the details of a product by its ID. Permissions requises : tous les SupplierRoles.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `GetProductRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetProductResponse` |
+
+
+---
+
+### `PUT /api/v{version}/products/{id}`
+
+**operationId:** `UpdateProductEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Update a product
+
+**description:**
+> Update a product
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateProductRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateProductResponse` |
+
+
+---
+
+### `DELETE /api/v{version}/products/{id}`
+
+**operationId:** `DeleteProductEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Deletes a product
+
+**description:**
+> Deletes a product by id with its variants
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 204 | No Content | `DeleteProductResponse` |
+
+
+---
+
+### `PATCH /api/v{version}/products/{id}/discount`
+
+**operationId:** `UpdateDiscountEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Update product's discount 
+
+**description:**
+> Update the discount price of a product
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateDiscountRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateDiscountResponse` |
+
+
+---
+
+### `PATCH /api/v{version}/products/{id}/price`
+
+**operationId:** `UpdatePriceEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Update product's price 
+
+**description:**
+> Update the price of a product
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdatePriceRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdatePriceResponse` |
+
+
+---
+
+### `POST /api/v{version}/receipts/search`
+
+**operationId:** `SearchReceiptsEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Gets a list of receipts
+
+**description:**
+> Gets a list of receipts with pagination and filtering support Required Permissions: GlobalRoles, SubContractorRoles, HubAdmin, HubStockManager, SupplierAdmin, or SupplierParcelsManager.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchReceiptsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_SearchReceiptResponse` |
+
+
+---
+
+### `GET /api/v{version}/receipts/{id}`
+
+**operationId:** `GetReceiptEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Get Receipt details
+
+**description:**
+> Get the details of a Receipt by its ID. Required Permissions: GlobalRoles, SubContractorRoles, HubAdmin, HubStockManager, SupplierAdmin, or SupplierParcelsManager.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetReceiptResponse` |
+
+
+---
+
+### `POST /api/v{version}/stock-movements/product/warehouse-stock/user`
+
+**operationId:** `CreateProductStockMovementUserEndpoint`
+
+**tags:** `catalog`
+
+**summary:** Creates a Stock movement by user
+
+**description:**
+> Creates a stock movement by user with type parameters equal to waiting-reception.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateProductStockMovementUserRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `CreateProductStockMovementUserResponse` |
+
+
+---

--- a/.agents/skills/zr-express/references/claims.md
+++ b/.agents/skills/zr-express/references/claims.md
@@ -1,0 +1,368 @@
+# ZR Express API — `claims`
+
+> Do not alter. Machine-generated verbatim from `swagger.json`. Re-run the generator to refresh.
+
+Source spec: `swagger.json` (raw) · Index: `endpoints-index.md`
+Full request/response shapes: `../schemas/claims.json`
+
+Endpoints in this domain: **11**
+
+| Method | Path | Summary |
+|--------|------|---------|
+| `POST` | `/api/v{version}/claim-categories/search` | Gets a list of claim categories |
+| `GET` | `/api/v{version}/claim-categories/{id}` | gets claim category item by id |
+| `PATCH` | `/api/v{version}/claim-comments/{claimId}` | Create a comment for a specific claim for current supplier. |
+| `POST` | `/api/v{version}/claim-comments/{claimId}/search` | Gets a list of claim comments for a specific claim by Id for current supplier |
+| `POST` | `/api/v{version}/claim-workflows/search` | Gets a list of claim workflows |
+| `POST` | `/api/v{version}/claims` | Creates a claim |
+| `POST` | `/api/v{version}/claims/search` | Gets a list of claims for Current Supplier |
+| `POST` | `/api/v{version}/claims/{claimId}` | gets claim item by id |
+| `PATCH` | `/api/v{version}/claims/{claimId}` | Update details for a specific claim. |
+| `DELETE` | `/api/v{version}/claims/{id}` | Deletes a Claim |
+| `GET` | `/api/v{version}/claims/{id}/state-histories` | get claim state histories |
+
+---
+
+### `POST /api/v{version}/claim-categories/search`
+
+**operationId:** `SearchClaimCategoriesEndpoint`
+
+**tags:** `claims`
+
+**summary:** Gets a list of claim categories
+
+**description:**
+> Gets a list of claim categories with pagination and filtering support
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchClaimCategoriesRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_SearchClaimCategoryResponse` |
+
+
+---
+
+### `GET /api/v{version}/claim-categories/{id}`
+
+**operationId:** `GetClaimCategoryEndpoint`
+
+**tags:** `claims`
+
+**summary:** gets claim category item by id
+
+**description:**
+> gets claim category item by id
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetCategoryClaimResponse` |
+
+
+---
+
+### `PATCH /api/v{version}/claim-comments/{claimId}`
+
+**operationId:** `CreateClaimCommentCurrentSupplierEndpoint`
+
+**tags:** `claims`
+
+**summary:** Create a comment for a specific claim for current supplier.
+
+**description:**
+> Create a comment for a specific claim for current supplier. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `claimId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateClaimCommentCurrentSupplierRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateClaimCommentResponse` |
+
+
+---
+
+### `POST /api/v{version}/claim-comments/{claimId}/search`
+
+**operationId:** `SearchClaimCommentsCurrentSupplierEndpoint`
+
+**tags:** `claims`
+
+**summary:** Gets a list of claim comments for a specific claim by Id for current supplier
+
+**description:**
+> Gets a list of claim comments for a specific claim by Id for current supplier with pagination and filtering support. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `claimId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchClaimCommentsCurrentSupplierRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_ClaimCommentResponse` |
+
+
+---
+
+### `POST /api/v{version}/claim-workflows/search`
+
+**operationId:** `SearchClaimWorkflowsEndpoint`
+
+**tags:** `claims`
+
+**summary:** Gets a list of claim workflows
+
+**description:**
+> Gets a list of claim workflows with pagination and filtering support
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchClaimWorkflowsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_ClaimWorkflowResponse` |
+
+
+---
+
+### `POST /api/v{version}/claims`
+
+**operationId:** `CreateClaimEndpoint`
+
+**tags:** `claims`
+
+**summary:** Creates a claim
+
+**description:**
+> Creates a claim. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateClaimRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `CreateClaimResponse` |
+
+
+---
+
+### `POST /api/v{version}/claims/search`
+
+**operationId:** `SearchClaimsSupplierEndpoint`
+
+**tags:** `claims`
+
+**summary:** Gets a list of claims for Current Supplier
+
+**description:**
+> Gets a list of claims for Current Supplier with pagination and filtering support. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchClaimsSupplierRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_ClaimResponse` |
+
+
+---
+
+### `POST /api/v{version}/claims/{claimId}`
+
+**operationId:** `GetClaimSupplierEndpoint`
+
+**tags:** `claims`
+
+**summary:** gets claim item by id
+
+**description:**
+> gets claim item by id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `claimId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `GetClaimSupplierRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `ClaimResponse` |
+
+
+---
+
+### `PATCH /api/v{version}/claims/{claimId}`
+
+**operationId:** `UpdateClaimDetailsEndpoint`
+
+**tags:** `claims`
+
+**summary:** Update details for a specific claim.
+
+**description:**
+> Update details for a specific claim. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole, HubAdminRole, HubClaimsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `claimId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateClaimDetailsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateClaimDetailsResponse` |
+
+
+---
+
+### `DELETE /api/v{version}/claims/{id}`
+
+**operationId:** `DeleteClaimEndpoint`
+
+**tags:** `claims`
+
+**summary:** Deletes a Claim
+
+**description:**
+> Deletes a Claim by id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 204 | No Content | `DeleteClaimResponse` |
+
+
+---
+
+### `GET /api/v{version}/claims/{id}/state-histories`
+
+**operationId:** `GetClaimStateHistoryEndpoint`
+
+**tags:** `claims`
+
+**summary:** get claim state histories
+
+**description:**
+> get claim state histories
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `(inline array of ClaimStateHistoryDto)` |
+
+
+---

--- a/.agents/skills/zr-express/references/customers.md
+++ b/.agents/skills/zr-express/references/customers.md
@@ -1,0 +1,490 @@
+# ZR Express API — `customers`
+
+> Do not alter. Machine-generated verbatim from `swagger.json`. Re-run the generator to refresh.
+
+Source spec: `swagger.json` (raw) · Index: `endpoints-index.md`
+Full request/response shapes: `../schemas/customers.json`
+
+Endpoints in this domain: **15**
+
+| Method | Path | Summary |
+|--------|------|---------|
+| `POST` | `/api/v{version}/customers/company` | Creates a customer |
+| `POST` | `/api/v{version}/customers/export` | Export a list of customers |
+| `GET` | `/api/v{version}/customers/global/search` | Top global customer search |
+| `POST` | `/api/v{version}/customers/import/individual` | Imports individual customers from an Excel file |
+| `GET` | `/api/v{version}/customers/import/individual/template` | Download template for importing individual customers |
+| `POST` | `/api/v{version}/customers/individual` | Creates a customer |
+| `PUT` | `/api/v{version}/customers/individual/{id}` | update individual customer. |
+| `POST` | `/api/v{version}/customers/reports/search` | Gets a list of customer export reports |
+| `POST` | `/api/v{version}/customers/reports/{reportId}/download` | Download a customer export report file by ID |
+| `POST` | `/api/v{version}/customers/search` | Gets a list of customers |
+| `POST` | `/api/v{version}/customers/{customerId}/address` | add customer address |
+| `PUT` | `/api/v{version}/customers/{customerId}/address/{addressId}` | update customer address |
+| `DELETE` | `/api/v{version}/customers/{customerId}/address/{addressId}` | delete customer address |
+| `GET` | `/api/v{version}/customers/{id}` | Get customer details |
+| `DELETE` | `/api/v{version}/customers/{id}` | Deletes customer by id |
+
+---
+
+### `POST /api/v{version}/customers/company`
+
+**operationId:** `CreateCompanyCustomerEndpoint`
+
+**tags:** `customers`
+
+**summary:** Creates a customer
+
+**description:**
+> Creates a customer, the 'TimeSlot' paramater indicates time slot preference and accepts 'morning','afternoon', or 'evening'. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateCompanyCustomerRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `Result_CreateCompanyCustomerResponse` |
+
+
+---
+
+### `POST /api/v{version}/customers/export`
+
+**operationId:** `ExportCustomersEndpoint`
+
+**tags:** `customers`
+
+**summary:** Export a list of customers
+
+**description:**
+> Export a list of customers to an Excel file. The export is processed asynchronously and returns a report ID. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `ExportCustomersRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `(inline string (uuid))` |
+
+
+---
+
+### `GET /api/v{version}/customers/global/search`
+
+**operationId:** `SearchGlobalCustomersEndpointTop`
+
+**tags:** `customers`
+
+**summary:** Top global customer search
+
+**description:**
+> Search customers by phone number for the GlobalSearch component without pagination or count queries.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `keyword` | query | no | `string` |
+| 3 | `top` | query | no | `integer (int32)` — default=`10` |
+| 4 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `(inline array of SearchGlobalCustomerResponse)` |
+
+
+---
+
+### `POST /api/v{version}/customers/import/individual`
+
+**operationId:** `ImportIndividualCustomersEndpoint`
+
+**tags:** `customers`
+
+**summary:** Imports individual customers from an Excel file
+
+**description:**
+> Imports individual customers using an Excel file. Supports two formats: 1) multipart/form-data with 'file' field (recommended, more efficient), 2) JSON body with 'excelFileBase64' (legacy). Optionally provide a dictionary of columns and their matching propertyNames.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `multipart/form-data` → schema `ImportIndividualCustomersFormData`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `CustomerImportResult` |
+| 400 | Bad Request | `ProblemDetails` |
+
+
+---
+
+### `GET /api/v{version}/customers/import/individual/template`
+
+**operationId:** `DownloadTemplateBulkIndividualCustomersEndpoint`
+
+**tags:** `customers`
+
+**summary:** Download template for importing individual customers
+
+**description:**
+> Returns an Excel template file for bulk importing individual customers.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | - |
+
+
+---
+
+### `POST /api/v{version}/customers/individual`
+
+**operationId:** `CreateIndividualCustomerEndpoint`
+
+**tags:** `customers`
+
+**summary:** Creates a customer
+
+**description:**
+> Creates a customer, The 'Gender' paramater indicates the gender of the customer and accepts 'male', or 'female', the 'TimeSlot' paramater indicates time slot preference and accepts 'morning','afternoon', or 'evening',the 'DeliveryPreference' paramater indicates delivery preference and accepts 'home', or 'pickup-point'. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateIndividualCustomerRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `CreateIndividualCustomerResponse` |
+
+
+---
+
+### `PUT /api/v{version}/customers/individual/{id}`
+
+**operationId:** ``
+
+**tags:** `customers`
+
+**summary:** update individual customer.
+
+**description:**
+> update individual customer by id, The 'Gender' paramater indicates the gender of the customer and accepts 'male', or 'female', the 'TimeSlot' paramater indicates time slot preference and accepts 'morning','afternoon', or 'evening',the 'DeliveryPreference' paramater indicates delivery preference and accepts 'home', or 'pickup-point' .
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateIndividualCustomerRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateIndividualCustomerResponse` |
+
+
+---
+
+### `POST /api/v{version}/customers/reports/search`
+
+**operationId:** `SearchExportReportsEndpoint`
+
+**tags:** `customers`
+
+**summary:** Gets a list of customer export reports
+
+**description:**
+> Gets a list of customer export reports with pagination and filtering support. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchExportReportsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_ExportReportResponse` |
+
+
+---
+
+### `POST /api/v{version}/customers/reports/{reportId}/download`
+
+**operationId:** `DownloadExportReportEndpoint`
+
+**tags:** `customers`
+
+**summary:** Download a customer export report file by ID
+
+**description:**
+> Returns a SAS URL to download the customer export report file by its ID. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `reportId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `DownloadExportReportResponse` |
+
+
+---
+
+### `POST /api/v{version}/customers/search`
+
+**operationId:** `SearchCustomersEndpoint`
+
+**tags:** `customers`
+
+**summary:** Gets a list of customers
+
+**description:**
+> Gets a list of customers with pagination and filtering support
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchCustomersRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_CustomerResponse` |
+
+
+---
+
+### `POST /api/v{version}/customers/{customerId}/address`
+
+**operationId:** ``
+
+**tags:** `customers`
+
+**summary:** add customer address
+
+**description:**
+> add new address to existing customer. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `customerId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateCustomerAddressRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `CreateCustomerAddressResponse` |
+
+
+---
+
+### `PUT /api/v{version}/customers/{customerId}/address/{addressId}`
+
+**operationId:** ``
+
+**tags:** `customers`
+
+**summary:** update customer address
+
+**description:**
+> update customer address using customer id
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `customerId` | path | yes | `string (uuid)` |
+| 3 | `addressId` | path | yes | `string (uuid)` |
+| 4 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateCustomerAddressRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateCustomerAddressResponse` |
+
+
+---
+
+### `DELETE /api/v{version}/customers/{customerId}/address/{addressId}`
+
+**operationId:** ``
+
+**tags:** `customers`
+
+**summary:** delete customer address
+
+**description:**
+> delete customer address using customer id and address id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `customerId` | path | yes | `string (uuid)` |
+| 3 | `addressId` | path | yes | `string (uuid)` |
+| 4 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `DeleteCustomerAddressResponse` |
+
+
+---
+
+### `GET /api/v{version}/customers/{id}`
+
+**operationId:** `GetCustomerEndpoint`
+
+**tags:** `customers`
+
+**summary:** Get customer details
+
+**description:**
+> Get the details of a customer by its Id.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetCustomerResponse` |
+
+
+---
+
+### `DELETE /api/v{version}/customers/{id}`
+
+**operationId:** `DeleteCustomerEndpoint`
+
+**tags:** `customers`
+
+**summary:** Deletes customer by id
+
+**description:**
+> Delete a customer by Id with related address. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 204 | No Content | `DeleteCustomerResponse` |
+
+
+---

--- a/.agents/skills/zr-express/references/delivery-pricing.md
+++ b/.agents/skills/zr-express/references/delivery-pricing.md
@@ -1,0 +1,161 @@
+# ZR Express API — `delivery-pricing`
+
+> Do not alter. Machine-generated verbatim from `swagger.json`. Re-run the generator to refresh.
+
+Source spec: `swagger.json` (raw) · Index: `endpoints-index.md`
+Full request/response shapes: `../schemas/delivery-pricing.json`
+
+Endpoints in this domain: **5**
+
+| Method | Path | Summary |
+|--------|------|---------|
+| `GET` | `/api/v{version}/delivery-pricing/price-lists/{id}` | [Deprecated] Gets a price list |
+| `GET` | `/api/v{version}/delivery-pricing/rates` | Get effective delivery rates for all territories |
+| `GET` | `/api/v{version}/delivery-pricing/rates/{toTerritoryId}` | Get effective delivery rate for a specific territory |
+| `GET` | `/api/v{version}/delivery-pricing/service-pricing` | Get the service pricing for the current supplier |
+| `GET` | `/api/v{version}/delivery-pricing/supplier-specific-prices/{supplierId}` | [Deprecated] Get supplier-specific delivery prices |
+
+---
+
+### `GET /api/v{version}/delivery-pricing/price-lists/{id}`
+
+**operationId:** `GetPriceListEndpoint`
+
+**tags:** `delivery-pricing`, `deprecated`
+
+**summary:** [Deprecated] Gets a price list
+
+**description:**
+> Gets a price list. This endpoint is deprecated. Please use GET /delivery-pricing/rates instead to get effective delivery prices with priority logic already applied.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetPriceListResponse` |
+
+
+---
+
+### `GET /api/v{version}/delivery-pricing/rates`
+
+**operationId:** `GetAllRatesEndpoint`
+
+**tags:** `rates`
+
+**summary:** Get effective delivery rates for all territories
+
+**description:**
+> Returns the effective delivery prices for all destination territories. Supply an optional 'fromTerritoryId' (origin wilaya) to resolve the price list from the supplier's explicit assignment for that origin. Returns 404 when no assignment exists. This endpoint automatically applies the priority logic: supplier-specific prices take precedence over PriceList prices.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `fromTerritoryId` | query | no | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetAllRatesResponse` |
+| 404 | Not Found | `ProblemDetails` |
+
+
+---
+
+### `GET /api/v{version}/delivery-pricing/rates/{toTerritoryId}`
+
+**operationId:** `GetRateEndpoint`
+
+**tags:** `rates`
+
+**summary:** Get effective delivery rate for a specific territory
+
+**description:**
+> Returns the effective delivery prices for a specific destination territory. This endpoint automatically applies the priority logic: supplier-specific prices take precedence over PriceList prices.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `toTerritoryId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetRateResponse` |
+| 404 | Not Found | `ProblemDetails` |
+
+
+---
+
+### `GET /api/v{version}/delivery-pricing/service-pricing`
+
+**operationId:** `GetCurrentSupplierServicePricingEndpoint`
+
+**tags:** `service-pricing`
+
+**summary:** Get the service pricing for the current supplier
+
+**description:**
+> Returns the service pricing (labeling, weighting, switch) for the currently authenticated supplier.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `ServicePricingResponse` |
+| 404 | Not Found | `ProblemDetails` |
+
+
+---
+
+### `GET /api/v{version}/delivery-pricing/supplier-specific-prices/{supplierId}`
+
+**operationId:** `GetSupplierSpecificPricesEndpoint`
+
+**tags:** `specific-prices`, `deprecated`
+
+**summary:** [Deprecated] Get supplier-specific delivery prices
+
+**description:**
+> Retrieves all supplier-specific delivery prices for a given supplier. This endpoint is deprecated. Please use GET /delivery-pricing/rates instead to get effective delivery prices with priority logic already applied.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `supplierId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | - |
+| 404 | Not Found | `ProblemDetails` |
+
+
+---

--- a/.agents/skills/zr-express/references/hubs.md
+++ b/.agents/skills/zr-express/references/hubs.md
@@ -1,0 +1,80 @@
+# ZR Express API — `hubs`
+
+> Do not alter. Machine-generated verbatim from `swagger.json`. Re-run the generator to refresh.
+
+Source spec: `swagger.json` (raw) · Index: `endpoints-index.md`
+Full request/response shapes: `../schemas/hubs.json`
+
+Endpoints in this domain: **2**
+
+| Method | Path | Summary |
+|--------|------|---------|
+| `POST` | `/api/v{version}/hubs/search` | Get a list of hubs |
+| `POST` | `/api/v{version}/hubs/{id}` | Get a hub by Id |
+
+---
+
+### `POST /api/v{version}/hubs/search`
+
+**operationId:** `SearchSupplierHubsEndpoint`
+
+**tags:** `hubs`
+
+**summary:** Get a list of hubs
+
+**description:**
+> Get a list of hubs with pagination and filtering support
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchSupplierHubsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_SupplierHubResponse` |
+
+
+---
+
+### `POST /api/v{version}/hubs/{id}`
+
+**operationId:** `GetSupplierHubEndpoint`
+
+**tags:** `hubs`
+
+**summary:** Get a hub by Id
+
+**description:**
+> Get a hub by Id
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `GetSupplierHubRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `SupplierHubResponse` |
+
+
+---

--- a/.agents/skills/zr-express/references/orders.md
+++ b/.agents/skills/zr-express/references/orders.md
@@ -1,0 +1,1674 @@
+# ZR Express API — `orders`
+
+> Do not alter. Machine-generated verbatim from `swagger.json`. Re-run the generator to refresh.
+
+Source spec: `swagger.json` (raw) · Index: `endpoints-index.md`
+Full request/response shapes: `../schemas/orders.json`
+
+Endpoints in this domain: **50**
+
+| Method | Path | Summary |
+|--------|------|---------|
+| `POST` | `/api/v{version}/orders/reports/search` | Gets a list of Reports in orders module |
+| `POST` | `/api/v{version}/orders/reports/{reportId}/download` | Download a report file by ID |
+| `POST` | `/api/v{version}/parcel-modification-requests` | Creates a parcel modification request |
+| `POST` | `/api/v{version}/parcel-modification-requests/phone` | Change parcel phone (auto-applied modification request) |
+| `POST` | `/api/v{version}/parcel-modification-requests/search` | Search supplier's parcels' modification requests |
+| `GET` | `/api/v{version}/parcel-modification-requests/{id}` | get parcel modification request item by id |
+| `DELETE` | `/api/v{version}/parcel-modification-requests/{id}` | Deletes an existing parcel modification request |
+| `POST` | `/api/v{version}/parcel-modification-requests/{parcelId}` | Search parcels' modification requests |
+| `PATCH` | `/api/v{version}/parcel-modification-requests/{requestId}` | Updates an existing parcel modification request |
+| `POST` | `/api/v{version}/parcels` | Creates a parcel |
+| `POST` | `/api/v{version}/parcels/bulk` | Create multiple parcels in bulk |
+| `DELETE` | `/api/v{version}/parcels/bulk` | Delete multiple parcels in bulk |
+| `POST` | `/api/v{version}/parcels/bulk-exchange` | Create multiple exchange parcels in bulk |
+| `POST` | `/api/v{version}/parcels/bulk-refund` | Create multiple refund parcels in bulk |
+| `DELETE` | `/api/v{version}/parcels/bulk/by-tracking-number` | Delete multiple parcels by tracking numbers in bulk |
+| `POST` | `/api/v{version}/parcels/exchange` | Creates an exchange for a parcel |
+| `POST` | `/api/v{version}/parcels/export` | Export supplier parcels to CSV |
+| `POST` | `/api/v{version}/parcels/import-parcels` | Imports parcels from an Excel file |
+| `GET` | `/api/v{version}/parcels/import-parcels/template` | Download template for importing bulk parcels |
+| `POST` | `/api/v{version}/parcels/labels/individual` | Generate individual parcel labels |
+| `POST` | `/api/v{version}/parcels/labels/individual/pdf` | Generate individual parcel labels as PDF |
+| `POST` | `/api/v{version}/parcels/labels/multiple` | Generate multiple parcel labels in one HTML file |
+| `POST` | `/api/v{version}/parcels/labels/multiple/pdf` | Generate multiple parcel labels as a single PDF |
+| `POST` | `/api/v{version}/parcels/refund` | Creates a parcel refund |
+| `POST` | `/api/v{version}/parcels/search` | Get a list of parcels |
+| `GET` | `/api/v{version}/parcels/search/global` | Top global search of supplier parcels |
+| `GET` | `/api/v{version}/parcels/stats/workflow/{workflowId}/state/{stateId}` | Gets parcels stats per situation Id for a workflow for the current supplier |
+| `GET` | `/api/v{version}/parcels/stats/{workflowId}` | Gets parcels stats per state for a workflow for the current tenant |
+| `GET` | `/api/v{version}/parcels/{id}` | get parcel item by id |
+| `DELETE` | `/api/v{version}/parcels/{id}` | Delete a parcel |
+| `PATCH` | `/api/v{version}/parcels/{id}/amount` | Update an order's total amount |
+| `PATCH` | `/api/v{version}/parcels/{id}/customer` | Update an parcel's customer infos |
+| `PATCH` | `/api/v{version}/parcels/{id}/deliveryAddress` | Update an order's delivery address |
+| `PATCH` | `/api/v{version}/parcels/{parcelId}/products` | Update products of an parcel |
+| `PATCH` | `/api/v{version}/parcels/{parcelId}/state` | Updates parcel state |
+| `GET` | `/api/v{version}/parcels/{parcelId}/state-history` | gets parcel state history |
+| `POST` | `/api/v{version}/parcels/{parcelId}/state-history/{parcelStateHistoryId}/workflow/{workflowId}/situation-history` | Creates a parcel state situation history |
+| `PATCH` | `/api/v{version}/parcels/{parcelId}/state/refund` | Updates parcel state for a refund |
+| `GET` | `/api/v{version}/parcels/{trackingNumber}` | get parcel item by trackingNumber |
+| `POST` | `/api/v{version}/pickup-bags` | Creates a pickup bag. |
+| `POST` | `/api/v{version}/pickup-bags/labels/pdf` | Generate pickup bag label as PDF |
+| `POST` | `/api/v{version}/pickup-bags/search` | Search all supplier's pickup bags |
+| `PATCH` | `/api/v{version}/pickup-bags/{bagId}/add-parcel` | Add a parcel to a pickup bag |
+| `PATCH` | `/api/v{version}/pickup-bags/{bagId}/remove-parcel` | Remove a parcel from a pickup bag |
+| `GET` | `/api/v{version}/pickup-bags/{id}` | Get pickup bag item by id |
+| `DELETE` | `/api/v{version}/pickup-bags/{id}` | Deletes an existing pickup bag |
+| `GET` | `/api/v{version}/pickup-bags/{trackingNumber}` | Get pickup bag item by tracking number |
+| `POST` | `/api/v{version}/pickup-bags/{trackingNumber}/parcels/search` | Search parcels of the given pickup bag tracking number |
+| `POST` | `/api/v{version}/territories/search` | Gets a list of territories |
+| `POST` | `/api/v{version}/workflows/search` | Gets a list of workflows |
+
+---
+
+### `POST /api/v{version}/orders/reports/search`
+
+**operationId:** `SearchOrdersReportsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Gets a list of Reports in orders module
+
+**description:**
+> Gets a list of Reports in orders module with pagination support.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchOrdersReportsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_SearchOrdersReportsResponse` |
+
+
+---
+
+### `POST /api/v{version}/orders/reports/{reportId}/download`
+
+**operationId:** `DownloadOrdersReportEndpoint`
+
+**tags:** `orders`
+
+**summary:** Download a report file by ID
+
+**description:**
+> Returns a SAS URL to download the report file by its ID.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `reportId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `DownloadReportResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcel-modification-requests`
+
+**operationId:** `CreateParcelModificationRequestEndpoint`
+
+**tags:** `orders`
+
+**summary:** Creates a parcel modification request
+
+**description:**
+> Creates a parcel modification request. Permissions required: SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateParcelModificationRequestRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `CreateParcelModificationRequestResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcel-modification-requests/phone`
+
+**operationId:** `ChangeParcelPhoneEndpoint`
+
+**tags:** `orders`
+
+**summary:** Change parcel phone (auto-applied modification request)
+
+**description:**
+> Creates an immediately validated phone modification request and applies Parcel.ChangePhone. Enforces modification-request preconditions and phone-change quota. Permissions required: SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `ChangeParcelPhoneRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `ChangeParcelPhoneResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcel-modification-requests/search`
+
+**operationId:** `SearchSupplierParcelsModificationRequestsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Search supplier's parcels' modification requests
+
+**description:**
+> Search supplier's parcels' modification requests. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchSupplierParcelsModificationRequestsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_ParcelModificationRequestResult` |
+
+
+---
+
+### `GET /api/v{version}/parcel-modification-requests/{id}`
+
+**operationId:** `GetParcelModificationRequestEndpoint`
+
+**tags:** `orders`
+
+**summary:** get parcel modification request item by id
+
+**description:**
+> gets parcel modification request item by id.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `ParcelModificationRequestResult` |
+
+
+---
+
+### `DELETE /api/v{version}/parcel-modification-requests/{id}`
+
+**operationId:** `DeleteParcelModificationRequestEndpoint`
+
+**tags:** `orders`
+
+**summary:** Deletes an existing parcel modification request
+
+**description:**
+> Deletes an existing parcel modification request before it is validated. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `DeleteParcelModificationRequestResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcel-modification-requests/{parcelId}`
+
+**operationId:** `SearchParcelModificationRequestsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Search parcels' modification requests
+
+**description:**
+> Search parcels' modification requests. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole, HubAdminRole, HubParcelsManagerRole, GlobalAdminRole, GlobalViewerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `parcelId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchParcelModificationRequestsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_ParcelModificationRequestResult` |
+
+
+---
+
+### `PATCH /api/v{version}/parcel-modification-requests/{requestId}`
+
+**operationId:** `UpdateParcelModificationRequestEndpoint`
+
+**tags:** `orders`
+
+**summary:** Updates an existing parcel modification request
+
+**description:**
+> Updates an existing parcel modification request before it is validated. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `requestId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateParcelModificationRequestRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateParcelModificationRequestResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcels`
+
+**operationId:** `CreateParcelEndpoint`
+
+**tags:** `orders`
+
+**summary:** Creates a parcel
+
+**description:**
+> Creates a parcel with products. The `StockType` parameter indicates the type of stock and accepts 'local' or 'warehouse'. Defaults to 'local' if not specified. the 'DeliveryType' parameter indicates the type of delivery and accepts 'home' or 'pickup-point'. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateParcelRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `CreateParcelResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcels/bulk`
+
+**operationId:** `CreateBulkParcelsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Create multiple parcels in bulk
+
+**description:**
+> Creates up to 100 parcels in a single request. 
+                Returns detailed success/failure information for each parcel.
+
+                Response Status Codes:
+                - 200 OK: All parcels created successfully
+                - 207 Multi-Status: Partial success (some parcels created, some failed)
+                - 400 Bad Request: All parcels failed validation or creation
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateBulkParcelsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `CreateBulkParcelsResponse` |
+| 207 | Multi-Status | `CreateBulkParcelsResponse` |
+| 400 | Bad Request | `CreateBulkParcelsResponse` |
+
+
+---
+
+### `DELETE /api/v{version}/parcels/bulk`
+
+**operationId:** `DeleteBulkParcelsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Delete multiple parcels in bulk
+
+**description:**
+> Deletes up to 200 parcels in a single request. 
+            Returns detailed success/failure information for each parcel.
+            
+            Important notes:
+            - ExchangeReturn parcels cannot be deleted
+            - If a parcel has a ReturnParcel, it will also be deleted
+            - If deleting a ReturnParcel, the OriginalParcel's IsExchanged flag will be reset
+
+            Response Status Codes:
+            - 200 OK: All parcels deleted successfully
+            - 207 Multi-Status: Partial success (some parcels deleted, some failed)
+            - 400 Bad Request: All parcels failed validation or deletion
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `DeleteBulkParcelsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `DeleteBulkParcelsResponse` |
+| 207 | Multi-Status | `DeleteBulkParcelsResponse` |
+| 400 | Bad Request | `DeleteBulkParcelsResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcels/bulk-exchange`
+
+**operationId:** `CreateBulkParcelExchangeEndpoint`
+
+**tags:** `orders`
+
+**summary:** Create multiple exchange parcels in bulk
+
+**description:**
+> Creates up to 100 exchange parcels in a single request. 
+        Each exchange can optionally create a return parcel for the original item.
+
+        Response Status Codes:
+        - 200 OK: All parcels created successfully
+        - 207 Multi-Status: Partial success (some parcels created, some failed)
+        - 400 Bad Request: All parcels failed validation or creation
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateBulkParcelExchangeRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `CreateBulkParcelExchangeResponse` |
+| 207 | Multi-Status | `CreateBulkParcelExchangeResponse` |
+| 400 | Bad Request | `CreateBulkParcelExchangeResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcels/bulk-refund`
+
+**operationId:** `CreateBulkParcelRefundEndpoint`
+
+**tags:** `orders`
+
+**summary:** Create multiple refund parcels in bulk
+
+**description:**
+> Creates up to 100 refund parcels in a single request.
+        The supplier balance is checked before creation to ensure sufficient funds.
+
+        Response Status Codes:
+        - 200 OK: All parcels created successfully
+        - 207 Multi-Status: Partial success (some parcels created, some failed)
+        - 400 Bad Request: All parcels failed validation or creation
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateBulkParcelRefundRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `CreateBulkParcelRefundResponse` |
+| 207 | Multi-Status | `CreateBulkParcelRefundResponse` |
+| 400 | Bad Request | `CreateBulkParcelRefundResponse` |
+
+
+---
+
+### `DELETE /api/v{version}/parcels/bulk/by-tracking-number`
+
+**operationId:** `DeleteBulkParcelsByTrackingNumberEndpoint`
+
+**tags:** `orders`
+
+**summary:** Delete multiple parcels by tracking numbers in bulk
+
+**description:**
+> Deletes up to 200 parcels in a single request using tracking numbers. 
+            Returns detailed success/failure information for each parcel.
+            
+            Important notes:
+            - ExchangeReturn parcels cannot be deleted
+            - If a parcel has a ReturnParcel, it will also be deleted
+            - If deleting a ReturnParcel, the OriginalParcel's IsExchanged flag will be reset
+
+            Response Status Codes:
+            - 200 OK: All parcels deleted successfully
+            - 207 Multi-Status: Partial success (some parcels deleted, some failed)
+            - 400 Bad Request: All parcels failed validation or deletion
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `DeleteBulkParcelsByTrackingNumberRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `DeleteBulkParcelsByTrackingNumberResponse` |
+| 207 | Multi-Status | `DeleteBulkParcelsByTrackingNumberResponse` |
+| 400 | Bad Request | `DeleteBulkParcelsByTrackingNumberResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcels/exchange`
+
+**operationId:** `CreateParcelExchangeEndpoint`
+
+**tags:** `orders`
+
+**summary:** Creates an exchange for a parcel
+
+**description:**
+> Creates an exchange for a parcel with products. The `StockType` parameter indicates the type of stock and accepts 'local' or 'warehouse'. Defaults to 'local' if not specified. the 'DeliveryType' parameter indicates the type of delivery and accepts 'home' or 'pickup-point'. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateParcelExchangeRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `CreateParcelExchangeResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcels/export`
+
+**operationId:** `ExportSupplierParcelsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Export supplier parcels to CSV
+
+**description:**
+> Exports a list of supplier parcels with filtering support. Returns an export job ID. Permissions required : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `ExportSupplierParcelsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `(inline string (uuid))` |
+
+
+---
+
+### `POST /api/v{version}/parcels/import-parcels`
+
+**operationId:** `ImportParcelsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Imports parcels from an Excel file
+
+**description:**
+> Imports parcels using an Excel file. Supports two formats: 1) multipart/form-data with 'file' field (recommended, more efficient), 2) JSON body with 'excelFileBase64' (legacy). Optionally provide a dictionary of columns and their matching propertyNames.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `multipart/form-data` → schema `ImportParcelsFormData`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `ParcelImportResult` |
+| 400 | Bad Request | `ProblemDetails` |
+
+
+---
+
+### `GET /api/v{version}/parcels/import-parcels/template`
+
+**operationId:** `DownloadTemplateBulkParcelsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Download template for importing bulk parcels
+
+**description:**
+> Returns an Excel template file for bulk importing parcels.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | - |
+
+
+---
+
+### `POST /api/v{version}/parcels/labels/individual`
+
+**operationId:** `GenerateIndividualLabelsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Generate individual parcel labels
+
+**description:**
+> Generates individual HTML files for each parcel label (max 100 parcels). Returns an array of tracking numbers with their file URLs and list of failed tracking numbers. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `GenerateIndividualLabelsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GenerateIndividualLabelsResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcels/labels/individual/pdf`
+
+**operationId:** `GenerateIndividualLabelsPdfEndpoint`
+
+**tags:** `orders`
+
+**summary:** Generate individual parcel labels as PDF
+
+**description:**
+> Generates individual PDF files for each parcel label (max 100 parcels). Supports A4 format (4 labels per page) or A6 format (1 label per page). Returns an array of tracking numbers with their PDF file URLs and list of failed tracking numbers. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `GenerateIndividualLabelsPdfRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GenerateIndividualLabelsPdfResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcels/labels/multiple`
+
+**operationId:** `GenerateMultipleLabelsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Generate multiple parcel labels in one HTML file
+
+**description:**
+> Generates parcel labels for multiple parcels (max 250) in a single HTML file. Returns the file URL with SAS token and list of failed tracking numbers. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `GenerateMultipleLabelsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GenerateMultipleLabelsResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcels/labels/multiple/pdf`
+
+**operationId:** `GenerateMultipleLabelsPdfEndpoint`
+
+**tags:** `orders`
+
+**summary:** Generate multiple parcel labels as a single PDF
+
+**description:**
+> Generates a single PDF file containing multiple parcel labels (max 250 parcels). Supports A4 format (4 labels per page) or A6 format (1 label per page). Returns the PDF file URL and list of failed tracking numbers. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `GenerateMultipleLabelsPdfRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GenerateMultipleLabelsPdfResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcels/refund`
+
+**operationId:** `CreateParcelRefundEndpoint`
+
+**tags:** `orders`
+
+**summary:** Creates a parcel refund
+
+**description:**
+> Creates a parcel refund. the 'DeliveryType' parameter indicates the type of delivery and accepts 'home' or 'pickup-point'. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateParcelRefundRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `CreateParcelRefundResponse` |
+
+
+---
+
+### `POST /api/v{version}/parcels/search`
+
+**operationId:** `SearchSupplierParcelsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Get a list of parcels
+
+**description:**
+> Get a list of parcels with pagination and filtering support. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchSupplierParcelsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_SearchSupplierParcelResponse` |
+
+
+---
+
+### `GET /api/v{version}/parcels/search/global`
+
+**operationId:** `SearchGlobalSupplierParcelsEndpointTop`
+
+**tags:** `orders`
+
+**summary:** Top global search of supplier parcels
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `keyword` | query | no | `string` |
+| 3 | `top` | query | no | `integer (int32)` — default=`10` |
+| 4 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `(inline array of SearchGlobalSupplierParcelResponse)` |
+
+
+---
+
+### `GET /api/v{version}/parcels/stats/workflow/{workflowId}/state/{stateId}`
+
+**operationId:** `GetSupplierSituationParcelsStatsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Gets parcels stats per situation Id for a workflow for the current supplier
+
+**description:**
+> Retrieves the number of parcels per situation  for the workflow identified by its id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `workflowId` | path | yes | `string (uuid)` |
+| 3 | `stateId` | path | yes | `string (uuid)` |
+| 4 | `parcelTypes` | query | no | `array of string` |
+| 5 | `isReturn` | query | no | `boolean` |
+| 6 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `(inline array of SupplierSituationParcelsStatsResponseItem)` |
+
+
+---
+
+### `GET /api/v{version}/parcels/stats/{workflowId}`
+
+**operationId:** `GetSupplierParcelsStatsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Gets parcels stats per state for a workflow for the current tenant
+
+**description:**
+> Retrieves the number of parcels per state for the workflow identified by its id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `workflowId` | path | yes | `string (uuid)` |
+| 3 | `parcelTypes` | query | no | `array of string` |
+| 4 | `isReturn` | query | no | `boolean` |
+| 5 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `(inline array of SupplierParcelsStatsResponseItem)` |
+
+
+---
+
+### `GET /api/v{version}/parcels/{id}`
+
+**operationId:** `GetParcelByIdSupplierEndpoint`
+
+**tags:** `orders`
+
+**summary:** get parcel item by id
+
+**description:**
+> gets parcel item by id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetSupplierParcelResponse` |
+
+
+---
+
+### `DELETE /api/v{version}/parcels/{id}`
+
+**operationId:** `DeleteParcelEndpoint`
+
+**tags:** `orders`
+
+**summary:** Delete a parcel
+
+**description:**
+> Delete a parcel by ID. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `DeleteParcelRespone` |
+
+
+---
+
+### `PATCH /api/v{version}/parcels/{id}/amount`
+
+**operationId:** `UpdateAmountEndpoint`
+
+**tags:** `orders`
+
+**summary:** Update an order's total amount
+
+**description:**
+> Update an order's total amount. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateAmountRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateAmountResponse` |
+
+
+---
+
+### `PATCH /api/v{version}/parcels/{id}/customer`
+
+**operationId:** `UpdateCustomerEndpoint`
+
+**tags:** `orders`
+
+**summary:** Update an parcel's customer infos
+
+**description:**
+> Update an parcel's customer infos. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateCustomerRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateCustomerResponse` |
+
+
+---
+
+### `PATCH /api/v{version}/parcels/{id}/deliveryAddress`
+
+**operationId:** `UpdateDeliveryAddressEndpoint`
+
+**tags:** `orders`
+
+**summary:** Update an order's delivery address
+
+**description:**
+> Update an order's delivery address. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateDeliveryAddressRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateDeliveryAddressResponse` |
+
+
+---
+
+### `PATCH /api/v{version}/parcels/{parcelId}/products`
+
+**operationId:** `UpdateOrderedProductsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Update products of an parcel
+
+**description:**
+> Update products of an parcel. The `StockType` parameter indicates the type of stock and accepts 'local' or 'warehouse'. Defaults to 'local' if not specified. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `parcelId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateOrderedProductsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 202 | Accepted | `UpdateOrderProductsResponse` |
+
+
+---
+
+### `PATCH /api/v{version}/parcels/{parcelId}/state`
+
+**operationId:** `UpdateParcelStateEndpoint`
+
+**tags:** `orders`
+
+**summary:** Updates parcel state
+
+**description:**
+> Updates parcel state. Permissions requises : HubParcelsManagerRole, HubAdminRole, SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `parcelId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateParcelStateRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateParcelStateResponse` |
+
+
+---
+
+### `GET /api/v{version}/parcels/{parcelId}/state-history`
+
+**operationId:** `GetParcelStateHistorySupplierEndpoint`
+
+**tags:** `orders`
+
+**summary:** gets parcel state history
+
+**description:**
+> gets parcel state history. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `parcelId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `(inline array of ParcelStateHistoryDto)` |
+
+
+---
+
+### `POST /api/v{version}/parcels/{parcelId}/state-history/{parcelStateHistoryId}/workflow/{workflowId}/situation-history`
+
+**operationId:** `CreateParcelStateSituationHistorySupplierEndpoint`
+
+**tags:** `orders`
+
+**summary:** Creates a parcel state situation history
+
+**description:**
+> Creates a parcel state situation history. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `parcelId` | path | yes | `string (uuid)` |
+| 3 | `parcelStateHistoryId` | path | yes | `string (uuid)` |
+| 4 | `workflowId` | path | yes | `string (uuid)` |
+| 5 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateParcelStateSituationHistorySupplierRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `CreateParcelStateSituationHistorySupplierResponse` |
+
+
+---
+
+### `PATCH /api/v{version}/parcels/{parcelId}/state/refund`
+
+**operationId:** `UpdateParcelRefundStateEndpoint`
+
+**tags:** `orders`
+
+**summary:** Updates parcel state for a refund
+
+**description:**
+> Updates parcel state for a refund. Permissions requises : HubDeliveryPeopleSettlementMangerRole, HubAdminRole, HubParcelsSettlementMangerRole,SupplierAdminRole,SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `parcelId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateParcelRefundStateRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateParcelRefundStateResponse` |
+
+
+---
+
+### `GET /api/v{version}/parcels/{trackingNumber}`
+
+**operationId:** `GetParcelByTrackingNumberSupplierEndpoint`
+
+**tags:** `orders`
+
+**summary:** get parcel item by trackingNumber
+
+**description:**
+> gets parcel item by id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `trackingNumber` | path | yes | `string` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetSupplierParcelResponse` |
+
+
+---
+
+### `POST /api/v{version}/pickup-bags`
+
+**operationId:** `CreatePickupBagEndpoint`
+
+**tags:** `orders`
+
+**summary:** Creates a pickup bag.
+
+**description:**
+> Creates a pickup bag. Permissions required: SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreatePickupBagRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `CreatePickupBagResponse` |
+
+
+---
+
+### `POST /api/v{version}/pickup-bags/labels/pdf`
+
+**operationId:** `GeneratePickupBagLabelPdfEndpoint`
+
+**tags:** `orders`
+
+**summary:** Generate pickup bag label as PDF
+
+**description:**
+> Generates a PDF label for a specific pickup bag in A4 format. Returns the tracking number and the PDF file URL.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `GeneratePickupBagLabelPdfRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GeneratePickupBagLabelPdfResponse` |
+
+
+---
+
+### `POST /api/v{version}/pickup-bags/search`
+
+**operationId:** `SearchSupplierPickupBagsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Search all supplier's pickup bags
+
+**description:**
+> Search all supplier's pickup bags. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchSupplierPickupBagsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_SupplierPickupBagResult` |
+
+
+---
+
+### `PATCH /api/v{version}/pickup-bags/{bagId}/add-parcel`
+
+**operationId:** `AddParcelsToPickupBagEndpoint`
+
+**tags:** `orders`
+
+**summary:** Add a parcel to a pickup bag
+
+**description:**
+> Add a parcel to an existing pickup bag.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `bagId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `AddParcelsToPickupBagRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `AddParcelsToPickupBagResponse` |
+
+
+---
+
+### `PATCH /api/v{version}/pickup-bags/{bagId}/remove-parcel`
+
+**operationId:** `RemoveParcelFromPickupBagEndpoint`
+
+**tags:** `orders`
+
+**summary:** Remove a parcel from a pickup bag
+
+**description:**
+> Remove a parcel from an existing pickup bag.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `bagId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `RemoveParcelFromPickupBagRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `RemoveParcelsFromPickupBagResponse` |
+
+
+---
+
+### `GET /api/v{version}/pickup-bags/{id}`
+
+**operationId:** `GetSupplierPickupBagByIdEndpoint`
+
+**tags:** `orders`
+
+**summary:** Get pickup bag item by id
+
+**description:**
+> Get pickup bag item by id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `SupplierPickupBagResult` |
+
+
+---
+
+### `DELETE /api/v{version}/pickup-bags/{id}`
+
+**operationId:** `DeletePickupBagEndpoint`
+
+**tags:** `orders`
+
+**summary:** Deletes an existing pickup bag
+
+**description:**
+> Deletes an existing pickup bag. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `DeletePickupBagResponse` |
+
+
+---
+
+### `GET /api/v{version}/pickup-bags/{trackingNumber}`
+
+**operationId:** `GetSupplierPickupBagByTrackingNumberEndpoint`
+
+**tags:** `orders`
+
+**summary:** Get pickup bag item by tracking number
+
+**description:**
+> Get pickup bag item by tracking number. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `trackingNumber` | path | yes | `string` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `SupplierPickupBagResult` |
+
+
+---
+
+### `POST /api/v{version}/pickup-bags/{trackingNumber}/parcels/search`
+
+**operationId:** `SearchSupplierPickupBagByTrackingNumberEndpoint`
+
+**tags:** `orders`
+
+**summary:** Search parcels of the given pickup bag tracking number
+
+**description:**
+> Search parcels of the given pickup bag tracking number.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `trackingNumber` | path | yes | `string` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchSupplierPickupBagByTrackingNumberRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_PickupBagParcelResponse` |
+
+
+---
+
+### `POST /api/v{version}/territories/search`
+
+**operationId:** `SearchTerritoriesEndpoint`
+
+**tags:** `orders`
+
+**summary:** Gets a list of territories
+
+**description:**
+> Gets a list of territories with pagination and filtering support
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchTerritoriesRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_TerritoryResponse` |
+
+
+---
+
+### `POST /api/v{version}/workflows/search`
+
+**operationId:** `SearchWorkflowsEndpoint`
+
+**tags:** `orders`
+
+**summary:** Gets a list of workflows
+
+**description:**
+> Gets a list of workflows with pagination and filtering support
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchWorkflowsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_WorkflowResponse` |
+
+
+---

--- a/.agents/skills/zr-express/references/supplier.md
+++ b/.agents/skills/zr-express/references/supplier.md
@@ -1,0 +1,110 @@
+# ZR Express API — `supplier`
+
+> Do not alter. Machine-generated verbatim from `swagger.json`. Re-run the generator to refresh.
+
+Source spec: `swagger.json` (raw) · Index: `endpoints-index.md`
+Full request/response shapes: `../schemas/supplier.json`
+
+Endpoints in this domain: **3**
+
+| Method | Path | Summary |
+|--------|------|---------|
+| `GET` | `/api/v{version}/supplier/supplier-price-list-assignments/{supplierId}` | List supplier price list assignments by origin territory |
+| `POST` | `/api/v{version}/supplier/{supplierId}` | gets supplier item by id |
+| `PATCH` | `/api/v{version}/supplier/{supplierId}/blocked` | Update supplier blocked status |
+
+---
+
+### `GET /api/v{version}/supplier/supplier-price-list-assignments/{supplierId}`
+
+**operationId:** `ListSupplierPriceListAssignmentsEndpoint`
+
+**tags:** `supplier`
+
+**summary:** List supplier price list assignments by origin territory
+
+**description:**
+> Returns all origin-territory price list assignments configured for a supplier.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `supplierId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | - |
+
+
+---
+
+### `POST /api/v{version}/supplier/{supplierId}`
+
+**operationId:** `GetSupplierEndpoint`
+
+**tags:** `supplier`
+
+**summary:** gets supplier item by id
+
+**description:**
+> gets supplier item by id. Permissions requises : GlobalAdminRole, GlobalViewerRole, HubAdminRole, HubSuppliersManagerRole, et tous les SupplierRoles.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `supplierId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `GetSupplierRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetSupplierResponse` |
+
+
+---
+
+### `PATCH /api/v{version}/supplier/{supplierId}/blocked`
+
+**operationId:** `UpdateSupplierBlockedStatusEndpoint`
+
+**tags:** `supplier`
+
+**summary:** Update supplier blocked status
+
+**description:**
+> Sets whether the supplier is blocked from parcel operations. Super-admins and operations admins (root / sub-contractor).
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `supplierId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateSupplierBlockedStatusRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateSupplierBlockedStatusResponse` |
+
+
+---

--- a/.agents/skills/zr-express/references/treasury.md
+++ b/.agents/skills/zr-express/references/treasury.md
@@ -1,0 +1,491 @@
+# ZR Express API — `treasury`
+
+> Do not alter. Machine-generated verbatim from `swagger.json`. Re-run the generator to refresh.
+
+Source spec: `swagger.json` (raw) · Index: `endpoints-index.md`
+Full request/response shapes: `../schemas/treasury.json`
+
+Endpoints in this domain: **15**
+
+| Method | Path | Summary |
+|--------|------|---------|
+| `POST` | `/api/v{version}/payment-request` | Creates a payment request |
+| `POST` | `/api/v{version}/payment-request/search` | Search payment requests (supplier) |
+| `GET` | `/api/v{version}/payment-request/{id}` | Gets a payment request by id (supplier) |
+| `DELETE` | `/api/v{version}/payment-request/{id}` | Deletes a payment request |
+| `PATCH` | `/api/v{version}/payment-request/{id}/date` | Updates the requested date of a payment request |
+| `POST` | `/api/v{version}/supplier-payment/export` | Export a list of SupplierPayment current supplier |
+| `POST` | `/api/v{version}/supplier-payment/search` | Gets a list of SupplierPayment current supplier |
+| `GET` | `/api/v{version}/supplier-payment/stats/current-supplier` | Get transactions stats current supplier. |
+| `GET` | `/api/v{version}/supplier-payment/supplier-balance` | get supplier balance by a supplier |
+| `POST` | `/api/v{version}/supplier-payment/{id}/details` | Get supplier payment details |
+| `PUT` | `/api/v{version}/supplier-payment/{referenceId}` | Accept a payment by a supplier |
+| `PUT` | `/api/v{version}/supplier-payment/{supplierPaymentId}` | Accept a payment by a supplier |
+| `POST` | `/api/v{version}/treasury-transactions/search/supplier-payment/by-supplier-payment/{supplierPaymentId}` | Gets a list of transactions linked to a supplier payment |
+| `POST` | `/api/v{version}/treasury/reports/search` | Gets a list of Reports |
+| `POST` | `/api/v{version}/treasury/reports/{reportId}/download` | Download a report file by ID in treasury module |
+
+---
+
+### `POST /api/v{version}/payment-request`
+
+**operationId:** `CreatePaymentRequestEndpoint`
+
+**tags:** `treasury`
+
+**summary:** Creates a payment request
+
+**description:**
+> Creates a payment request. The requested date must be at least tomorrow. Permissions required: SupplierAdminRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreatePaymentRequestRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `CreatePaymentRequestResponse` |
+
+
+---
+
+### `POST /api/v{version}/payment-request/search`
+
+**operationId:** `SearchPaymentRequestsCurrentSupplierEndpoint`
+
+**tags:** `treasury`
+
+**summary:** Search payment requests (supplier)
+
+**description:**
+> Search payment requests for the current supplier. Permissions required: SupplierAdminRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchPaymentRequestsCurrentSupplierRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_PaymentRequestResponse` |
+
+
+---
+
+### `GET /api/v{version}/payment-request/{id}`
+
+**operationId:** `GetPaymentRequestCurrentSupplierEndpoint`
+
+**tags:** `treasury`
+
+**summary:** Gets a payment request by id (supplier)
+
+**description:**
+> Gets a payment request by id. Permissions required: SupplierAdminRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PaymentRequestResponse` |
+
+
+---
+
+### `DELETE /api/v{version}/payment-request/{id}`
+
+**operationId:** `DeletePaymentRequestEndpoint`
+
+**tags:** `treasury`
+
+**summary:** Deletes a payment request
+
+**description:**
+> Deletes a payment request. Only pending requests can be deleted. Permissions required: SupplierAdminRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `DeletePaymentRequestResponse` |
+
+
+---
+
+### `PATCH /api/v{version}/payment-request/{id}/date`
+
+**operationId:** `UpdatePaymentRequestDateEndpoint`
+
+**tags:** `treasury`
+
+**summary:** Updates the requested date of a payment request
+
+**description:**
+> Updates the requested date. Only pending requests can be updated. The date must be at least tomorrow. Permissions required: SupplierAdminRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdatePaymentRequestDateRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdatePaymentRequestDateResponse` |
+
+
+---
+
+### `POST /api/v{version}/supplier-payment/export`
+
+**operationId:** `ExportSupplierPaymentsCurrentSupplierEndpoint`
+
+**tags:** `treasury`
+
+**summary:** Export a list of SupplierPayment current supplier
+
+**description:**
+> Export a list of SupplierPayment current supplier with pagination and filtering support
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `ExportSupplierPaymentsCurrentSupplierRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `(inline string (uuid))` |
+
+
+---
+
+### `POST /api/v{version}/supplier-payment/search`
+
+**operationId:** `SearchSupplierPaymentsCurrentSupplierEndpoint`
+
+**tags:** `treasury`
+
+**summary:** Gets a list of SupplierPayment current supplier
+
+**description:**
+> Gets a list of SupplierPayment current supplier with pagination and filtering support
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchSupplierPaymentsCurrentSupplierRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_SupplierPaymentResponse` |
+
+
+---
+
+### `GET /api/v{version}/supplier-payment/stats/current-supplier`
+
+**operationId:** `GetTransactionsStatsCurrentSupplierEndpoint`
+
+**tags:** `treasury`
+
+**summary:** Get transactions stats current supplier.
+
+**description:**
+> Get transactions stats current supplier.Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `SupplierTransactionStatsDto` |
+
+
+---
+
+### `GET /api/v{version}/supplier-payment/supplier-balance`
+
+**operationId:** `GetSupplierStatsAmountEndpoint`
+
+**tags:** `treasury`
+
+**summary:** get supplier balance by a supplier
+
+**description:**
+> E-commerce supplier FO balance badges. Classic-mail suppliers must use /supplier-balance/classic-mail. Permissions: SupplierAdminRole.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetSupplierStatsAmountResponse` |
+
+
+---
+
+### `POST /api/v{version}/supplier-payment/{id}/details`
+
+**operationId:** `GetSupplierPaymentCurrentSupplierEndpoint`
+
+**tags:** `treasury`
+
+**summary:** Get supplier payment details
+
+**description:**
+> Get the details of a supplier payment by its ID.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `GetSupplierPaymentCurrentSupplierRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `SupplierPaymentSupplierResponse` |
+
+
+---
+
+### `PUT /api/v{version}/supplier-payment/{referenceId}`
+
+**operationId:** `AcceptSupplierPaymentByReferenceIdEndpoint`
+
+**tags:** `treasury`
+
+**summary:** Accept a payment by a supplier
+
+**description:**
+> Accept a payment by a supplier
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `referenceId` | path | yes | `string` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `AcceptSupplierPaymentByReferenceIdRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `AcceptSupplierPaymentByReferenceIResponse` |
+
+
+---
+
+### `PUT /api/v{version}/supplier-payment/{supplierPaymentId}`
+
+**operationId:** `AcceptSupplierPaymentEndpoint`
+
+**tags:** `treasury`
+
+**summary:** Accept a payment by a supplier
+
+**description:**
+> Accept a payment by a supplier
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `supplierPaymentId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `AcceptSupplierPaymentRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `AcceptSupplierPaymentResponse` |
+
+
+---
+
+### `POST /api/v{version}/treasury-transactions/search/supplier-payment/by-supplier-payment/{supplierPaymentId}`
+
+**operationId:** `SearchTreasuryTransactionsSupplierPaymentBySupplierPaymentIdEndpoint`
+
+**tags:** `treasury-transactions`
+
+**summary:** Gets a list of transactions linked to a supplier payment
+
+**description:**
+> Gets a list of transactions with pagination and filtering support linked to a supplier payment
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `supplierPaymentId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchTreasuryTransactionsSupplierPaymentBySupplierPaymentIdRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_TreasurySupplierPaymentTransactionResponse` |
+
+
+---
+
+### `POST /api/v{version}/treasury/reports/search`
+
+**operationId:** `SearchTreasuryReportsEndpoint`
+
+**tags:** `treasury`
+
+**summary:** Gets a list of Reports
+
+**description:**
+> Gets a list of Reports in treasury module with pagination and filtering support
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchTreasuryReportsRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `PagedList_SearchReportsResponse` |
+
+
+---
+
+### `POST /api/v{version}/treasury/reports/{reportId}/download`
+
+**operationId:** `DownloadTreasuryReportByIdEndpoint`
+
+**tags:** `treasury`
+
+**summary:** Download a report file by ID in treasury module
+
+**description:**
+> Returns a SAS URL to download the report file by its ID.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `reportId` | path | yes | `string (uuid)` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `DownloadReportByIdResponse` |
+
+
+---

--- a/.agents/skills/zr-express/references/users.md
+++ b/.agents/skills/zr-express/references/users.md
@@ -1,0 +1,133 @@
+# ZR Express API — `users`
+
+> Do not alter. Machine-generated verbatim from `swagger.json`. Re-run the generator to refresh.
+
+Source spec: `swagger.json` (raw) · Index: `endpoints-index.md`
+Full request/response shapes: `../schemas/users.json`
+
+Endpoints in this domain: **4**
+
+| Method | Path | Summary |
+|--------|------|---------|
+| `POST` | `/api/v{version}/users/keys` | Generate API Key |
+| `POST` | `/api/v{version}/users/keys/search` | Search user tokens with advanced filtering |
+| `DELETE` | `/api/v{version}/users/keys/{id}` | Delete API Key |
+| `GET` | `/api/v{version}/users/profile` | Get current user information based on token |
+
+---
+
+### `POST /api/v{version}/users/keys`
+
+**operationId:** `GenerateUserKeyEndpoint`
+
+**tags:** `users`
+
+**summary:** Generate API Key
+
+**description:**
+> Generates a secure API key for user authentication.\n
+                        Supported expiration values : 7, 30, 90, 180, 365 days.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateUserKeyRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | - |
+
+
+---
+
+### `POST /api/v{version}/users/keys/search`
+
+**operationId:** `SearchUserKeysEndpoint`
+
+**tags:** `users`
+
+**summary:** Search user tokens with advanced filtering
+
+**description:**
+> Search user tokens with pagination support.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+
+**requestBody:**
+
+- `application/json` → schema `SearchUserKeysRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | - |
+
+
+---
+
+### `DELETE /api/v{version}/users/keys/{id}`
+
+**operationId:** `DeleteUserKeyEndpoint`
+
+**tags:** `users`
+
+**summary:** Delete API Key
+
+**description:**
+> Delete an API key for the users.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `id` | path | yes | `string (uuid)` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | - |
+
+
+---
+
+### `GET /api/v{version}/users/profile`
+
+**operationId:** `GetMeEndpoint`
+
+**tags:** `users`
+
+**summary:** Get current user information based on token
+
+**description:**
+> Get current user information based on token
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UserDetail` |
+
+
+---

--- a/.agents/skills/zr-express/references/webhooks.md
+++ b/.agents/skills/zr-express/references/webhooks.md
@@ -1,0 +1,250 @@
+# ZR Express API — `webhooks`
+
+> Do not alter. Machine-generated verbatim from `swagger.json`. Re-run the generator to refresh.
+
+Source spec: `swagger.json` (raw) · Index: `endpoints-index.md`
+Full request/response shapes: `../schemas/webhooks.json`
+
+Endpoints in this domain: **7**
+
+| Method | Path | Summary |
+|--------|------|---------|
+| `POST` | `/api/v{version}/webhooks/endpoints` | Create a webhook endpoint |
+| `GET` | `/api/v{version}/webhooks/endpoints` | List webhook endpoints |
+| `PUT` | `/api/v{version}/webhooks/endpoints/{endpointId}` | Update a webhook endpoint |
+| `GET` | `/api/v{version}/webhooks/endpoints/{endpointId}` | Get a webhook endpoint |
+| `DELETE` | `/api/v{version}/webhooks/endpoints/{endpointId}` | Delete a webhook endpoint |
+| `GET` | `/api/v{version}/webhooks/endpoints/{endpointId}/headers` | Get webhook endpoint headers |
+| `GET` | `/api/v{version}/webhooks/endpoints/{endpointId}/secret` | Get webhook endpoint secret |
+
+---
+
+### `POST /api/v{version}/webhooks/endpoints`
+
+**operationId:** `CreateEndpointEndpoint`
+
+**tags:** `webhooks`
+
+**summary:** Create a webhook endpoint
+
+**description:**
+> Creates a new webhook endpoint for the supplier to receive webhook events
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `CreateEndpointRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 201 | Created | `CreateEndpointResponse` |
+| 400 | Bad Request | `ProblemDetails` |
+| 401 | Unauthorized | `ProblemDetails` |
+| 403 | Forbidden | `ProblemDetails` |
+
+
+---
+
+### `GET /api/v{version}/webhooks/endpoints`
+
+**operationId:** `ListEndpointsEndpoint`
+
+**tags:** `webhooks`
+
+**summary:** List webhook endpoints
+
+**description:**
+> Retrieves all webhook endpoints configured for the supplier
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `ListEndpointsResponse` |
+| 400 | Bad Request | `ProblemDetails` |
+| 401 | Unauthorized | `ProblemDetails` |
+| 403 | Forbidden | `ProblemDetails` |
+
+
+---
+
+### `PUT /api/v{version}/webhooks/endpoints/{endpointId}`
+
+**operationId:** `UpdateEndpointEndpoint`
+
+**tags:** `webhooks`
+
+**summary:** Update a webhook endpoint
+
+**description:**
+> Updates an existing webhook endpoint configuration
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `endpointId` | path | yes | `string` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**requestBody:**
+
+- `application/json` → schema `UpdateEndpointRequest`
+- **required**
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `UpdateEndpointResponse` |
+| 400 | Bad Request | `ProblemDetails` |
+| 401 | Unauthorized | `ProblemDetails` |
+| 403 | Forbidden | `ProblemDetails` |
+| 404 | Not Found | `ProblemDetails` |
+
+
+---
+
+### `GET /api/v{version}/webhooks/endpoints/{endpointId}`
+
+**operationId:** `GetEndpointEndpoint`
+
+**tags:** `webhooks`
+
+**summary:** Get a webhook endpoint
+
+**description:**
+> Retrieves the details of a specific webhook endpoint by its ID
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `endpointId` | path | yes | `string` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetEndpointResponse` |
+| 400 | Bad Request | `ProblemDetails` |
+| 401 | Unauthorized | `ProblemDetails` |
+| 403 | Forbidden | `ProblemDetails` |
+| 404 | Not Found | `ProblemDetails` |
+
+
+---
+
+### `DELETE /api/v{version}/webhooks/endpoints/{endpointId}`
+
+**operationId:** `DeleteEndpointEndpoint`
+
+**tags:** `webhooks`
+
+**summary:** Delete a webhook endpoint
+
+**description:**
+> Deletes a webhook endpoint permanently
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `endpointId` | path | yes | `string` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 204 | No Content | - |
+| 400 | Bad Request | `ProblemDetails` |
+| 401 | Unauthorized | `ProblemDetails` |
+| 403 | Forbidden | `ProblemDetails` |
+| 404 | Not Found | `ProblemDetails` |
+
+
+---
+
+### `GET /api/v{version}/webhooks/endpoints/{endpointId}/headers`
+
+**operationId:** `GetEndpointHeadersEndpoint`
+
+**tags:** `webhooks`
+
+**summary:** Get webhook endpoint headers
+
+**description:**
+> Retrieves the custom headers configured for a specific webhook endpoint
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `endpointId` | path | yes | `string` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetEndpointHeadersResponse` |
+| 400 | Bad Request | `ProblemDetails` |
+| 401 | Unauthorized | `ProblemDetails` |
+| 403 | Forbidden | `ProblemDetails` |
+| 404 | Not Found | `ProblemDetails` |
+
+
+---
+
+### `GET /api/v{version}/webhooks/endpoints/{endpointId}/secret`
+
+**operationId:** `GetEndpointSecretEndpoint`
+
+**tags:** `webhooks`
+
+**summary:** Get webhook endpoint secret
+
+**description:**
+> Retrieves the signing secret for a specific webhook endpoint. This secret should be used to verify webhook signatures.
+
+**parameters:**
+
+| # | name | in | required | description / schema |
+|---|------|----|----------|----------------------|
+| 1 | `version` | path | yes | The requested API version — `string` — default=`1` |
+| 2 | `endpointId` | path | yes | `string` |
+| 3 | `X-Tenant` | header | yes | Input your tenant Id to access this API — `string` |
+
+**responses:**
+
+| status | description | schema |
+|--------|-------------|--------|
+| 200 | OK | `GetEndpointSecretResponse` |
+| 400 | Bad Request | `ProblemDetails` |
+| 401 | Unauthorized | `ProblemDetails` |
+| 403 | Forbidden | `ProblemDetails` |
+| 404 | Not Found | `ProblemDetails` |
+
+
+---

--- a/.agents/skills/zr-express/schemas/catalog.json
+++ b/.agents/skills/zr-express/schemas/catalog.json
@@ -1,0 +1,1337 @@
+{
+  "ImportProductFormData": {
+    "type": "object",
+    "properties": {
+      "file": {
+        "type": "string",
+        "format": "binary",
+        "nullable": true
+      },
+      "columnsAndTheirPropertyNames": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ExportProductsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      }
+    },
+    "additionalProperties": false
+  },
+  "Filter": {
+    "type": "object",
+    "properties": {
+      "logic": {
+        "type": "string",
+        "nullable": true
+      },
+      "filters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Filter"
+        },
+        "nullable": true
+      },
+      "field": {
+        "type": "string",
+        "nullable": true
+      },
+      "operator": {
+        "type": "string",
+        "nullable": true
+      },
+      "value": {
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "Search": {
+    "type": "object",
+    "properties": {
+      "fields": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_SearchProductResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SearchProductResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchProductResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "tenantId": {
+        "type": "string",
+        "nullable": true
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "sku": {
+        "type": "string",
+        "nullable": true
+      },
+      "localStock": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "categoryName": {
+        "type": "string",
+        "nullable": true
+      },
+      "categoryNameArabic": {
+        "type": "string",
+        "nullable": true
+      },
+      "categoryNameEnglish": {
+        "type": "string",
+        "nullable": true
+      },
+      "subCategoryName": {
+        "type": "string",
+        "nullable": true
+      },
+      "subCategoryNameArabic": {
+        "type": "string",
+        "nullable": true
+      },
+      "subCategoryNameEnglish": {
+        "type": "string",
+        "nullable": true
+      },
+      "price": {
+        "$ref": "#/components/schemas/PriceResponse"
+      },
+      "purchasePrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "dimensions": {
+        "$ref": "#/components/schemas/DimensionsResponse"
+      },
+      "warehouseStock": {
+        "$ref": "#/components/schemas/WarehouseStockResponse"
+      },
+      "weight": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "variants": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/VariantResponse"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "VariantResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "color": {
+        "type": "string",
+        "nullable": true
+      },
+      "stockQuantity": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "price": {
+        "$ref": "#/components/schemas/PriceResponse"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PriceResponse": {
+    "type": "object",
+    "properties": {
+      "base": {
+        "type": "number",
+        "format": "double"
+      },
+      "promotional": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "promotionStart": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "promotionEnd": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "WarehouseStockResponse": {
+    "type": "object",
+    "properties": {
+      "damageQuantity": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "availableQuantity": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pendingReceptionQuantity": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "withdrawalQuantity": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "underDeliveryQuantity": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "deliveredQuantity": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "hubName": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "DimensionsResponse": {
+    "type": "object",
+    "properties": {
+      "length": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "width": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "height": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeleteProductResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_SearchProductsReportsResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SearchProductsReportsResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchProductsReportsResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "tenantId": {
+        "type": "string",
+        "nullable": true
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "createdBy": {
+        "$ref": "#/components/schemas/UserSnapshot"
+      },
+      "status": {
+        "type": "string",
+        "nullable": true
+      },
+      "fileId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UserSnapshot": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "readOnly": true
+      },
+      "fullName": {
+        "type": "string",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateDiscountRequest": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "promotionalPrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "promotionStart": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "promotionEnd": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateProductStockMovementUserRequest": {
+    "type": "object",
+    "properties": {
+      "products": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ProductStockRequest"
+        },
+        "nullable": true
+      },
+      "hubStockId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "ProductStockRequest": {
+    "type": "object",
+    "properties": {
+      "productId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "quantity": {
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetProductResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "sku": {
+        "type": "string",
+        "nullable": true
+      },
+      "category": {
+        "$ref": "#/components/schemas/CategoryResponse"
+      },
+      "subCategory": {
+        "$ref": "#/components/schemas/SubCategoryResponse"
+      },
+      "price": {
+        "$ref": "#/components/schemas/PriceResponse"
+      },
+      "purchasePrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "dimensions": {
+        "$ref": "#/components/schemas/DimensionsResponse"
+      },
+      "localStock": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "warehouseStocks": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/WarehouseStockResponse"
+        },
+        "nullable": true
+      },
+      "weight": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "variants": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/VariantResponse"
+        },
+        "nullable": true
+      },
+      "stockMovements": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/StockMovementResponse"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "StockMovementResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "quantity": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "productInfo": {
+        "$ref": "#/components/schemas/ProductInfoResponse"
+      },
+      "receipt": {
+        "$ref": "#/components/schemas/ReceiptResponse"
+      }
+    },
+    "additionalProperties": false
+  },
+  "ReceiptResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "totalProducts": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "referenceId": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ProductInfoResponse": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "price": {
+        "type": "number",
+        "format": "double"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SubCategoryResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "nameArabic": {
+        "type": "string",
+        "nullable": true
+      },
+      "nameEnglish": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CategoryResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "nameArabic": {
+        "type": "string",
+        "nullable": true
+      },
+      "nameEnglish": {
+        "type": "string",
+        "nullable": true
+      },
+      "subCategories": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SubCategoryResponse"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetProductRequest": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "includeReceipts": {
+        "type": "boolean"
+      },
+      "includeStockMovement": {
+        "type": "boolean"
+      },
+      "includeWarehouseStock": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchProductsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateProductResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ProblemDetails": {
+    "type": "object",
+    "properties": {
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "title": {
+        "type": "string",
+        "nullable": true
+      },
+      "status": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "detail": {
+        "type": "string",
+        "nullable": true
+      },
+      "instance": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": {}
+  },
+  "UpdatePriceResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateProductLocalStockResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdatePriceRequest": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "basePrice": {
+        "type": "number",
+        "format": "double"
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetReceiptResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "referenceId": {
+        "type": "string",
+        "nullable": true
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "totalProducts": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "supplier": {
+        "$ref": "#/components/schemas/SupplierInfoDto"
+      },
+      "address": {
+        "$ref": "#/components/schemas/ReceiptAddressDto"
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "receivedBy": {
+        "type": "string",
+        "nullable": true
+      },
+      "stockMovements": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/StockMovementsReceiptResponse"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "StockMovementsReceiptResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "quantity": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "productInfo": {
+        "$ref": "#/components/schemas/ProductInfoResponse"
+      }
+    },
+    "additionalProperties": false
+  },
+  "ReceiptAddressDto": {
+    "type": "object",
+    "properties": {
+      "street": {
+        "type": "string",
+        "nullable": true
+      },
+      "city": {
+        "type": "string",
+        "nullable": true
+      },
+      "cityTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "district": {
+        "type": "string",
+        "nullable": true
+      },
+      "districtTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "postalCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "country": {
+        "type": "string",
+        "nullable": true
+      },
+      "coordinates": {
+        "$ref": "#/components/schemas/Coordinates"
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "hubName": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "Coordinates": {
+    "type": "object",
+    "properties": {
+      "lat": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "lng": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SupplierInfoDto": {
+    "type": "object",
+    "properties": {
+      "supplierId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchProductsReportsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchCategoriesRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "includeSubCategories": {
+        "type": "boolean"
+      },
+      "expiration": {
+        "type": "string",
+        "format": "date-span",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateProductLocalStockRequest": {
+    "type": "object",
+    "properties": {
+      "productId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "localStock": {
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchReceiptsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateDiscountResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateProductResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "DownloadProductsReportResponse": {
+    "type": "object",
+    "properties": {
+      "sasUrl": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ProductImportResult": {
+    "type": "object",
+    "properties": {
+      "succeededs": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SucceededImportProductResult"
+        },
+        "nullable": true
+      },
+      "faileds": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/FailedImportProductResult"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "FailedImportProductResult": {
+    "type": "object",
+    "properties": {
+      "rowIndex": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "errorMessage": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SucceededImportProductResult": {
+    "type": "object",
+    "properties": {
+      "rowIndex": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "productId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateProductRequest": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "categoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "subCategoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "length": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "purchasePrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "width": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "height": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "weight": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "sku": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateProductStockMovementUserResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_CategoryResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/CategoryResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_SearchReceiptResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SearchReceiptResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchReceiptResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "referenceId": {
+        "type": "string",
+        "nullable": true
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "totalProducts": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "supplier": {
+        "$ref": "#/components/schemas/SupplierInfoDto"
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "receivedBy": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateProductRequest": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "localStock": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "sku": {
+        "type": "string",
+        "nullable": true
+      },
+      "categoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "subCategoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "basePrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "purchasePrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "length": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "width": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "height": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "weight": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/.agents/skills/zr-express/schemas/claims.json
+++ b/.agents/skills/zr-express/schemas/claims.json
@@ -1,0 +1,761 @@
+{
+  "CreateClaimRequest": {
+    "type": "object",
+    "properties": {
+      "categoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "title": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchClaimCategoriesRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "expiration": {
+        "type": "string",
+        "format": "date-span",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "Filter": {
+    "type": "object",
+    "properties": {
+      "logic": {
+        "type": "string",
+        "nullable": true
+      },
+      "filters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Filter"
+        },
+        "nullable": true
+      },
+      "field": {
+        "type": "string",
+        "nullable": true
+      },
+      "operator": {
+        "type": "string",
+        "nullable": true
+      },
+      "value": {
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "Search": {
+    "type": "object",
+    "properties": {
+      "fields": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateClaimDetailsRequest": {
+    "type": "object",
+    "properties": {
+      "claimId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "categoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "title": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ClaimResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "title": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "parcel": {
+        "$ref": "#/components/schemas/ParcelInfoClaimDto"
+      },
+      "state": {
+        "$ref": "#/components/schemas/StateClaimResponse"
+      },
+      "category": {
+        "$ref": "#/components/schemas/CategoryClaimResponse"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "lastModifiedAt": {
+        "type": "string",
+        "format": "date-time"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CategoryClaimResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "nameEnglish": {
+        "type": "string",
+        "nullable": true
+      },
+      "nameArabic": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "StateClaimResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "isBlocking": {
+        "type": "boolean"
+      },
+      "isLocked": {
+        "type": "boolean"
+      },
+      "color": {
+        "type": "string",
+        "nullable": true
+      },
+      "ranking": {
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "additionalProperties": false
+  },
+  "ParcelInfoClaimDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "city": {
+        "type": "string",
+        "nullable": true
+      },
+      "district": {
+        "type": "string",
+        "nullable": true
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "stateName": {
+        "type": "string",
+        "nullable": true
+      },
+      "customerFullName": {
+        "type": "string",
+        "nullable": true
+      },
+      "phone": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_SearchClaimCategoryResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SearchClaimCategoryResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchClaimCategoryResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "nameEnglish": {
+        "type": "string",
+        "nullable": true
+      },
+      "nameArabic": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetClaimSupplierRequest": {
+    "type": "object",
+    "properties": {
+      "claimId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetCategoryClaimResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "nameEnglish": {
+        "type": "string",
+        "nullable": true
+      },
+      "nameArabic": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateClaimCommentResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_ClaimWorkflowResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ClaimWorkflowResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ClaimWorkflowResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "isDefault": {
+        "type": "boolean"
+      },
+      "states": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ClaimStateResponseDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ClaimStateResponseDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "ranking": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "color": {
+        "type": "string",
+        "nullable": true
+      },
+      "requirements": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "transitions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/TransitionClaimResponseDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "TransitionClaimResponseDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "actionName": {
+        "type": "string",
+        "nullable": true
+      },
+      "fromStateId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "toStateId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_ClaimCommentResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ClaimCommentResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ClaimCommentResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "claimId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "content": {
+        "type": "string",
+        "nullable": true
+      },
+      "modifiedBy": {
+        "$ref": "#/components/schemas/UserSnapshot"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      }
+    },
+    "additionalProperties": false
+  },
+  "UserSnapshot": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "readOnly": true
+      },
+      "fullName": {
+        "type": "string",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchClaimWorkflowsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "expiration": {
+        "type": "string",
+        "format": "date-span",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateClaimDetailsResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateClaimResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_ClaimResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ClaimResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateClaimCommentCurrentSupplierRequest": {
+    "type": "object",
+    "properties": {
+      "claimId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "comment": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchClaimCommentsCurrentSupplierRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "claimId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeleteClaimResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchClaimsSupplierRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/.agents/skills/zr-express/schemas/customers.json
+++ b/.agents/skills/zr-express/schemas/customers.json
@@ -1,0 +1,874 @@
+{
+  "DeleteCustomerAddressResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateIndividualCustomerRequest": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "phone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "dateOfBirth": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "timeSlot": {
+        "type": "string",
+        "nullable": true
+      },
+      "instruction": {
+        "type": "string",
+        "nullable": true
+      },
+      "deliveryPreference": {
+        "type": "string",
+        "nullable": true
+      },
+      "addresses": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/CreateAddressDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateAddressDto": {
+    "type": "object",
+    "properties": {
+      "street": {
+        "type": "string",
+        "nullable": true
+      },
+      "city": {
+        "type": "string",
+        "nullable": true
+      },
+      "cityTerritoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "district": {
+        "type": "string",
+        "nullable": true
+      },
+      "districtTerritoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "postalCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "country": {
+        "type": "string",
+        "nullable": true
+      },
+      "isPrimary": {
+        "type": "boolean"
+      },
+      "coordinates": {
+        "$ref": "#/components/schemas/Coordinates"
+      }
+    },
+    "additionalProperties": false
+  },
+  "Coordinates": {
+    "type": "object",
+    "properties": {
+      "lat": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "lng": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PhoneDto": {
+    "type": "object",
+    "properties": {
+      "number1": {
+        "type": "string",
+        "nullable": true
+      },
+      "number2": {
+        "type": "string",
+        "nullable": true
+      },
+      "number3": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateCustomerAddressRequest": {
+    "type": "object",
+    "properties": {
+      "customerId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "address": {
+        "$ref": "#/components/schemas/CreateAddressDto"
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateIndividualCustomerResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_ExportReportResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ExportReportResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ExportReportResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "tenantId": {
+        "type": "string",
+        "nullable": true
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "createdBy": {
+        "$ref": "#/components/schemas/UserSnapshot"
+      },
+      "status": {
+        "type": "string",
+        "nullable": true
+      },
+      "fileId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UserSnapshot": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "readOnly": true
+      },
+      "fullName": {
+        "type": "string",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ImportIndividualCustomersFormData": {
+    "type": "object",
+    "properties": {
+      "file": {
+        "type": "string",
+        "format": "binary",
+        "nullable": true
+      },
+      "columnsAndTheirPropertyNames": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ExportCustomersRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      }
+    },
+    "additionalProperties": false
+  },
+  "Filter": {
+    "type": "object",
+    "properties": {
+      "logic": {
+        "type": "string",
+        "nullable": true
+      },
+      "filters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Filter"
+        },
+        "nullable": true
+      },
+      "field": {
+        "type": "string",
+        "nullable": true
+      },
+      "operator": {
+        "type": "string",
+        "nullable": true
+      },
+      "value": {
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "Search": {
+    "type": "object",
+    "properties": {
+      "fields": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateCompanyCustomerRequest": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "phone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "companyId": {
+        "type": "string",
+        "nullable": true
+      },
+      "companyContactPerson": {
+        "type": "string",
+        "nullable": true
+      },
+      "timeSlot": {
+        "type": "string",
+        "nullable": true
+      },
+      "instruction": {
+        "type": "string",
+        "nullable": true
+      },
+      "addresses": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/CreateAddressDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "DownloadExportReportResponse": {
+    "type": "object",
+    "properties": {
+      "sasUrl": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ProblemDetails": {
+    "type": "object",
+    "properties": {
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "title": {
+        "type": "string",
+        "nullable": true
+      },
+      "status": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "detail": {
+        "type": "string",
+        "nullable": true
+      },
+      "instance": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": {}
+  },
+  "PagedList_CustomerResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/CustomerResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CustomerResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "phone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "dateOfBirth": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "instruction": {
+        "type": "string",
+        "nullable": true
+      },
+      "timeSlot": {
+        "type": "string",
+        "nullable": true
+      },
+      "deliveryPreference": {
+        "type": "string",
+        "nullable": true
+      },
+      "companyId": {
+        "type": "string",
+        "nullable": true
+      },
+      "companyContactPerson": {
+        "type": "string",
+        "nullable": true
+      },
+      "addresses": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/AddressResponse"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "AddressResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "street": {
+        "type": "string",
+        "nullable": true
+      },
+      "city": {
+        "type": "string",
+        "nullable": true
+      },
+      "cityTerritoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "district": {
+        "type": "string",
+        "nullable": true
+      },
+      "districtTerritoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "postalCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "country": {
+        "type": "string",
+        "nullable": true
+      },
+      "isPrimary": {
+        "type": "boolean"
+      },
+      "coordinates": {
+        "$ref": "#/components/schemas/Coordinates"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CustomerImportResult": {
+    "type": "object",
+    "properties": {
+      "succeededs": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SucceededImportCustomerResult"
+        },
+        "nullable": true
+      },
+      "faileds": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/FailedImportCustomerResult"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "FailedImportCustomerResult": {
+    "type": "object",
+    "properties": {
+      "rowIndex": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "errorMessage": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SucceededImportCustomerResult": {
+    "type": "object",
+    "properties": {
+      "rowIndex": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "customerId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchCustomersRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "includeAllAddresses": {
+        "type": "boolean"
+      },
+      "includePrimaryAddressOnly": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateCustomerAddressResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateIndividualCustomerRequest": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "phone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "timeSlot": {
+        "type": "string",
+        "nullable": true
+      },
+      "instruction": {
+        "type": "string",
+        "nullable": true
+      },
+      "deliveryPreference": {
+        "type": "string",
+        "nullable": true
+      },
+      "dateOfBirth": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "Result_CreateCompanyCustomerResponse": {
+    "type": "object",
+    "properties": {
+      "isSuccess": {
+        "type": "boolean"
+      },
+      "isFailure": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "error": {
+        "$ref": "#/components/schemas/Error"
+      },
+      "value": {
+        "$ref": "#/components/schemas/CreateCompanyCustomerResponse"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateCompanyCustomerResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "Error": {
+    "type": "object",
+    "properties": {
+      "code": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "type": {
+        "$ref": "#/components/schemas/ErrorType"
+      }
+    },
+    "additionalProperties": false
+  },
+  "ErrorType": {
+    "enum": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5
+    ],
+    "type": "integer",
+    "format": "int32"
+  },
+  "DeleteCustomerResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetCustomerResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "phone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "dateOfBirth": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "instruction": {
+        "type": "string",
+        "nullable": true
+      },
+      "timeSlot": {
+        "type": "string",
+        "nullable": true
+      },
+      "deliveryPreference": {
+        "type": "string",
+        "nullable": true
+      },
+      "companyId": {
+        "type": "string",
+        "nullable": true
+      },
+      "companyContactPerson": {
+        "type": "string",
+        "nullable": true
+      },
+      "addresses": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/AddressResponse"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateIndividualCustomerResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateCustomerAddressResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateCustomerAddressRequest": {
+    "type": "object",
+    "properties": {
+      "customerId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "addressId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "street": {
+        "type": "string",
+        "nullable": true
+      },
+      "city": {
+        "type": "string",
+        "nullable": true
+      },
+      "cityTerritoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "district": {
+        "type": "string",
+        "nullable": true
+      },
+      "districtTerritoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "postalCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "country": {
+        "type": "string",
+        "nullable": true
+      },
+      "isPrimary": {
+        "type": "boolean",
+        "nullable": true
+      },
+      "coordinates": {
+        "$ref": "#/components/schemas/Coordinates"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchExportReportsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/.agents/skills/zr-express/schemas/delivery-pricing.json
+++ b/.agents/skills/zr-express/schemas/delivery-pricing.json
@@ -1,0 +1,352 @@
+{
+  "GetAllRatesResponse": {
+    "type": "object",
+    "properties": {
+      "rates": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/TerritoryRateDto"
+        },
+        "nullable": true
+      },
+      "appliedDiscounts": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/AppliedDiscountDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "AppliedDiscountDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "percentage": {
+        "type": "number",
+        "format": "double"
+      },
+      "toTerritoryName": {
+        "type": "string",
+        "nullable": true
+      },
+      "toTerritoryNameArabic": {
+        "type": "string",
+        "nullable": true
+      },
+      "startDate": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "endDate": {
+        "type": "string",
+        "format": "date-time"
+      }
+    },
+    "additionalProperties": false
+  },
+  "TerritoryRateDto": {
+    "type": "object",
+    "properties": {
+      "toTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "toTerritoryCode": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "toTerritoryName": {
+        "type": "string",
+        "nullable": true
+      },
+      "toTerritoryNameArabic": {
+        "type": "string",
+        "nullable": true
+      },
+      "toTerritoryLevel": {
+        "type": "string",
+        "nullable": true
+      },
+      "deliveryPrices": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/RateDeliveryPriceDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "RateDeliveryPriceDto": {
+    "type": "object",
+    "properties": {
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "price": {
+        "type": "number",
+        "format": "double"
+      },
+      "discountedPrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "isSpecificPrice": {
+        "type": "boolean"
+      },
+      "specificPriceId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "priceTtc": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "discountedPriceTtc": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "vatRate": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetRateResponse": {
+    "type": "object",
+    "properties": {
+      "toTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "toTerritoryName": {
+        "type": "string",
+        "nullable": true
+      },
+      "toTerritoryNameArabic": {
+        "type": "string",
+        "nullable": true
+      },
+      "toTerritoryLevel": {
+        "type": "string",
+        "nullable": true
+      },
+      "deliveryPrices": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/RateDeliveryPriceDto"
+        },
+        "nullable": true
+      },
+      "appliedDiscounts": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/AppliedDiscountDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetPriceListResponse": {
+    "type": "object",
+    "properties": {
+      "priceLists": {
+        "$ref": "#/components/schemas/PriceListDto"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PriceListDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "isDefault": {
+        "type": "boolean"
+      },
+      "fromTerritory": {
+        "$ref": "#/components/schemas/TerritoryResponse"
+      },
+      "deliveryPrices": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/GetPriceListDeliveryPriceDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetPriceListDeliveryPriceDto": {
+    "type": "object",
+    "properties": {
+      "toTerritory": {
+        "$ref": "#/components/schemas/TerritoryResponse"
+      },
+      "deliveryPriceDetails": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/GetPriceListDeliveryPriceDetailDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetPriceListDeliveryPriceDetailDto": {
+    "type": "object",
+    "properties": {
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "price": {
+        "type": "number",
+        "format": "double"
+      }
+    },
+    "additionalProperties": false
+  },
+  "TerritoryResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "code": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "nameArabic": {
+        "type": "string",
+        "nullable": true
+      },
+      "postalCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "level": {
+        "type": "string",
+        "nullable": true
+      },
+      "parentId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "delivery": {
+        "$ref": "#/components/schemas/DeliveryCapability"
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeliveryCapability": {
+    "type": "object",
+    "properties": {
+      "hasHomeDelivery": {
+        "type": "boolean"
+      },
+      "hasPickupPoint": {
+        "type": "boolean"
+      },
+      "canSend": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "ProblemDetails": {
+    "type": "object",
+    "properties": {
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "title": {
+        "type": "string",
+        "nullable": true
+      },
+      "status": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "detail": {
+        "type": "string",
+        "nullable": true
+      },
+      "instance": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": {}
+  },
+  "ServicePricingResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "supplierName": {
+        "type": "string",
+        "nullable": true
+      },
+      "labelingPrice": {
+        "type": "number",
+        "format": "double"
+      },
+      "weightingPrice": {
+        "type": "number",
+        "format": "double"
+      },
+      "swapSameCityPrice": {
+        "type": "number",
+        "format": "double"
+      },
+      "swapDifferentCityPrice": {
+        "type": "number",
+        "format": "double"
+      },
+      "phoneChangePrice": {
+        "type": "number",
+        "format": "double"
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/.agents/skills/zr-express/schemas/hubs.json
+++ b/.agents/skills/zr-express/schemas/hubs.json
@@ -1,0 +1,299 @@
+{
+  "GetSupplierHubRequest": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "includeServices": {
+        "type": "boolean"
+      },
+      "expiration": {
+        "type": "string",
+        "format": "date-span",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SupplierHubResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "isPickupPoint": {
+        "type": "boolean"
+      },
+      "isVisible": {
+        "type": "boolean"
+      },
+      "isReturnCenter": {
+        "type": "boolean"
+      },
+      "address": {
+        "$ref": "#/components/schemas/AddressDto"
+      },
+      "openingHours": {
+        "type": "string",
+        "nullable": true
+      },
+      "phone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "paymentRequestEligibilityCutoffTime": {
+        "type": "string",
+        "format": "time"
+      },
+      "paymentRequestEligibilityCutoffTimezoneId": {
+        "type": "string",
+        "nullable": true
+      },
+      "services": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/HubServiceDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "HubServiceDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PhoneDto": {
+    "type": "object",
+    "properties": {
+      "number1": {
+        "type": "string",
+        "nullable": true
+      },
+      "number2": {
+        "type": "string",
+        "nullable": true
+      },
+      "number3": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "AddressDto": {
+    "type": "object",
+    "properties": {
+      "street": {
+        "type": "string",
+        "nullable": true
+      },
+      "city": {
+        "type": "string",
+        "nullable": true
+      },
+      "cityTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "district": {
+        "type": "string",
+        "nullable": true
+      },
+      "districtTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "postalCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "country": {
+        "type": "string",
+        "nullable": true
+      },
+      "coordinates": {
+        "$ref": "#/components/schemas/Coordinates"
+      }
+    },
+    "additionalProperties": false
+  },
+  "Coordinates": {
+    "type": "object",
+    "properties": {
+      "lat": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "lng": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_SupplierHubResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SupplierHubResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchSupplierHubsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "onlySortingCentersWhenAvailable": {
+        "type": "boolean"
+      },
+      "includeServices": {
+        "type": "boolean"
+      },
+      "services": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "expiration": {
+        "type": "string",
+        "format": "date-span",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "Filter": {
+    "type": "object",
+    "properties": {
+      "logic": {
+        "type": "string",
+        "nullable": true
+      },
+      "filters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Filter"
+        },
+        "nullable": true
+      },
+      "field": {
+        "type": "string",
+        "nullable": true
+      },
+      "operator": {
+        "type": "string",
+        "nullable": true
+      },
+      "value": {
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "Search": {
+    "type": "object",
+    "properties": {
+      "fields": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/.agents/skills/zr-express/schemas/orders.json
+++ b/.agents/skills/zr-express/schemas/orders.json
@@ -1,0 +1,3860 @@
+{
+  "GeneratePickupBagLabelPdfResponse": {
+    "type": "object",
+    "properties": {
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "fileUrl": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateBulkParcelExchangeRequest": {
+    "type": "object",
+    "properties": {
+      "parcels": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SingleParcelExchangeRequest"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SingleParcelExchangeRequest": {
+    "type": "object",
+    "properties": {
+      "customer": {
+        "$ref": "#/components/schemas/ParcelCustomerDto"
+      },
+      "deliveryAddress": {
+        "$ref": "#/components/schemas/DeliveryAddressInputDto"
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "orderedProducts": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/OrderedProductDto"
+        },
+        "nullable": true
+      },
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "amount": {
+        "type": "number",
+        "format": "double"
+      },
+      "weight": {
+        "$ref": "#/components/schemas/ParcelWeightDto"
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      },
+      "hubStockId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "originalParcelTrackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "stateId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ParcelWeightDto": {
+    "type": "object",
+    "properties": {
+      "weight": {
+        "type": "number",
+        "format": "double"
+      },
+      "dimensionalWeight": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "OrderedProductDto": {
+    "type": "object",
+    "properties": {
+      "productId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "productName": {
+        "type": "string",
+        "nullable": true
+      },
+      "productSku": {
+        "type": "string",
+        "nullable": true
+      },
+      "unitPrice": {
+        "type": "number",
+        "format": "double"
+      },
+      "quantity": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "length": {
+        "type": "number",
+        "format": "double"
+      },
+      "width": {
+        "type": "number",
+        "format": "double"
+      },
+      "height": {
+        "type": "number",
+        "format": "double"
+      },
+      "weight": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "stockType": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeliveryAddressInputDto": {
+    "type": "object",
+    "properties": {
+      "cityTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "districtTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "street": {
+        "type": "string",
+        "nullable": true
+      },
+      "postalCode": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ParcelCustomerDto": {
+    "type": "object",
+    "properties": {
+      "customerId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "phone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PhoneDto": {
+    "type": "object",
+    "properties": {
+      "number1": {
+        "type": "string",
+        "nullable": true
+      },
+      "number2": {
+        "type": "string",
+        "nullable": true
+      },
+      "number3": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GenerateMultipleLabelsResponse": {
+    "type": "object",
+    "properties": {
+      "fileUrl": {
+        "type": "string",
+        "format": "uri",
+        "nullable": true
+      },
+      "failedTrackingNumbers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateParcelStateResponse": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "newStateId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "newStateName": {
+        "type": "string",
+        "nullable": true
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ProblemDetails": {
+    "type": "object",
+    "properties": {
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "title": {
+        "type": "string",
+        "nullable": true
+      },
+      "status": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "detail": {
+        "type": "string",
+        "nullable": true
+      },
+      "instance": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": {}
+  },
+  "SearchSupplierPickupBagByTrackingNumberRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "onlyUnprocessedParcels": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "Filter": {
+    "type": "object",
+    "properties": {
+      "logic": {
+        "type": "string",
+        "nullable": true
+      },
+      "filters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Filter"
+        },
+        "nullable": true
+      },
+      "field": {
+        "type": "string",
+        "nullable": true
+      },
+      "operator": {
+        "type": "string",
+        "nullable": true
+      },
+      "value": {
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "Search": {
+    "type": "object",
+    "properties": {
+      "fields": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchWorkflowsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "expiration": {
+        "type": "string",
+        "format": "date-span",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeleteBulkParcelsByTrackingNumberResponse": {
+    "type": "object",
+    "properties": {
+      "totalRequested": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "successCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "failureCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "successes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/BulkParcelDeleteByTrackingNumberSuccess"
+        },
+        "nullable": true
+      },
+      "failures": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/BulkParcelDeleteByTrackingNumberFailure"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "BulkParcelDeleteByTrackingNumberFailure": {
+    "type": "object",
+    "properties": {
+      "index": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "errorCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "errorMessage": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "BulkParcelDeleteByTrackingNumberSuccess": {
+    "type": "object",
+    "properties": {
+      "index": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GenerateIndividualLabelsPdfResponse": {
+    "type": "object",
+    "properties": {
+      "parcelLabelFiles": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ParcelLabelPdfFile"
+        },
+        "nullable": true
+      },
+      "failedTrackingNumbers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ParcelLabelPdfFile": {
+    "type": "object",
+    "properties": {
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "fileUrl": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ChangeParcelPhoneResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateDeliveryAddressRequest": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "deliveryAddress": {
+        "$ref": "#/components/schemas/DeliveryAddressInputDto"
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchSupplierPickupBagsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "onlyUnprocessed": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateBulkParcelRefundRequest": {
+    "type": "object",
+    "properties": {
+      "parcels": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SingleParcelRefundRequest"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SingleParcelRefundRequest": {
+    "type": "object",
+    "properties": {
+      "customer": {
+        "$ref": "#/components/schemas/ParcelCustomerDto"
+      },
+      "deliveryAddress": {
+        "$ref": "#/components/schemas/DeliveryAddressInputDto"
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "amount": {
+        "type": "number",
+        "format": "double"
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeletePickupBagResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateBulkParcelsRequest": {
+    "type": "object",
+    "properties": {
+      "parcels": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SingleParcelCreationRequest"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SingleParcelCreationRequest": {
+    "type": "object",
+    "properties": {
+      "customer": {
+        "$ref": "#/components/schemas/ParcelCustomerDto"
+      },
+      "deliveryAddress": {
+        "$ref": "#/components/schemas/DeliveryAddressInputDto"
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "orderedProducts": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/OrderedProductDto"
+        },
+        "nullable": true
+      },
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "amount": {
+        "type": "number",
+        "format": "double"
+      },
+      "weight": {
+        "$ref": "#/components/schemas/ParcelWeightDto"
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      },
+      "hubStockId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "stateId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateCustomerRequest": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "phone": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchSupplierParcelsModificationRequestsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "onlyPending": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateCustomerResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateParcelModificationRequestResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "RemoveParcelsFromPickupBagResponse": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateParcelRefundRequest": {
+    "type": "object",
+    "properties": {
+      "customer": {
+        "$ref": "#/components/schemas/ParcelCustomerDto"
+      },
+      "deliveryAddress": {
+        "$ref": "#/components/schemas/DeliveryAddressInputDto"
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "amount": {
+        "type": "number",
+        "format": "double"
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeleteBulkParcelsResponse": {
+    "type": "object",
+    "properties": {
+      "totalRequested": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "successCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "failureCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "successes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/BulkParcelDeleteSuccess"
+        },
+        "nullable": true
+      },
+      "failures": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/BulkParcelDeleteFailure"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "BulkParcelDeleteFailure": {
+    "type": "object",
+    "properties": {
+      "index": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "errorCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "errorMessage": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "BulkParcelDeleteSuccess": {
+    "type": "object",
+    "properties": {
+      "index": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateParcelExchangeRequest": {
+    "type": "object",
+    "properties": {
+      "customer": {
+        "$ref": "#/components/schemas/ParcelCustomerDto"
+      },
+      "deliveryAddress": {
+        "$ref": "#/components/schemas/DeliveryAddressInputDto"
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "orderedProducts": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/OrderedProductDto"
+        },
+        "nullable": true
+      },
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "stateId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "weight": {
+        "$ref": "#/components/schemas/ParcelWeightDto"
+      },
+      "originalParcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "amount": {
+        "type": "number",
+        "format": "double"
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      },
+      "hubStockId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateDeliveryAddressResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ParcelImportResult": {
+    "type": "object",
+    "properties": {
+      "succeededs": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SucceededImportParcelResult"
+        },
+        "nullable": true
+      },
+      "faileds": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/FailedImportParcelResult"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "FailedImportParcelResult": {
+    "type": "object",
+    "properties": {
+      "rowIndex": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "reason": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SucceededImportParcelResult": {
+    "type": "object",
+    "properties": {
+      "rowIndex": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "AddParcelsToPickupBagResponse": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "successes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PickupBagParcelSuccess"
+        },
+        "nullable": true
+      },
+      "failures": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PickupBagParcelFailure"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PickupBagParcelFailure": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "errorCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "errorMessage": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PickupBagParcelSuccess": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateOrderProductsResponse": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateOrderedProductsRequest": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "orderedProducts": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/OrderedProductDto"
+        },
+        "nullable": true
+      },
+      "amount": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "hubStockId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchTerritoriesRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "expiration": {
+        "type": "string",
+        "format": "date-span",
+        "nullable": true,
+        "readOnly": true
+      },
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "deliveryType": {
+        "$ref": "#/components/schemas/DeliveryType"
+      },
+      "includeUnavailable": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeliveryType": {
+    "type": "object",
+    "properties": {
+      "value": {
+        "type": "string",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateAmountResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetSupplierParcelResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "customer": {
+        "$ref": "#/components/schemas/ParcelCustomerDto"
+      },
+      "supplier": {
+        "$ref": "#/components/schemas/ParcelSupplierDto"
+      },
+      "deliveryAddress": {
+        "$ref": "#/components/schemas/ParcelAddressDto"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "amount": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "deliveryPrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "returnPrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "paymentMethod": {
+        "type": "string",
+        "nullable": true
+      },
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "weight": {
+        "$ref": "#/components/schemas/WeightDto"
+      },
+      "bagId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "deliveryPersonId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "deliveryPerson": {
+        "$ref": "#/components/schemas/GetDeliveryPersonWithHubDto"
+      },
+      "state": {
+        "$ref": "#/components/schemas/StateDto"
+      },
+      "lastStateSituationId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "lastStateSitutationHistoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "lastStateHistoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "situation": {
+        "$ref": "#/components/schemas/SituationDto"
+      },
+      "tenantId": {
+        "type": "string",
+        "nullable": true
+      },
+      "lastLocationHubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "lastStateUpdateAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "lastSituationUpdateAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "lastStateHistoryAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "hubStockId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "productsDescription": {
+        "type": "string",
+        "nullable": true
+      },
+      "productsStockType": {
+        "type": "string",
+        "nullable": true
+      },
+      "isReturn": {
+        "type": "boolean",
+        "nullable": true
+      },
+      "canBeReturned": {
+        "type": "boolean",
+        "nullable": true
+      },
+      "deliveredAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "markedAsReturnAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "returnedAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "controlInfo": {
+        "$ref": "#/components/schemas/ControlInfoDto"
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "isExchanged": {
+        "type": "boolean",
+        "nullable": true
+      },
+      "originalParcelId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "returnParcelId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "pickupBagId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      },
+      "firstConfirmationAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "hubDeliveryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "hasActiveModificationRequest": {
+        "type": "boolean",
+        "nullable": true
+      },
+      "orderedProducts": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/OrderedProductResponse"
+        },
+        "nullable": true
+      },
+      "oldTrackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "swap": {
+        "$ref": "#/components/schemas/SupplierSwapInfoDto"
+      },
+      "modificationCount": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "phoneChangeCount": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "phoneChangePaymentCount": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "phoneChangePrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "applicablePhoneChangeThreshold": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "applicableModificationThreshold": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "applicableSwapThreshold": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "isEligibleForModification": {
+        "type": "boolean"
+      },
+      "isEligibleForPhoneChange": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SupplierSwapInfoDto": {
+    "type": "object",
+    "properties": {
+      "count": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "sameCityCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "differentCityCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "swappedAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "sameCityPrice": {
+        "type": "number",
+        "format": "double"
+      },
+      "differentCityPrice": {
+        "type": "number",
+        "format": "double"
+      },
+      "isEligibleForSwap": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "OrderedProductResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "productId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "productName": {
+        "type": "string",
+        "nullable": true
+      },
+      "productSku": {
+        "type": "string",
+        "nullable": true
+      },
+      "unitPrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "quantity": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "stockType": {
+        "type": "string",
+        "nullable": true
+      },
+      "dimensions": {
+        "$ref": "#/components/schemas/DimensionsResponse"
+      }
+    },
+    "additionalProperties": false
+  },
+  "DimensionsResponse": {
+    "type": "object",
+    "properties": {
+      "length": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "width": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "height": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ControlInfoDto": {
+    "type": "object",
+    "properties": {
+      "controlledByUserId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "controlledByUserFullName": {
+        "type": "string",
+        "nullable": true
+      },
+      "controlledAtHubId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "controlledAtHubName": {
+        "type": "string",
+        "nullable": true
+      },
+      "controlledAt": {
+        "type": "string",
+        "format": "date-time"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SituationDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "slug": {
+        "type": "string",
+        "nullable": true
+      },
+      "metadata": {
+        "type": "object",
+        "additionalProperties": {},
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "StateDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "isBlocking": {
+        "type": "boolean",
+        "nullable": true
+      },
+      "isLocked": {
+        "type": "boolean",
+        "nullable": true
+      },
+      "visibleFor": {
+        "$ref": "#/components/schemas/ActorVisibilities"
+      },
+      "editableBy": {
+        "$ref": "#/components/schemas/ActorVisibilities"
+      },
+      "color": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ActorVisibilities": {
+    "enum": [
+      0,
+      1,
+      2,
+      4,
+      8
+    ],
+    "type": "integer",
+    "format": "int32"
+  },
+  "GetDeliveryPersonWithHubDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "firstName": {
+        "type": "string",
+        "nullable": true
+      },
+      "lastName": {
+        "type": "string",
+        "nullable": true
+      },
+      "assignedPriceListId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "phone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "hub": {
+        "$ref": "#/components/schemas/GetHubDto"
+      },
+      "email": {
+        "type": "string",
+        "nullable": true
+      },
+      "status": {
+        "type": "string",
+        "nullable": true
+      },
+      "isUnavailable": {
+        "type": "boolean"
+      },
+      "isAccountActivated": {
+        "type": "boolean"
+      },
+      "penalities": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PenalityDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PenalityDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "reducedCommission": {
+        "type": "number",
+        "format": "double"
+      },
+      "startDate": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "endDate": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "comment": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetHubDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "isReturnCenter": {
+        "type": "boolean"
+      },
+      "address": {
+        "$ref": "#/components/schemas/AddressDto"
+      },
+      "services": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/HubServiceDto"
+        },
+        "nullable": true
+      },
+      "paymentRequestEligibilityCutoffTime": {
+        "type": "string",
+        "format": "time",
+        "nullable": true
+      },
+      "paymentRequestEligibilityCutoffTimezoneId": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "HubServiceDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "AddressDto": {
+    "type": "object",
+    "properties": {
+      "street": {
+        "type": "string",
+        "nullable": true
+      },
+      "city": {
+        "type": "string",
+        "nullable": true
+      },
+      "cityTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "district": {
+        "type": "string",
+        "nullable": true
+      },
+      "districtTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "postalCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "country": {
+        "type": "string",
+        "nullable": true
+      },
+      "coordinates": {
+        "$ref": "#/components/schemas/Coordinates"
+      }
+    },
+    "additionalProperties": false
+  },
+  "Coordinates": {
+    "type": "object",
+    "properties": {
+      "lat": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "lng": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "WeightDto": {
+    "type": "object",
+    "properties": {
+      "weight": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "dimensionalWeight": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "effectiveWeight": {
+        "type": "number",
+        "format": "double"
+      }
+    },
+    "additionalProperties": false
+  },
+  "ParcelAddressDto": {
+    "type": "object",
+    "properties": {
+      "street": {
+        "type": "string",
+        "nullable": true
+      },
+      "city": {
+        "type": "string",
+        "nullable": true
+      },
+      "cityTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "district": {
+        "type": "string",
+        "nullable": true
+      },
+      "districtTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "cityTerritoryCode": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "postalCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "country": {
+        "type": "string",
+        "nullable": true
+      },
+      "coordinates": {
+        "$ref": "#/components/schemas/Coordinates"
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "hubName": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ParcelSupplierDto": {
+    "type": "object",
+    "properties": {
+      "supplierName": {
+        "type": "string",
+        "nullable": true
+      },
+      "supplierCityTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "supplierHubId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "supplierHubCityTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "supplierHubName": {
+        "type": "string",
+        "nullable": true
+      },
+      "phone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "supportPhone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchSupplierParcelsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "stateIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "nullable": true
+      },
+      "parcelTypes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateParcelModificationRequestRequest": {
+    "type": "object",
+    "properties": {
+      "requestId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "amount": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "deliveryAddress": {
+        "$ref": "#/components/schemas/DeliveryAddressInputDto"
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ImportParcelsFormData": {
+    "type": "object",
+    "properties": {
+      "file": {
+        "type": "string",
+        "format": "binary",
+        "nullable": true
+      },
+      "columnsAndTheirPropertyNames": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateParcelRequest": {
+    "type": "object",
+    "properties": {
+      "customer": {
+        "$ref": "#/components/schemas/ParcelCustomerDto"
+      },
+      "deliveryAddress": {
+        "$ref": "#/components/schemas/DeliveryAddressInputDto"
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "orderedProducts": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/OrderedProductDto"
+        },
+        "nullable": true
+      },
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "stateId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "amount": {
+        "type": "number",
+        "format": "double"
+      },
+      "weight": {
+        "$ref": "#/components/schemas/ParcelWeightDto"
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      },
+      "hubStockId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SupplierPickupBagResult": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "unprocessedParcelsCount": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "state": {
+        "type": "string",
+        "nullable": true
+      },
+      "supplier": {
+        "$ref": "#/components/schemas/PickupBagSupplierDto"
+      },
+      "totalParcels": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PickupBagSupplierDto": {
+    "type": "object",
+    "properties": {
+      "supplierName": {
+        "type": "string",
+        "nullable": true
+      },
+      "supplierCityTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "supplierHubId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateParcelStateSituationHistorySupplierRequest": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "workflowId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "parcelStateHistoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "situation": {
+        "$ref": "#/components/schemas/SituationDto"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_PickupBagParcelResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PickupBagParcelResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PickupBagParcelResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "pickupBagId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "supplier": {
+        "$ref": "#/components/schemas/PickupBagParcelSupplierResponse"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PickupBagParcelSupplierResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "AddParcelsToPickupBagRequest": {
+    "type": "object",
+    "properties": {
+      "pickupBagId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "parcelIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeleteBulkParcelsRequest": {
+    "type": "object",
+    "properties": {
+      "parcelIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_SearchSupplierParcelResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SearchSupplierParcelResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchSupplierParcelResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "customer": {
+        "$ref": "#/components/schemas/ParcelCustomerDto"
+      },
+      "supplier": {
+        "$ref": "#/components/schemas/ParcelSupplierDto"
+      },
+      "deliveryAddress": {
+        "$ref": "#/components/schemas/ParcelAddressDto"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "amount": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "returnPrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "deliveryPrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "paymentMethod": {
+        "type": "string",
+        "nullable": true
+      },
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "weight": {
+        "$ref": "#/components/schemas/WeightDto"
+      },
+      "bagId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "deliveryPersonId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "state": {
+        "$ref": "#/components/schemas/StateDto"
+      },
+      "lastStateSituationId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "lastStateSitutationHistoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "lastStateHistoryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "hubStockId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "situation": {
+        "$ref": "#/components/schemas/SituationDto"
+      },
+      "tenantId": {
+        "type": "string",
+        "nullable": true
+      },
+      "lastLocationHubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "lastStateUpdateAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "lastSituationUpdateAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "lastStateHistoryAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "productsDescription": {
+        "type": "string",
+        "nullable": true
+      },
+      "productsStockType": {
+        "type": "string",
+        "nullable": true
+      },
+      "isReturn": {
+        "type": "boolean",
+        "nullable": true
+      },
+      "canBeReturned": {
+        "type": "boolean",
+        "nullable": true
+      },
+      "deliveredAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "markedAsReturnAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "returnedAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "controlInfo": {
+        "$ref": "#/components/schemas/ControlInfoDto"
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "isExchanged": {
+        "type": "boolean",
+        "nullable": true
+      },
+      "originalParcelId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "returnParcelId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "pickupBagId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      },
+      "firstConfirmationAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "hubDeliveryId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "oldTrackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "swap": {
+        "$ref": "#/components/schemas/SupplierSwapInfoDto"
+      },
+      "modificationCount": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "firstConfirmationHubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "phoneChangeCount": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "phoneChangePaymentCount": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "phoneChangePrice": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "applicablePhoneChangeThreshold": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "applicableModificationThreshold": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "applicableSwapThreshold": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "isEligibleForModification": {
+        "type": "boolean"
+      },
+      "isEligibleForPhoneChange": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_SearchOrdersReportsResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SearchOrdersReportsResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchOrdersReportsResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "tenantId": {
+        "type": "string",
+        "nullable": true
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "createdBy": {
+        "$ref": "#/components/schemas/UserSnapshot"
+      },
+      "status": {
+        "type": "string",
+        "nullable": true
+      },
+      "request": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UserSnapshot": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "readOnly": true
+      },
+      "fullName": {
+        "type": "string",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateParcelResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_WorkflowResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/WorkflowResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "WorkflowResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "isDefault": {
+        "type": "boolean"
+      },
+      "states": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/StateResponseDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "StateResponseDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "ranking": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "visibleFor": {
+        "$ref": "#/components/schemas/ActorVisibilities"
+      },
+      "editableBy": {
+        "$ref": "#/components/schemas/ActorVisibilities"
+      },
+      "color": {
+        "type": "string",
+        "nullable": true
+      },
+      "requirements": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "transitions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/TransitionResponseDto"
+        },
+        "nullable": true
+      },
+      "situations": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SituationResponseDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SituationResponseDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "slug": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "order": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "requirements": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "metadataType": {
+        "type": "string",
+        "nullable": true
+      },
+      "metadataConfiguration": {
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "TransitionResponseDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "actionName": {
+        "type": "string",
+        "nullable": true
+      },
+      "fromStateId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "toStateId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchParcelModificationRequestsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "onlyPending": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_SupplierPickupBagResult": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SupplierPickupBagResult"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GenerateIndividualLabelsRequest": {
+    "required": [
+      "trackingNumbers"
+    ],
+    "type": "object",
+    "properties": {
+      "trackingNumbers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GenerateIndividualLabelsResponse": {
+    "type": "object",
+    "properties": {
+      "parcelLabelFiles": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ParcelLabelFile"
+        },
+        "nullable": true
+      },
+      "failedTrackingNumbers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ParcelLabelFile": {
+    "type": "object",
+    "properties": {
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "fileUrl": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateBulkParcelsResponse": {
+    "type": "object",
+    "properties": {
+      "totalRequested": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "successCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "failureCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "successes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/BulkParcelSuccess"
+        },
+        "nullable": true
+      },
+      "failures": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/BulkParcelFailure"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "BulkParcelFailure": {
+    "type": "object",
+    "properties": {
+      "index": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "errorCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "errorMessage": {
+        "type": "string",
+        "nullable": true
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "BulkParcelSuccess": {
+    "type": "object",
+    "properties": {
+      "index": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeleteBulkParcelsByTrackingNumberRequest": {
+    "type": "object",
+    "properties": {
+      "trackingNumbers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GenerateMultipleLabelsRequest": {
+    "required": [
+      "trackingNumbers"
+    ],
+    "type": "object",
+    "properties": {
+      "trackingNumbers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateParcelModificationRequestResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateBulkParcelExchangeResponse": {
+    "type": "object",
+    "properties": {
+      "totalRequested": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "successCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "failureCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "successes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/BulkParcelExchangeSuccess"
+        },
+        "nullable": true
+      },
+      "failures": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/BulkParcelExchangeFailure"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "BulkParcelExchangeFailure": {
+    "type": "object",
+    "properties": {
+      "index": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "errorCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "errorMessage": {
+        "type": "string",
+        "nullable": true
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "BulkParcelExchangeSuccess": {
+    "type": "object",
+    "properties": {
+      "index": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "newParcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "newParcelTrackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "returnParcelId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "returnParcelTrackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "originalParcelId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreatePickupBagResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "successes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PickupBagParcelSuccess"
+        },
+        "nullable": true
+      },
+      "failures": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PickupBagParcelFailure"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_ParcelModificationRequestResult": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ParcelModificationRequestResult"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ParcelModificationRequestResult": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "parcelTrackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "clientName": {
+        "type": "string",
+        "nullable": true
+      },
+      "parcelProductsDescription": {
+        "type": "string",
+        "nullable": true
+      },
+      "parcelState": {
+        "$ref": "#/components/schemas/StateDto"
+      },
+      "parcelPhone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "parcelAmount": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "parcelDeliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "parcelDeliveryAddress": {
+        "$ref": "#/components/schemas/ParcelAddressDto"
+      },
+      "newPhone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "newAmount": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "newDeliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "newDeliveryAddress": {
+        "$ref": "#/components/schemas/ParcelAddressDto"
+      },
+      "newCustomerName": {
+        "type": "string",
+        "nullable": true
+      },
+      "oldPhone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "oldAmount": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "oldDeliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "oldDeliveryAddress": {
+        "$ref": "#/components/schemas/ParcelAddressDto"
+      },
+      "oldCustomerName": {
+        "type": "string",
+        "nullable": true
+      },
+      "validatedBy": {
+        "$ref": "#/components/schemas/UserSnapshot"
+      },
+      "validatedAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "isApproved": {
+        "type": "boolean",
+        "nullable": true
+      },
+      "isSwap": {
+        "type": "boolean",
+        "nullable": true
+      },
+      "oldTrackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "newTrackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "comment": {
+        "type": "string",
+        "nullable": true
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "isManagedByProDelivery": {
+        "type": "boolean"
+      },
+      "parcelSubContractorId": {
+        "type": "string",
+        "nullable": true
+      },
+      "canValidate": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateParcelExchangeResponse": {
+    "type": "object",
+    "properties": {
+      "newParcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "returnParcelId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "originalParcelId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ExportSupplierParcelsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "stateIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "nullable": true
+      },
+      "parcelTypes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GeneratePickupBagLabelPdfRequest": {
+    "required": [
+      "trackingNumber"
+    ],
+    "type": "object",
+    "properties": {
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateParcelModificationRequestRequest": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "amount": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "deliveryAddress": {
+        "$ref": "#/components/schemas/DeliveryAddressInputDto"
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateParcelStateSituationHistorySupplierResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreatePickupBagRequest": {
+    "type": "object",
+    "properties": {
+      "parcelIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_TerritoryResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/TerritoryResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "TerritoryResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "code": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "nameArabic": {
+        "type": "string",
+        "nullable": true
+      },
+      "postalCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "level": {
+        "type": "string",
+        "nullable": true
+      },
+      "parentId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "delivery": {
+        "$ref": "#/components/schemas/DeliveryCapability"
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeliveryCapability": {
+    "type": "object",
+    "properties": {
+      "hasHomeDelivery": {
+        "type": "boolean"
+      },
+      "hasPickupPoint": {
+        "type": "boolean"
+      },
+      "canSend": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeleteParcelRespone": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateParcelRefundStateRequest": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "newStateId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "deliveryPersonId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "arrivalHubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "comment": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GenerateIndividualLabelsPdfRequest": {
+    "required": [
+      "trackingNumbers"
+    ],
+    "type": "object",
+    "properties": {
+      "trackingNumbers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "format": {
+        "$ref": "#/components/schemas/PdfLabelFormat"
+      },
+      "isPreview": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PdfLabelFormat": {
+    "type": "object",
+    "properties": {
+      "value": {
+        "type": "string",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ChangeParcelPhoneRequest": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "phone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      }
+    },
+    "additionalProperties": false
+  },
+  "GenerateMultipleLabelsPdfRequest": {
+    "required": [
+      "trackingNumbers"
+    ],
+    "type": "object",
+    "properties": {
+      "trackingNumbers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "format": {
+        "$ref": "#/components/schemas/PdfLabelFormat"
+      }
+    },
+    "additionalProperties": false
+  },
+  "GenerateMultipleLabelsPdfResponse": {
+    "type": "object",
+    "properties": {
+      "fileUrl": {
+        "type": "string",
+        "format": "uri",
+        "nullable": true
+      },
+      "failedTrackingNumbers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateAmountRequest": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "amount": {
+        "type": "number",
+        "format": "double"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateParcelRefundResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateParcelStateRequest": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "newStateId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "deliveryPersonId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "arrivalHubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "comment": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchOrdersReportsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateBulkParcelRefundResponse": {
+    "type": "object",
+    "properties": {
+      "totalRequested": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "successCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "failureCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "successes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/BulkParcelRefundSuccess"
+        },
+        "nullable": true
+      },
+      "failures": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/BulkParcelRefundFailure"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "BulkParcelRefundFailure": {
+    "type": "object",
+    "properties": {
+      "index": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "errorCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "errorMessage": {
+        "type": "string",
+        "nullable": true
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "BulkParcelRefundSuccess": {
+    "type": "object",
+    "properties": {
+      "index": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateParcelRefundStateResponse": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "newStateId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "newStateName": {
+        "type": "string",
+        "nullable": true
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeleteParcelModificationRequestResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "RemoveParcelFromPickupBagRequest": {
+    "type": "object",
+    "properties": {
+      "pickupBagId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "DownloadReportResponse": {
+    "type": "object",
+    "properties": {
+      "sasUrl": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/.agents/skills/zr-express/schemas/supplier.json
+++ b/.agents/skills/zr-express/schemas/supplier.json
@@ -1,0 +1,245 @@
+{
+  "GetSupplierResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "codeName": {
+        "type": "string",
+        "nullable": true
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "assignedPriceListId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "hubName": {
+        "type": "string",
+        "nullable": true
+      },
+      "address": {
+        "$ref": "#/components/schemas/AddressDto"
+      },
+      "phone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "supportPhone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "tenantId": {
+        "type": "string",
+        "nullable": true
+      },
+      "legalInformation": {
+        "$ref": "#/components/schemas/SupplierLegalInformationDto"
+      },
+      "owner": {
+        "$ref": "#/components/schemas/GetSupplierOwnerDto"
+      },
+      "paymentDays": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "services": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SupplierServiceDto"
+        },
+        "nullable": true
+      },
+      "isBlocked": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SupplierServiceDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetSupplierOwnerDto": {
+    "type": "object",
+    "properties": {
+      "firstName": {
+        "type": "string",
+        "nullable": true
+      },
+      "lastName": {
+        "type": "string",
+        "nullable": true
+      },
+      "email": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SupplierLegalInformationDto": {
+    "type": "object",
+    "properties": {
+      "rc": {
+        "type": "string",
+        "nullable": true
+      },
+      "nif": {
+        "type": "string",
+        "nullable": true
+      },
+      "ai": {
+        "type": "string",
+        "nullable": true
+      },
+      "nis": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PhoneDto": {
+    "type": "object",
+    "properties": {
+      "number1": {
+        "type": "string",
+        "nullable": true
+      },
+      "number2": {
+        "type": "string",
+        "nullable": true
+      },
+      "number3": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "AddressDto": {
+    "type": "object",
+    "properties": {
+      "street": {
+        "type": "string",
+        "nullable": true
+      },
+      "city": {
+        "type": "string",
+        "nullable": true
+      },
+      "cityTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "district": {
+        "type": "string",
+        "nullable": true
+      },
+      "districtTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "postalCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "country": {
+        "type": "string",
+        "nullable": true
+      },
+      "coordinates": {
+        "$ref": "#/components/schemas/Coordinates"
+      }
+    },
+    "additionalProperties": false
+  },
+  "Coordinates": {
+    "type": "object",
+    "properties": {
+      "lat": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "lng": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateSupplierBlockedStatusResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetSupplierRequest": {
+    "type": "object",
+    "properties": {
+      "supplierId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "includeServices": {
+        "type": "boolean"
+      },
+      "expiration": {
+        "type": "string",
+        "format": "date-span",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateSupplierBlockedStatusRequest": {
+    "type": "object",
+    "properties": {
+      "supplierId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "isBlocked": {
+        "type": "boolean"
+      },
+      "cachedRequestsToInvalidate": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/.agents/skills/zr-express/schemas/treasury.json
+++ b/.agents/skills/zr-express/schemas/treasury.json
@@ -1,0 +1,1111 @@
+{
+  "SupplierPaymentSupplierResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "supplier": {
+        "$ref": "#/components/schemas/TreasurySupplierResponse"
+      },
+      "amount": {
+        "type": "number",
+        "format": "double"
+      },
+      "totalParcelsDelivered": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalParcelsCancelled": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalRefundsCredited": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalRefundsDebited": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalItemLabeling": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "labelingAmount": {
+        "type": "number",
+        "format": "double"
+      },
+      "storage": {
+        "type": "number",
+        "format": "double"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "referenceId": {
+        "type": "string",
+        "nullable": true
+      },
+      "status": {
+        "type": "string",
+        "nullable": true
+      },
+      "paymentRequestId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "TreasurySupplierResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "tenantId": {
+        "type": "string",
+        "nullable": true
+      },
+      "address": {
+        "$ref": "#/components/schemas/AddressDto"
+      },
+      "paymentDays": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "phone": {
+        "$ref": "#/components/schemas/PhoneDto"
+      },
+      "owner": {
+        "$ref": "#/components/schemas/TreasurySupplierOwnerDto"
+      },
+      "legalInformation": {
+        "$ref": "#/components/schemas/SupplierLegalInformationDto"
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SupplierLegalInformationDto": {
+    "type": "object",
+    "properties": {
+      "rc": {
+        "type": "string",
+        "nullable": true
+      },
+      "nif": {
+        "type": "string",
+        "nullable": true
+      },
+      "ai": {
+        "type": "string",
+        "nullable": true
+      },
+      "nis": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "TreasurySupplierOwnerDto": {
+    "type": "object",
+    "properties": {
+      "firstName": {
+        "type": "string",
+        "nullable": true
+      },
+      "lastName": {
+        "type": "string",
+        "nullable": true
+      },
+      "email": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PhoneDto": {
+    "type": "object",
+    "properties": {
+      "number1": {
+        "type": "string",
+        "nullable": true
+      },
+      "number2": {
+        "type": "string",
+        "nullable": true
+      },
+      "number3": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "AddressDto": {
+    "type": "object",
+    "properties": {
+      "street": {
+        "type": "string",
+        "nullable": true
+      },
+      "city": {
+        "type": "string",
+        "nullable": true
+      },
+      "cityTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "district": {
+        "type": "string",
+        "nullable": true
+      },
+      "districtTerritoryId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "postalCode": {
+        "type": "string",
+        "nullable": true
+      },
+      "country": {
+        "type": "string",
+        "nullable": true
+      },
+      "coordinates": {
+        "$ref": "#/components/schemas/Coordinates"
+      }
+    },
+    "additionalProperties": false
+  },
+  "Coordinates": {
+    "type": "object",
+    "properties": {
+      "lat": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      },
+      "lng": {
+        "type": "number",
+        "format": "double",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdatePaymentRequestDateResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchTreasuryReportsRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "Filter": {
+    "type": "object",
+    "properties": {
+      "logic": {
+        "type": "string",
+        "nullable": true
+      },
+      "filters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Filter"
+        },
+        "nullable": true
+      },
+      "field": {
+        "type": "string",
+        "nullable": true
+      },
+      "operator": {
+        "type": "string",
+        "nullable": true
+      },
+      "value": {
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "Search": {
+    "type": "object",
+    "properties": {
+      "fields": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "AcceptSupplierPaymentResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ExportSupplierPaymentsCurrentSupplierRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "startDate": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "endDate": {
+        "type": "string",
+        "format": "date-time"
+      }
+    },
+    "additionalProperties": false
+  },
+  "AcceptSupplierPaymentRequest": {
+    "type": "object",
+    "properties": {
+      "supplierPaymentId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PaymentRequestResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "tenantId": {
+        "type": "string",
+        "nullable": true
+      },
+      "supplierHubId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "supplierName": {
+        "type": "string",
+        "nullable": true
+      },
+      "hubName": {
+        "type": "string",
+        "nullable": true
+      },
+      "requestedDate": {
+        "type": "string",
+        "format": "date"
+      },
+      "validatedBy": {
+        "$ref": "#/components/schemas/UserSnapshot"
+      },
+      "validatedAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "isApproved": {
+        "type": "boolean",
+        "nullable": true
+      },
+      "comment": {
+        "type": "string",
+        "nullable": true
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UserSnapshot": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "readOnly": true
+      },
+      "fullName": {
+        "type": "string",
+        "nullable": true,
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdatePaymentRequestDateRequest": {
+    "type": "object",
+    "properties": {
+      "requestId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "requestedDate": {
+        "type": "string",
+        "format": "date"
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetSupplierPaymentCurrentSupplierRequest": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreatePaymentRequestRequest": {
+    "type": "object",
+    "properties": {
+      "requestedDate": {
+        "type": "string",
+        "format": "date"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_TreasurySupplierPaymentTransactionResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/TreasurySupplierPaymentTransactionResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "TreasurySupplierPaymentTransactionResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "amount": {
+        "type": "number",
+        "format": "double"
+      },
+      "weightCost": {
+        "type": "number",
+        "format": "double"
+      },
+      "swapCost": {
+        "type": "number",
+        "format": "double"
+      },
+      "phoneChangeCost": {
+        "type": "number",
+        "format": "double"
+      },
+      "comment": {
+        "type": "string",
+        "nullable": true
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "supplier": {
+        "$ref": "#/components/schemas/SupplierInfoDto"
+      },
+      "parcel": {
+        "$ref": "#/components/schemas/ParcelInfoResponse"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "cashReceiptId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "supplierPaymentId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      },
+      "supplierPaymentReference": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ParcelInfoResponse": {
+    "type": "object",
+    "properties": {
+      "parcelId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "trackingNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "customerFullName": {
+        "type": "string",
+        "nullable": true
+      },
+      "deliveryType": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "deliveryPrice": {
+        "type": "number",
+        "format": "double"
+      },
+      "returnPrice": {
+        "type": "number",
+        "format": "double"
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "weight": {
+        "type": "number",
+        "format": "double"
+      },
+      "totalSwap": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "externalId": {
+        "type": "string",
+        "nullable": true
+      },
+      "stateName": {
+        "type": "string",
+        "nullable": true
+      },
+      "managementFee": {
+        "type": "number",
+        "format": "double"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SupplierInfoDto": {
+    "type": "object",
+    "properties": {
+      "supplierId": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "hubId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "AcceptSupplierPaymentByReferenceIdRequest": {
+    "type": "object",
+    "properties": {
+      "referenceId": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetSupplierStatsAmountResponse": {
+    "type": "object",
+    "properties": {
+      "totalAmountPaid": {
+        "type": "number",
+        "format": "double"
+      },
+      "totalAmountReadyToBePaid": {
+        "type": "number",
+        "format": "double"
+      },
+      "totalAmountDelivered": {
+        "type": "number",
+        "format": "double"
+      },
+      "totalAmountNotReadyCashed": {
+        "type": "number",
+        "format": "double"
+      },
+      "totalAmountReadyToBeCashed": {
+        "type": "number",
+        "format": "double"
+      }
+    },
+    "additionalProperties": false
+  },
+  "DeletePaymentRequestResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SupplierTransactionStatsDto": {
+    "type": "object",
+    "properties": {
+      "amount": {
+        "type": "number",
+        "format": "double"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchSupplierPaymentsCurrentSupplierRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_PaymentRequestResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PaymentRequestResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "DownloadReportByIdResponse": {
+    "type": "object",
+    "properties": {
+      "sasUrl": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreatePaymentRequestResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_SupplierPaymentResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SupplierPaymentResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SupplierPaymentResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "supplier": {
+        "$ref": "#/components/schemas/TreasurySupplierResponse"
+      },
+      "amount": {
+        "type": "number",
+        "format": "double"
+      },
+      "totalParcelsDelivered": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalParcelsCancelled": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalRefundsCredited": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalRefundsDebited": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalItemLabeling": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "labelingAmount": {
+        "type": "number",
+        "format": "double"
+      },
+      "storage": {
+        "type": "number",
+        "format": "double"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "acceptedAt": {
+        "type": "string",
+        "format": "date-time",
+        "nullable": true
+      },
+      "cashDrawer": {
+        "$ref": "#/components/schemas/CashDrawerResponse"
+      },
+      "referenceId": {
+        "type": "string",
+        "nullable": true
+      },
+      "status": {
+        "type": "string",
+        "nullable": true
+      },
+      "paymentRequestId": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CashDrawerResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "cashDrawerUser": {
+        "$ref": "#/components/schemas/CashDrawerUserResponse"
+      },
+      "amount": {
+        "type": "number",
+        "format": "double"
+      },
+      "isActive": {
+        "type": "boolean"
+      },
+      "hub": {
+        "$ref": "#/components/schemas/TreasuryHubResponse"
+      }
+    },
+    "additionalProperties": false
+  },
+  "TreasuryHubResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "address": {
+        "$ref": "#/components/schemas/AddressDto"
+      }
+    },
+    "additionalProperties": false
+  },
+  "CashDrawerUserResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "firstName": {
+        "type": "string",
+        "nullable": true
+      },
+      "lastName": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchPaymentRequestsCurrentSupplierRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "onlyPending": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  "PagedList_SearchReportsResponse": {
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SearchReportsResponse"
+        },
+        "nullable": true
+      },
+      "pageNumber": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageSize": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalCount": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "totalPages": {
+        "type": "integer",
+        "format": "int32",
+        "readOnly": true
+      },
+      "hasPrevious": {
+        "type": "boolean",
+        "readOnly": true
+      },
+      "hasNext": {
+        "type": "boolean",
+        "readOnly": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchReportsResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "tenantId": {
+        "type": "string",
+        "nullable": true
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "frequency": {
+        "type": "string",
+        "nullable": true
+      },
+      "startDate": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "endDate": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "createdBy": {
+        "$ref": "#/components/schemas/UserSnapshot"
+      },
+      "status": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "AcceptSupplierPaymentByReferenceIResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchTreasuryTransactionsSupplierPaymentBySupplierPaymentIdRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "supplierPaymentId": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/.agents/skills/zr-express/schemas/users.json
+++ b/.agents/skills/zr-express/schemas/users.json
@@ -1,0 +1,172 @@
+{
+  "CreateUserKeyRequest": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "nullable": true
+      },
+      "expiresInDays": {
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "additionalProperties": false
+  },
+  "SearchUserKeysRequest": {
+    "type": "object",
+    "properties": {
+      "advancedSearch": {
+        "$ref": "#/components/schemas/Search"
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      },
+      "advancedFilter": {
+        "$ref": "#/components/schemas/Filter"
+      },
+      "pageSize": {
+        "maximum": 1000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "pageNumber": {
+        "maximum": 10000,
+        "minimum": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderBy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "Filter": {
+    "type": "object",
+    "properties": {
+      "logic": {
+        "type": "string",
+        "nullable": true
+      },
+      "filters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Filter"
+        },
+        "nullable": true
+      },
+      "field": {
+        "type": "string",
+        "nullable": true
+      },
+      "operator": {
+        "type": "string",
+        "nullable": true
+      },
+      "value": {
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "Search": {
+    "type": "object",
+    "properties": {
+      "fields": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "keyword": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UserDetail": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "nullable": true
+      },
+      "firstName": {
+        "type": "string",
+        "nullable": true
+      },
+      "lastName": {
+        "type": "string",
+        "nullable": true
+      },
+      "email": {
+        "type": "string",
+        "nullable": true
+      },
+      "phoneNumber": {
+        "type": "string",
+        "nullable": true
+      },
+      "memberships": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/TenantMembershipDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "TenantMembershipDto": {
+    "type": "object",
+    "properties": {
+      "tenantId": {
+        "type": "string",
+        "nullable": true
+      },
+      "tenantName": {
+        "type": "string",
+        "nullable": true
+      },
+      "isActive": {
+        "type": "boolean"
+      },
+      "isDefault": {
+        "type": "boolean"
+      },
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "supplierType": {
+        "type": "string",
+        "nullable": true
+      },
+      "membership": {
+        "type": "string",
+        "nullable": true
+      },
+      "subContractorNameSubDomain": {
+        "type": "string",
+        "nullable": true
+      },
+      "roles": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/.agents/skills/zr-express/schemas/webhooks.json
+++ b/.agents/skills/zr-express/schemas/webhooks.json
@@ -1,0 +1,272 @@
+{
+  "UpdateEndpointRequest": {
+    "type": "object",
+    "properties": {
+      "endpointId": {
+        "type": "string",
+        "nullable": true
+      },
+      "url": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "eventTypes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "headers": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "CreateEndpointResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "nullable": true
+      },
+      "url": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "eventTypes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      }
+    },
+    "additionalProperties": false
+  },
+  "ListEndpointsResponse": {
+    "type": "object",
+    "properties": {
+      "endpoints": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/EndpointDto"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "EndpointDto": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "nullable": true
+      },
+      "url": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "eventTypes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "updatedAt": {
+        "type": "string",
+        "format": "date-time"
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetEndpointResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "nullable": true
+      },
+      "url": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "eventTypes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "headers": {
+        "$ref": "#/components/schemas/EndpointHeadersOut"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "updatedAt": {
+        "type": "string",
+        "format": "date-time"
+      }
+    },
+    "additionalProperties": false
+  },
+  "EndpointHeadersOut": {
+    "required": [
+      "headers",
+      "sensitive"
+    ],
+    "type": "object",
+    "properties": {
+      "headers": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "sensitive": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetEndpointHeadersResponse": {
+    "type": "object",
+    "properties": {
+      "headers": {
+        "$ref": "#/components/schemas/EndpointHeadersOut"
+      }
+    },
+    "additionalProperties": false
+  },
+  "GetEndpointSecretResponse": {
+    "type": "object",
+    "properties": {
+      "secret": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "ProblemDetails": {
+    "type": "object",
+    "properties": {
+      "type": {
+        "type": "string",
+        "nullable": true
+      },
+      "title": {
+        "type": "string",
+        "nullable": true
+      },
+      "status": {
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
+      },
+      "detail": {
+        "type": "string",
+        "nullable": true
+      },
+      "instance": {
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": {}
+  },
+  "CreateEndpointRequest": {
+    "type": "object",
+    "properties": {
+      "url": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "eventTypes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "headers": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "UpdateEndpointResponse": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "nullable": true
+      },
+      "url": {
+        "type": "string",
+        "nullable": true
+      },
+      "description": {
+        "type": "string",
+        "nullable": true
+      },
+      "eventTypes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "nullable": true
+      },
+      "updatedAt": {
+        "type": "string",
+        "format": "date-time"
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/.agents/skills/zr-express/swagger.json
+++ b/.agents/skills/zr-express/swagger.json
@@ -1,0 +1,16204 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "ZRExpress.Api (Public)",
+    "description": "Public API surface. Endpoints marked as front-end-only are excluded.",
+    "contact": {
+      "name": "ZRExpress",
+      "email": "support@zrexpress.net"
+    },
+    "version": "1"
+  },
+  "servers": [
+    {
+      "url": "https://api.zrexpress.app"
+    }
+  ],
+  "paths": {
+    "/api/v{version}/products": {
+      "post": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Creates a product",
+        "description": "Creates a product. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "CreateProductEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProductRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateProductResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/products/search": {
+      "post": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Gets a list of products",
+        "description": "Gets a list of products with pagination and filtering support. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "SearchSupplierProductsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchProductsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_SearchProductResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/products/{id}": {
+      "post": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Get product details",
+        "description": "Get the details of a product by its ID. Permissions requises : tous les SupplierRoles.",
+        "operationId": "GetSupplierProductEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetProductRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetProductResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Update a product",
+        "description": "Update a product",
+        "operationId": "UpdateProductEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProductRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateProductResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Deletes a product",
+        "description": "Deletes a product by id with its variants",
+        "operationId": "DeleteProductEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteProductResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/products/{id}/price": {
+      "patch": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Update product's price ",
+        "description": "Update the price of a product",
+        "operationId": "UpdatePriceEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePriceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdatePriceResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/products/{id}/discount": {
+      "patch": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Update product's discount ",
+        "description": "Update the discount price of a product",
+        "operationId": "UpdateDiscountEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDiscountRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateDiscountResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/products/product/{productId}/local-stock": {
+      "patch": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Update local Stock",
+        "description": "Update local Stock.",
+        "operationId": "UpdateProductLocalStockEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "productId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProductLocalStockRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateProductLocalStockResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/products/import/template": {
+      "get": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Download template for importing bulk catalog products",
+        "description": "Returns an Excel template file for bulk importing catalog products.",
+        "operationId": "DownloadTemplateBulkCatalogProductsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v{version}/products/import": {
+      "post": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Imports products from an Excel file",
+        "description": "Imports products using an Excel file. Supports two formats: 1) multipart/form-data with 'file' field (recommended, more efficient), 2) JSON body with 'excelFileBase64' (legacy). Optionally provide a dictionary of columns and their matching propertyNames.",
+        "operationId": "ImportProductEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportProductFormData"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductImportResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/products/export": {
+      "post": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Export a list of products",
+        "description": "Export a list of products to a CSV file. The export is processed asynchronously and returns a report ID. Permissions required: SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "ExportProductsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportProductsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/stock-movements/product/warehouse-stock/user": {
+      "post": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Creates a Stock movement by user",
+        "description": "Creates a stock movement by user with type parameters equal to waiting-reception.",
+        "operationId": "CreateProductStockMovementUserEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProductStockMovementUserRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateProductStockMovementUserResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/receipts/search": {
+      "post": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Gets a list of receipts",
+        "description": "Gets a list of receipts with pagination and filtering support Required Permissions: GlobalRoles, SubContractorRoles, HubAdmin, HubStockManager, SupplierAdmin, or SupplierParcelsManager.",
+        "operationId": "SearchReceiptsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchReceiptsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_SearchReceiptResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/receipts/{id}": {
+      "get": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Get Receipt details",
+        "description": "Get the details of a Receipt by its ID. Required Permissions: GlobalRoles, SubContractorRoles, HubAdmin, HubStockManager, SupplierAdmin, or SupplierParcelsManager.",
+        "operationId": "GetReceiptEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetReceiptResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/categories/search": {
+      "post": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Gets a list of categories",
+        "description": "Gets a list of categories with pagination and filtering support. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "SearchCategoriesEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchCategoriesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_CategoryResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/catalog/reports/search": {
+      "post": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Gets a list of product export reports",
+        "description": "Gets a list of product export reports with pagination and filtering support. Permissions required: SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "SearchProductsReportsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchProductsReportsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_SearchProductsReportsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/catalog/reports/{reportId}/download": {
+      "post": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Download a product export report file by ID",
+        "description": "Returns a SAS URL to download the product export report file by its ID. Permissions required: SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "DownloadProductsReportEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "reportId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadProductsReportResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/claim-categories/search": {
+      "post": {
+        "tags": [
+          "claims"
+        ],
+        "summary": "Gets a list of claim categories",
+        "description": "Gets a list of claim categories with pagination and filtering support",
+        "operationId": "SearchClaimCategoriesEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchClaimCategoriesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_SearchClaimCategoryResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/claim-categories/{id}": {
+      "get": {
+        "tags": [
+          "claims"
+        ],
+        "summary": "gets claim category item by id",
+        "description": "gets claim category item by id",
+        "operationId": "GetClaimCategoryEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCategoryClaimResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/claims/search": {
+      "post": {
+        "tags": [
+          "claims"
+        ],
+        "summary": "Gets a list of claims for Current Supplier",
+        "description": "Gets a list of claims for Current Supplier with pagination and filtering support. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "SearchClaimsSupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchClaimsSupplierRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_ClaimResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/claims/{claimId}": {
+      "post": {
+        "tags": [
+          "claims"
+        ],
+        "summary": "gets claim item by id",
+        "description": "gets claim item by id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "GetClaimSupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "claimId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetClaimSupplierRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClaimResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "claims"
+        ],
+        "summary": "Update details for a specific claim.",
+        "description": "Update details for a specific claim. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole, HubAdminRole, HubClaimsManagerRole.",
+        "operationId": "UpdateClaimDetailsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "claimId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateClaimDetailsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateClaimDetailsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/claims": {
+      "post": {
+        "tags": [
+          "claims"
+        ],
+        "summary": "Creates a claim",
+        "description": "Creates a claim. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "CreateClaimEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateClaimRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateClaimResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/claims/{id}": {
+      "delete": {
+        "tags": [
+          "claims"
+        ],
+        "summary": "Deletes a Claim",
+        "description": "Deletes a Claim by id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "DeleteClaimEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteClaimResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/claims/{id}/state-histories": {
+      "get": {
+        "tags": [
+          "claims"
+        ],
+        "summary": "get claim state histories",
+        "description": "get claim state histories",
+        "operationId": "GetClaimStateHistoryEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ClaimStateHistoryDto"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/claim-comments/{claimId}": {
+      "patch": {
+        "tags": [
+          "claims"
+        ],
+        "summary": "Create a comment for a specific claim for current supplier.",
+        "description": "Create a comment for a specific claim for current supplier. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "CreateClaimCommentCurrentSupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "claimId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateClaimCommentCurrentSupplierRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateClaimCommentResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/claim-comments/{claimId}/search": {
+      "post": {
+        "tags": [
+          "claims"
+        ],
+        "summary": "Gets a list of claim comments for a specific claim by Id for current supplier",
+        "description": "Gets a list of claim comments for a specific claim by Id for current supplier with pagination and filtering support. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "SearchClaimCommentsCurrentSupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "claimId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchClaimCommentsCurrentSupplierRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_ClaimCommentResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/claim-workflows/search": {
+      "post": {
+        "tags": [
+          "claims"
+        ],
+        "summary": "Gets a list of claim workflows",
+        "description": "Gets a list of claim workflows with pagination and filtering support",
+        "operationId": "SearchClaimWorkflowsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchClaimWorkflowsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_ClaimWorkflowResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/customers/search": {
+      "post": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "Gets a list of customers",
+        "description": "Gets a list of customers with pagination and filtering support",
+        "operationId": "SearchCustomersEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchCustomersRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_CustomerResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/customers/global/search": {
+      "get": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "Top global customer search",
+        "description": "Search customers by phone number for the GlobalSearch component without pagination or count queries.",
+        "operationId": "SearchGlobalCustomersEndpointTop",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "keyword",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "top",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SearchGlobalCustomerResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/customers/{id}": {
+      "get": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "Get customer details",
+        "description": "Get the details of a customer by its Id.",
+        "operationId": "GetCustomerEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCustomerResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "Deletes customer by id",
+        "description": "Delete a customer by Id with related address. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "DeleteCustomerEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteCustomerResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/customers/individual": {
+      "post": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "Creates a customer",
+        "description": "Creates a customer, The 'Gender' paramater indicates the gender of the customer and accepts 'male', or 'female', the 'TimeSlot' paramater indicates time slot preference and accepts 'morning','afternoon', or 'evening',the 'DeliveryPreference' paramater indicates delivery preference and accepts 'home', or 'pickup-point'. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "CreateIndividualCustomerEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateIndividualCustomerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateIndividualCustomerResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/customers/company": {
+      "post": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "Creates a customer",
+        "description": "Creates a customer, the 'TimeSlot' paramater indicates time slot preference and accepts 'morning','afternoon', or 'evening'. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "CreateCompanyCustomerEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCompanyCustomerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result_CreateCompanyCustomerResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/customers/individual/{id}": {
+      "put": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "update individual customer.",
+        "description": "update individual customer by id, The 'Gender' paramater indicates the gender of the customer and accepts 'male', or 'female', the 'TimeSlot' paramater indicates time slot preference and accepts 'morning','afternoon', or 'evening',the 'DeliveryPreference' paramater indicates delivery preference and accepts 'home', or 'pickup-point' .",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateIndividualCustomerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateIndividualCustomerResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/customers/{customerId}/address": {
+      "post": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "add customer address",
+        "description": "add new address to existing customer. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "customerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCustomerAddressRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateCustomerAddressResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/customers/{customerId}/address/{addressId}": {
+      "put": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "update customer address",
+        "description": "update customer address using customer id",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "customerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "addressId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCustomerAddressRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateCustomerAddressResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "delete customer address",
+        "description": "delete customer address using customer id and address id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "customerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "addressId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteCustomerAddressResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/customers/import/individual": {
+      "post": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "Imports individual customers from an Excel file",
+        "description": "Imports individual customers using an Excel file. Supports two formats: 1) multipart/form-data with 'file' field (recommended, more efficient), 2) JSON body with 'excelFileBase64' (legacy). Optionally provide a dictionary of columns and their matching propertyNames.",
+        "operationId": "ImportIndividualCustomersEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportIndividualCustomersFormData"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerImportResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/customers/import/individual/template": {
+      "get": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "Download template for importing individual customers",
+        "description": "Returns an Excel template file for bulk importing individual customers.",
+        "operationId": "DownloadTemplateBulkIndividualCustomersEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v{version}/customers/export": {
+      "post": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "Export a list of customers",
+        "description": "Export a list of customers to an Excel file. The export is processed asynchronously and returns a report ID. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "ExportCustomersEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportCustomersRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/customers/reports/search": {
+      "post": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "Gets a list of customer export reports",
+        "description": "Gets a list of customer export reports with pagination and filtering support. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "SearchExportReportsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchExportReportsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_ExportReportResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/customers/reports/{reportId}/download": {
+      "post": {
+        "tags": [
+          "customers"
+        ],
+        "summary": "Download a customer export report file by ID",
+        "description": "Returns a SAS URL to download the customer export report file by its ID. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "DownloadExportReportEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "reportId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadExportReportResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/delivery-pricing/price-lists/{id}": {
+      "get": {
+        "tags": [
+          "delivery-pricing",
+          "deprecated"
+        ],
+        "summary": "[Deprecated] Gets a price list",
+        "description": "Gets a price list. This endpoint is deprecated. Please use GET /delivery-pricing/rates instead to get effective delivery prices with priority logic already applied.",
+        "operationId": "GetPriceListEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPriceListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/hubs/{id}": {
+      "post": {
+        "tags": [
+          "hubs"
+        ],
+        "summary": "Get a hub by Id",
+        "description": "Get a hub by Id",
+        "operationId": "GetSupplierHubEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetSupplierHubRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupplierHubResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/hubs/search": {
+      "post": {
+        "tags": [
+          "hubs"
+        ],
+        "summary": "Get a list of hubs",
+        "description": "Get a list of hubs with pagination and filtering support",
+        "operationId": "SearchSupplierHubsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchSupplierHubsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_SupplierHubResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/{parcelId}/state": {
+      "patch": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Updates parcel state",
+        "description": "Updates parcel state. Permissions requises : HubParcelsManagerRole, HubAdminRole, SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "UpdateParcelStateEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "parcelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateParcelStateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateParcelStateResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/{parcelId}/state-history": {
+      "get": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "gets parcel state history",
+        "description": "gets parcel state history. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "GetParcelStateHistorySupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "parcelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ParcelStateHistoryDto"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/{parcelId}/state-history/{parcelStateHistoryId}/workflow/{workflowId}/situation-history": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Creates a parcel state situation history",
+        "description": "Creates a parcel state situation history. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "CreateParcelStateSituationHistorySupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "parcelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "parcelStateHistoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "workflowId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateParcelStateSituationHistorySupplierRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateParcelStateSituationHistorySupplierResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/{id}": {
+      "get": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "get parcel item by id",
+        "description": "gets parcel item by id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "GetParcelByIdSupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSupplierParcelResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Delete a parcel",
+        "description": "Delete a parcel by ID. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "DeleteParcelEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteParcelRespone"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/{trackingNumber}": {
+      "get": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "get parcel item by trackingNumber",
+        "description": "gets parcel item by id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "GetParcelByTrackingNumberSupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "trackingNumber",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSupplierParcelResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/search": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Get a list of parcels",
+        "description": "Get a list of parcels with pagination and filtering support. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "SearchSupplierParcelsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchSupplierParcelsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_SearchSupplierParcelResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/search/global": {
+      "get": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Top global search of supplier parcels",
+        "operationId": "SearchGlobalSupplierParcelsEndpointTop",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "keyword",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "top",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SearchGlobalSupplierParcelResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/export": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Export supplier parcels to CSV",
+        "description": "Exports a list of supplier parcels with filtering support. Returns an export job ID. Permissions required : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "ExportSupplierParcelsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportSupplierParcelsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Creates a parcel",
+        "description": "Creates a parcel with products. The `StockType` parameter indicates the type of stock and accepts 'local' or 'warehouse'. Defaults to 'local' if not specified. the 'DeliveryType' parameter indicates the type of delivery and accepts 'home' or 'pickup-point'. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "CreateParcelEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateParcelRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateParcelResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/bulk": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Create multiple parcels in bulk",
+        "description": "\n                Creates up to 100 parcels in a single request. \n                Returns detailed success/failure information for each parcel.\n\n                Response Status Codes:\n                - 200 OK: All parcels created successfully\n                - 207 Multi-Status: Partial success (some parcels created, some failed)\n                - 400 Bad Request: All parcels failed validation or creation\n            ",
+        "operationId": "CreateBulkParcelsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateBulkParcelsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateBulkParcelsResponse"
+                }
+              }
+            }
+          },
+          "207": {
+            "description": "Multi-Status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateBulkParcelsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateBulkParcelsResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Delete multiple parcels in bulk",
+        "description": "\n            Deletes up to 200 parcels in a single request. \n            Returns detailed success/failure information for each parcel.\n            \n            Important notes:\n            - ExchangeReturn parcels cannot be deleted\n            - If a parcel has a ReturnParcel, it will also be deleted\n            - If deleting a ReturnParcel, the OriginalParcel's IsExchanged flag will be reset\n\n            Response Status Codes:\n            - 200 OK: All parcels deleted successfully\n            - 207 Multi-Status: Partial success (some parcels deleted, some failed)\n            - 400 Bad Request: All parcels failed validation or deletion\n        ",
+        "operationId": "DeleteBulkParcelsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteBulkParcelsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteBulkParcelsResponse"
+                }
+              }
+            }
+          },
+          "207": {
+            "description": "Multi-Status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteBulkParcelsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteBulkParcelsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/exchange": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Creates an exchange for a parcel",
+        "description": "Creates an exchange for a parcel with products. The `StockType` parameter indicates the type of stock and accepts 'local' or 'warehouse'. Defaults to 'local' if not specified. the 'DeliveryType' parameter indicates the type of delivery and accepts 'home' or 'pickup-point'. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "CreateParcelExchangeEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateParcelExchangeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateParcelExchangeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/bulk-exchange": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Create multiple exchange parcels in bulk",
+        "description": "\n        Creates up to 100 exchange parcels in a single request. \n        Each exchange can optionally create a return parcel for the original item.\n\n        Response Status Codes:\n        - 200 OK: All parcels created successfully\n        - 207 Multi-Status: Partial success (some parcels created, some failed)\n        - 400 Bad Request: All parcels failed validation or creation\n        ",
+        "operationId": "CreateBulkParcelExchangeEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateBulkParcelExchangeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateBulkParcelExchangeResponse"
+                }
+              }
+            }
+          },
+          "207": {
+            "description": "Multi-Status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateBulkParcelExchangeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateBulkParcelExchangeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/refund": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Creates a parcel refund",
+        "description": "Creates a parcel refund. the 'DeliveryType' parameter indicates the type of delivery and accepts 'home' or 'pickup-point'. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "CreateParcelRefundEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateParcelRefundRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateParcelRefundResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/bulk-refund": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Create multiple refund parcels in bulk",
+        "description": "\n        Creates up to 100 refund parcels in a single request.\n        The supplier balance is checked before creation to ensure sufficient funds.\n\n        Response Status Codes:\n        - 200 OK: All parcels created successfully\n        - 207 Multi-Status: Partial success (some parcels created, some failed)\n        - 400 Bad Request: All parcels failed validation or creation\n        ",
+        "operationId": "CreateBulkParcelRefundEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateBulkParcelRefundRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateBulkParcelRefundResponse"
+                }
+              }
+            }
+          },
+          "207": {
+            "description": "Multi-Status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateBulkParcelRefundResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateBulkParcelRefundResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/bulk/by-tracking-number": {
+      "delete": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Delete multiple parcels by tracking numbers in bulk",
+        "description": "\n            Deletes up to 200 parcels in a single request using tracking numbers. \n            Returns detailed success/failure information for each parcel.\n            \n            Important notes:\n            - ExchangeReturn parcels cannot be deleted\n            - If a parcel has a ReturnParcel, it will also be deleted\n            - If deleting a ReturnParcel, the OriginalParcel's IsExchanged flag will be reset\n\n            Response Status Codes:\n            - 200 OK: All parcels deleted successfully\n            - 207 Multi-Status: Partial success (some parcels deleted, some failed)\n            - 400 Bad Request: All parcels failed validation or deletion\n        ",
+        "operationId": "DeleteBulkParcelsByTrackingNumberEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteBulkParcelsByTrackingNumberRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteBulkParcelsByTrackingNumberResponse"
+                }
+              }
+            }
+          },
+          "207": {
+            "description": "Multi-Status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteBulkParcelsByTrackingNumberResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteBulkParcelsByTrackingNumberResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/{parcelId}/products": {
+      "patch": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Update products of an parcel",
+        "description": "Update products of an parcel. The `StockType` parameter indicates the type of stock and accepts 'local' or 'warehouse'. Defaults to 'local' if not specified. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "UpdateOrderedProductsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "parcelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOrderedProductsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateOrderProductsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/{id}/amount": {
+      "patch": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Update an order's total amount",
+        "description": "Update an order's total amount. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "UpdateAmountEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAmountRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateAmountResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/{id}/customer": {
+      "patch": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Update an parcel's customer infos",
+        "description": "Update an parcel's customer infos. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "UpdateCustomerEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCustomerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateCustomerResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/{id}/deliveryAddress": {
+      "patch": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Update an order's delivery address",
+        "description": "Update an order's delivery address. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "UpdateDeliveryAddressEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDeliveryAddressRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateDeliveryAddressResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/stats/{workflowId}": {
+      "get": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Gets parcels stats per state for a workflow for the current tenant",
+        "description": "Retrieves the number of parcels per state for the workflow identified by its id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "GetSupplierParcelsStatsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "workflowId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "parcelTypes",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "isReturn",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SupplierParcelsStatsResponseItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/stats/workflow/{workflowId}/state/{stateId}": {
+      "get": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Gets parcels stats per situation Id for a workflow for the current supplier",
+        "description": "Retrieves the number of parcels per situation  for the workflow identified by its id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "GetSupplierSituationParcelsStatsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "workflowId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "stateId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "parcelTypes",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "isReturn",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SupplierSituationParcelsStatsResponseItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/import-parcels/template": {
+      "get": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Download template for importing bulk parcels",
+        "description": "Returns an Excel template file for bulk importing parcels.",
+        "operationId": "DownloadTemplateBulkParcelsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/import-parcels": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Imports parcels from an Excel file",
+        "description": "Imports parcels using an Excel file. Supports two formats: 1) multipart/form-data with 'file' field (recommended, more efficient), 2) JSON body with 'excelFileBase64' (legacy). Optionally provide a dictionary of columns and their matching propertyNames.",
+        "operationId": "ImportParcelsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportParcelsFormData"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ParcelImportResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/{parcelId}/state/refund": {
+      "patch": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Updates parcel state for a refund",
+        "description": "Updates parcel state for a refund. Permissions requises : HubDeliveryPeopleSettlementMangerRole, HubAdminRole, HubParcelsSettlementMangerRole,SupplierAdminRole,SupplierParcelsManagerRole.",
+        "operationId": "UpdateParcelRefundStateEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "parcelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateParcelRefundStateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateParcelRefundStateResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/labels/multiple": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Generate multiple parcel labels in one HTML file",
+        "description": "Generates parcel labels for multiple parcels (max 250) in a single HTML file. Returns the file URL with SAS token and list of failed tracking numbers. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "GenerateMultipleLabelsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateMultipleLabelsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateMultipleLabelsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/labels/individual": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Generate individual parcel labels",
+        "description": "Generates individual HTML files for each parcel label (max 100 parcels). Returns an array of tracking numbers with their file URLs and list of failed tracking numbers. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "GenerateIndividualLabelsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateIndividualLabelsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateIndividualLabelsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/labels/multiple/pdf": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Generate multiple parcel labels as a single PDF",
+        "description": "Generates a single PDF file containing multiple parcel labels (max 250 parcels). Supports A4 format (4 labels per page) or A6 format (1 label per page). Returns the PDF file URL and list of failed tracking numbers. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "GenerateMultipleLabelsPdfEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateMultipleLabelsPdfRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateMultipleLabelsPdfResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcels/labels/individual/pdf": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Generate individual parcel labels as PDF",
+        "description": "Generates individual PDF files for each parcel label (max 100 parcels). Supports A4 format (4 labels per page) or A6 format (1 label per page). Returns an array of tracking numbers with their PDF file URLs and list of failed tracking numbers. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "GenerateIndividualLabelsPdfEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateIndividualLabelsPdfRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateIndividualLabelsPdfResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/orders/reports/search": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Gets a list of Reports in orders module",
+        "description": "Gets a list of Reports in orders module with pagination support.",
+        "operationId": "SearchOrdersReportsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchOrdersReportsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_SearchOrdersReportsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/orders/reports/{reportId}/download": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Download a report file by ID",
+        "description": "Returns a SAS URL to download the report file by its ID.",
+        "operationId": "DownloadOrdersReportEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "reportId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadReportResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/workflows/search": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Gets a list of workflows",
+        "description": "Gets a list of workflows with pagination and filtering support",
+        "operationId": "SearchWorkflowsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchWorkflowsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_WorkflowResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcel-modification-requests": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Creates a parcel modification request",
+        "description": "Creates a parcel modification request. Permissions required: SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "CreateParcelModificationRequestEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateParcelModificationRequestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateParcelModificationRequestResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcel-modification-requests/phone": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Change parcel phone (auto-applied modification request)",
+        "description": "Creates an immediately validated phone modification request and applies Parcel.ChangePhone. Enforces modification-request preconditions and phone-change quota. Permissions required: SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "ChangeParcelPhoneEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangeParcelPhoneRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeParcelPhoneResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcel-modification-requests/{requestId}": {
+      "patch": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Updates an existing parcel modification request",
+        "description": "Updates an existing parcel modification request before it is validated. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "UpdateParcelModificationRequestEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateParcelModificationRequestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateParcelModificationRequestResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcel-modification-requests/{id}": {
+      "delete": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Deletes an existing parcel modification request",
+        "description": "Deletes an existing parcel modification request before it is validated. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "DeleteParcelModificationRequestEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteParcelModificationRequestResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "get parcel modification request item by id",
+        "description": "gets parcel modification request item by id.",
+        "operationId": "GetParcelModificationRequestEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ParcelModificationRequestResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcel-modification-requests/search": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Search supplier's parcels' modification requests",
+        "description": "Search supplier's parcels' modification requests. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "SearchSupplierParcelsModificationRequestsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchSupplierParcelsModificationRequestsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_ParcelModificationRequestResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/parcel-modification-requests/{parcelId}": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Search parcels' modification requests",
+        "description": "Search parcels' modification requests. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole, HubAdminRole, HubParcelsManagerRole, GlobalAdminRole, GlobalViewerRole.",
+        "operationId": "SearchParcelModificationRequestsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "parcelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchParcelModificationRequestsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_ParcelModificationRequestResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/pickup-bags": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Creates a pickup bag.",
+        "description": "Creates a pickup bag. Permissions required: SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "CreatePickupBagEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePickupBagRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatePickupBagResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/pickup-bags/{id}": {
+      "delete": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Deletes an existing pickup bag",
+        "description": "Deletes an existing pickup bag. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "DeletePickupBagEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletePickupBagResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Get pickup bag item by id",
+        "description": "Get pickup bag item by id. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "GetSupplierPickupBagByIdEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupplierPickupBagResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/pickup-bags/search": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Search all supplier's pickup bags",
+        "description": "Search all supplier's pickup bags. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "SearchSupplierPickupBagsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchSupplierPickupBagsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_SupplierPickupBagResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/pickup-bags/{bagId}/add-parcel": {
+      "patch": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Add a parcel to a pickup bag",
+        "description": "Add a parcel to an existing pickup bag.",
+        "operationId": "AddParcelsToPickupBagEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "bagId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddParcelsToPickupBagRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddParcelsToPickupBagResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/pickup-bags/{bagId}/remove-parcel": {
+      "patch": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Remove a parcel from a pickup bag",
+        "description": "Remove a parcel from an existing pickup bag.",
+        "operationId": "RemoveParcelFromPickupBagEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "bagId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemoveParcelFromPickupBagRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemoveParcelsFromPickupBagResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/pickup-bags/{trackingNumber}/parcels/search": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Search parcels of the given pickup bag tracking number",
+        "description": "Search parcels of the given pickup bag tracking number.",
+        "operationId": "SearchSupplierPickupBagByTrackingNumberEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "trackingNumber",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchSupplierPickupBagByTrackingNumberRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_PickupBagParcelResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/pickup-bags/{trackingNumber}": {
+      "get": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Get pickup bag item by tracking number",
+        "description": "Get pickup bag item by tracking number. Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "GetSupplierPickupBagByTrackingNumberEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "trackingNumber",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupplierPickupBagResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/pickup-bags/labels/pdf": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Generate pickup bag label as PDF",
+        "description": "Generates a PDF label for a specific pickup bag in A4 format. Returns the tracking number and the PDF file URL.",
+        "operationId": "GeneratePickupBagLabelPdfEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GeneratePickupBagLabelPdfRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneratePickupBagLabelPdfResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/territories/search": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "summary": "Gets a list of territories",
+        "description": "Gets a list of territories with pagination and filtering support",
+        "operationId": "SearchTerritoriesEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchTerritoriesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_TerritoryResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/delivery-pricing/rates": {
+      "get": {
+        "tags": [
+          "rates"
+        ],
+        "summary": "Get effective delivery rates for all territories",
+        "description": "Returns the effective delivery prices for all destination territories. Supply an optional 'fromTerritoryId' (origin wilaya) to resolve the price list from the supplier's explicit assignment for that origin. Returns 404 when no assignment exists. This endpoint automatically applies the priority logic: supplier-specific prices take precedence over PriceList prices.",
+        "operationId": "GetAllRatesEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "fromTerritoryId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAllRatesResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/delivery-pricing/rates/{toTerritoryId}": {
+      "get": {
+        "tags": [
+          "rates"
+        ],
+        "summary": "Get effective delivery rate for a specific territory",
+        "description": "Returns the effective delivery prices for a specific destination territory. This endpoint automatically applies the priority logic: supplier-specific prices take precedence over PriceList prices.",
+        "operationId": "GetRateEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "toTerritoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetRateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/delivery-pricing/service-pricing": {
+      "get": {
+        "tags": [
+          "service-pricing"
+        ],
+        "summary": "Get the service pricing for the current supplier",
+        "description": "Returns the service pricing (labeling, weighting, switch) for the currently authenticated supplier.",
+        "operationId": "GetCurrentSupplierServicePricingEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServicePricingResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/delivery-pricing/supplier-specific-prices/{supplierId}": {
+      "get": {
+        "tags": [
+          "specific-prices",
+          "deprecated"
+        ],
+        "summary": "[Deprecated] Get supplier-specific delivery prices",
+        "description": "Retrieves all supplier-specific delivery prices for a given supplier. This endpoint is deprecated. Please use GET /delivery-pricing/rates instead to get effective delivery prices with priority logic already applied.",
+        "operationId": "GetSupplierSpecificPricesEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "supplierId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/supplier/{supplierId}": {
+      "post": {
+        "tags": [
+          "supplier"
+        ],
+        "summary": "gets supplier item by id",
+        "description": "gets supplier item by id. Permissions requises : GlobalAdminRole, GlobalViewerRole, HubAdminRole, HubSuppliersManagerRole, et tous les SupplierRoles.",
+        "operationId": "GetSupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "supplierId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetSupplierRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSupplierResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/supplier/{supplierId}/blocked": {
+      "patch": {
+        "tags": [
+          "supplier"
+        ],
+        "summary": "Update supplier blocked status",
+        "description": "Sets whether the supplier is blocked from parcel operations. Super-admins and operations admins (root / sub-contractor).",
+        "operationId": "UpdateSupplierBlockedStatusEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "supplierId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSupplierBlockedStatusRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateSupplierBlockedStatusResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/supplier/supplier-price-list-assignments/{supplierId}": {
+      "get": {
+        "tags": [
+          "supplier"
+        ],
+        "summary": "List supplier price list assignments by origin territory",
+        "description": "Returns all origin-territory price list assignments configured for a supplier.",
+        "operationId": "ListSupplierPriceListAssignmentsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "supplierId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v{version}/supplier-payment/{id}/details": {
+      "post": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Get supplier payment details",
+        "description": "Get the details of a supplier payment by its ID.",
+        "operationId": "GetSupplierPaymentCurrentSupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetSupplierPaymentCurrentSupplierRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupplierPaymentSupplierResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/supplier-payment/{supplierPaymentId}": {
+      "put": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Accept a payment by a supplier",
+        "description": "Accept a payment by a supplier",
+        "operationId": "AcceptSupplierPaymentEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "supplierPaymentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcceptSupplierPaymentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptSupplierPaymentResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/supplier-payment/{referenceId}": {
+      "put": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Accept a payment by a supplier",
+        "description": "Accept a payment by a supplier",
+        "operationId": "AcceptSupplierPaymentByReferenceIdEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "referenceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcceptSupplierPaymentByReferenceIdRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptSupplierPaymentByReferenceIResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/supplier-payment/search": {
+      "post": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Gets a list of SupplierPayment current supplier",
+        "description": "Gets a list of SupplierPayment current supplier with pagination and filtering support",
+        "operationId": "SearchSupplierPaymentsCurrentSupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchSupplierPaymentsCurrentSupplierRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_SupplierPaymentResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/supplier-payment/export": {
+      "post": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Export a list of SupplierPayment current supplier",
+        "description": "Export a list of SupplierPayment current supplier with pagination and filtering support",
+        "operationId": "ExportSupplierPaymentsCurrentSupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportSupplierPaymentsCurrentSupplierRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/supplier-payment/stats/current-supplier": {
+      "get": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Get transactions stats current supplier.",
+        "description": "Get transactions stats current supplier.Permissions requises : SupplierAdminRole, SupplierParcelsManagerRole.",
+        "operationId": "GetTransactionsStatsCurrentSupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupplierTransactionStatsDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/supplier-payment/supplier-balance": {
+      "get": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "get supplier balance by a supplier",
+        "description": "E-commerce supplier FO balance badges. Classic-mail suppliers must use /supplier-balance/classic-mail. Permissions: SupplierAdminRole.",
+        "operationId": "GetSupplierStatsAmountEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSupplierStatsAmountResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/payment-request": {
+      "post": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Creates a payment request",
+        "description": "Creates a payment request. The requested date must be at least tomorrow. Permissions required: SupplierAdminRole.",
+        "operationId": "CreatePaymentRequestEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePaymentRequestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatePaymentRequestResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/payment-request/{id}": {
+      "delete": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Deletes a payment request",
+        "description": "Deletes a payment request. Only pending requests can be deleted. Permissions required: SupplierAdminRole.",
+        "operationId": "DeletePaymentRequestEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletePaymentRequestResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Gets a payment request by id (supplier)",
+        "description": "Gets a payment request by id. Permissions required: SupplierAdminRole.",
+        "operationId": "GetPaymentRequestCurrentSupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequestResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/payment-request/{id}/date": {
+      "patch": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Updates the requested date of a payment request",
+        "description": "Updates the requested date. Only pending requests can be updated. The date must be at least tomorrow. Permissions required: SupplierAdminRole.",
+        "operationId": "UpdatePaymentRequestDateEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePaymentRequestDateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdatePaymentRequestDateResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/payment-request/search": {
+      "post": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Search payment requests (supplier)",
+        "description": "Search payment requests for the current supplier. Permissions required: SupplierAdminRole.",
+        "operationId": "SearchPaymentRequestsCurrentSupplierEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchPaymentRequestsCurrentSupplierRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_PaymentRequestResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/treasury/reports/search": {
+      "post": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Gets a list of Reports",
+        "description": "Gets a list of Reports in treasury module with pagination and filtering support",
+        "operationId": "SearchTreasuryReportsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchTreasuryReportsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_SearchReportsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/treasury/reports/{reportId}/download": {
+      "post": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Download a report file by ID in treasury module",
+        "description": "Returns a SAS URL to download the report file by its ID.",
+        "operationId": "DownloadTreasuryReportByIdEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "reportId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadReportByIdResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/treasury-transactions/search/supplier-payment/by-supplier-payment/{supplierPaymentId}": {
+      "post": {
+        "tags": [
+          "treasury-transactions"
+        ],
+        "summary": "Gets a list of transactions linked to a supplier payment",
+        "description": "Gets a list of transactions with pagination and filtering support linked to a supplier payment",
+        "operationId": "SearchTreasuryTransactionsSupplierPaymentBySupplierPaymentIdEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "supplierPaymentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchTreasuryTransactionsSupplierPaymentBySupplierPaymentIdRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedList_TreasurySupplierPaymentTransactionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/users/profile": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Get current user information based on token",
+        "description": "Get current user information based on token",
+        "operationId": "GetMeEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/users/keys": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Generate API Key",
+        "description": "Generates a secure API key for user authentication.\\n\n                        Supported expiration values : 7, 30, 90, 180, 365 days.",
+        "operationId": "GenerateUserKeyEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUserKeyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v{version}/users/keys/search": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Search user tokens with advanced filtering",
+        "description": "Search user tokens with pagination support.",
+        "operationId": "SearchUserKeysEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchUserKeysRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v{version}/users/keys/{id}": {
+      "delete": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Delete API Key",
+        "description": "Delete an API key for the users.",
+        "operationId": "DeleteUserKeyEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v{version}/webhooks/endpoints": {
+      "post": {
+        "tags": [
+          "webhooks"
+        ],
+        "summary": "Create a webhook endpoint",
+        "description": "Creates a new webhook endpoint for the supplier to receive webhook events",
+        "operationId": "CreateEndpointEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateEndpointRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateEndpointResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "webhooks"
+        ],
+        "summary": "List webhook endpoints",
+        "description": "Retrieves all webhook endpoints configured for the supplier",
+        "operationId": "ListEndpointsEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListEndpointsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/webhooks/endpoints/{endpointId}": {
+      "get": {
+        "tags": [
+          "webhooks"
+        ],
+        "summary": "Get a webhook endpoint",
+        "description": "Retrieves the details of a specific webhook endpoint by its ID",
+        "operationId": "GetEndpointEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "endpointId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetEndpointResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "webhooks"
+        ],
+        "summary": "Update a webhook endpoint",
+        "description": "Updates an existing webhook endpoint configuration",
+        "operationId": "UpdateEndpointEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "endpointId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateEndpointRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateEndpointResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "webhooks"
+        ],
+        "summary": "Delete a webhook endpoint",
+        "description": "Deletes a webhook endpoint permanently",
+        "operationId": "DeleteEndpointEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "endpointId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/webhooks/endpoints/{endpointId}/headers": {
+      "get": {
+        "tags": [
+          "webhooks"
+        ],
+        "summary": "Get webhook endpoint headers",
+        "description": "Retrieves the custom headers configured for a specific webhook endpoint",
+        "operationId": "GetEndpointHeadersEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "endpointId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetEndpointHeadersResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v{version}/webhooks/endpoints/{endpointId}/secret": {
+      "get": {
+        "tags": [
+          "webhooks"
+        ],
+        "summary": "Get webhook endpoint secret",
+        "description": "Retrieves the signing secret for a specific webhook endpoint. This secret should be used to verify webhook signatures.",
+        "operationId": "GetEndpointSecretEndpoint",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "1"
+            }
+          },
+          {
+            "name": "endpointId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant",
+            "in": "header",
+            "description": "Input your tenant Id to access this API",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetEndpointSecretResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AcceptSupplierPaymentByReferenceIResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AcceptSupplierPaymentByReferenceIdRequest": {
+        "type": "object",
+        "properties": {
+          "referenceId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AcceptSupplierPaymentRequest": {
+        "type": "object",
+        "properties": {
+          "supplierPaymentId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AcceptSupplierPaymentResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ActorVisibilities": {
+        "enum": [
+          0,
+          1,
+          2,
+          4,
+          8
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "AddParcelsToPickupBagRequest": {
+        "type": "object",
+        "properties": {
+          "pickupBagId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parcelIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AddParcelsToPickupBagResponse": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "successes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PickupBagParcelSuccess"
+            },
+            "nullable": true
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PickupBagParcelFailure"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AddressDto": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "cityTerritoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "district": {
+            "type": "string",
+            "nullable": true
+          },
+          "districtTerritoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "postalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "coordinates": {
+            "$ref": "#/components/schemas/Coordinates"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AddressResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "street": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "cityTerritoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "district": {
+            "type": "string",
+            "nullable": true
+          },
+          "districtTerritoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "isPrimary": {
+            "type": "boolean"
+          },
+          "coordinates": {
+            "$ref": "#/components/schemas/Coordinates"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AppliedDiscountDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "percentage": {
+            "type": "number",
+            "format": "double"
+          },
+          "toTerritoryName": {
+            "type": "string",
+            "nullable": true
+          },
+          "toTerritoryNameArabic": {
+            "type": "string",
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BulkParcelDeleteByTrackingNumberFailure": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "errorCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BulkParcelDeleteByTrackingNumberSuccess": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BulkParcelDeleteFailure": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "errorCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BulkParcelDeleteSuccess": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BulkParcelExchangeFailure": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "errorCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BulkParcelExchangeSuccess": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "newParcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "newParcelTrackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "returnParcelId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "returnParcelTrackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "originalParcelId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BulkParcelFailure": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "errorCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BulkParcelRefundFailure": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "errorCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BulkParcelRefundSuccess": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BulkParcelSuccess": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CashDrawerResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "cashDrawerUser": {
+            "$ref": "#/components/schemas/CashDrawerUserResponse"
+          },
+          "amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "hub": {
+            "$ref": "#/components/schemas/TreasuryHubResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CashDrawerUserResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CategoryClaimResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameEnglish": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameArabic": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CategoryResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameArabic": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameEnglish": {
+            "type": "string",
+            "nullable": true
+          },
+          "subCategories": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubCategoryResponse"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeParcelPhoneRequest": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "phone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeParcelPhoneResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ClaimCommentResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "claimId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "content": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedBy": {
+            "$ref": "#/components/schemas/UserSnapshot"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ClaimResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "parcel": {
+            "$ref": "#/components/schemas/ParcelInfoClaimDto"
+          },
+          "state": {
+            "$ref": "#/components/schemas/StateClaimResponse"
+          },
+          "category": {
+            "$ref": "#/components/schemas/CategoryClaimResponse"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastModifiedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ClaimStateDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "isLocked": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ClaimStateHistoryDto": {
+        "type": "object",
+        "properties": {
+          "previousState": {
+            "$ref": "#/components/schemas/ClaimStateDto"
+          },
+          "newState": {
+            "$ref": "#/components/schemas/ClaimStateDto"
+          },
+          "modifiedBy": {
+            "$ref": "#/components/schemas/UserSnapshot"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ClaimStateResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "ranking": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "color": {
+            "type": "string",
+            "nullable": true
+          },
+          "requirements": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "transitions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransitionClaimResponseDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ClaimWorkflowResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "states": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClaimStateResponseDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ControlInfoDto": {
+        "type": "object",
+        "properties": {
+          "controlledByUserId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "controlledByUserFullName": {
+            "type": "string",
+            "nullable": true
+          },
+          "controlledAtHubId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "controlledAtHubName": {
+            "type": "string",
+            "nullable": true
+          },
+          "controlledAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Coordinates": {
+        "type": "object",
+        "properties": {
+          "lat": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "lng": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateAddressDto": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "cityTerritoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "district": {
+            "type": "string",
+            "nullable": true
+          },
+          "districtTerritoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "isPrimary": {
+            "type": "boolean"
+          },
+          "coordinates": {
+            "$ref": "#/components/schemas/Coordinates"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateBulkParcelExchangeRequest": {
+        "type": "object",
+        "properties": {
+          "parcels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SingleParcelExchangeRequest"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateBulkParcelExchangeResponse": {
+        "type": "object",
+        "properties": {
+          "totalRequested": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "successCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "failureCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "successes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkParcelExchangeSuccess"
+            },
+            "nullable": true
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkParcelExchangeFailure"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateBulkParcelRefundRequest": {
+        "type": "object",
+        "properties": {
+          "parcels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SingleParcelRefundRequest"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateBulkParcelRefundResponse": {
+        "type": "object",
+        "properties": {
+          "totalRequested": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "successCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "failureCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "successes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkParcelRefundSuccess"
+            },
+            "nullable": true
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkParcelRefundFailure"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateBulkParcelsRequest": {
+        "type": "object",
+        "properties": {
+          "parcels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SingleParcelCreationRequest"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateBulkParcelsResponse": {
+        "type": "object",
+        "properties": {
+          "totalRequested": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "successCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "failureCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "successes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkParcelSuccess"
+            },
+            "nullable": true
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkParcelFailure"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateClaimCommentCurrentSupplierRequest": {
+        "type": "object",
+        "properties": {
+          "claimId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateClaimRequest": {
+        "type": "object",
+        "properties": {
+          "categoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateClaimResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateCompanyCustomerRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "companyId": {
+            "type": "string",
+            "nullable": true
+          },
+          "companyContactPerson": {
+            "type": "string",
+            "nullable": true
+          },
+          "timeSlot": {
+            "type": "string",
+            "nullable": true
+          },
+          "instruction": {
+            "type": "string",
+            "nullable": true
+          },
+          "addresses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateAddressDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateCompanyCustomerResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateCustomerAddressRequest": {
+        "type": "object",
+        "properties": {
+          "customerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "address": {
+            "$ref": "#/components/schemas/CreateAddressDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateCustomerAddressResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateEndpointRequest": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "eventTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateEndpointResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "eventTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateIndividualCustomerRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "dateOfBirth": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "timeSlot": {
+            "type": "string",
+            "nullable": true
+          },
+          "instruction": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryPreference": {
+            "type": "string",
+            "nullable": true
+          },
+          "addresses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateAddressDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateIndividualCustomerResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateParcelExchangeRequest": {
+        "type": "object",
+        "properties": {
+          "customer": {
+            "$ref": "#/components/schemas/ParcelCustomerDto"
+          },
+          "deliveryAddress": {
+            "$ref": "#/components/schemas/DeliveryAddressInputDto"
+          },
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "orderedProducts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderedProductDto"
+            },
+            "nullable": true
+          },
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "stateId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "weight": {
+            "$ref": "#/components/schemas/ParcelWeightDto"
+          },
+          "originalParcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          },
+          "hubStockId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateParcelExchangeResponse": {
+        "type": "object",
+        "properties": {
+          "newParcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "returnParcelId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "originalParcelId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateParcelModificationRequestRequest": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryAddress": {
+            "$ref": "#/components/schemas/DeliveryAddressInputDto"
+          },
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateParcelModificationRequestResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateParcelRefundRequest": {
+        "type": "object",
+        "properties": {
+          "customer": {
+            "$ref": "#/components/schemas/ParcelCustomerDto"
+          },
+          "deliveryAddress": {
+            "$ref": "#/components/schemas/DeliveryAddressInputDto"
+          },
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateParcelRefundResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateParcelRequest": {
+        "type": "object",
+        "properties": {
+          "customer": {
+            "$ref": "#/components/schemas/ParcelCustomerDto"
+          },
+          "deliveryAddress": {
+            "$ref": "#/components/schemas/DeliveryAddressInputDto"
+          },
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "orderedProducts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderedProductDto"
+            },
+            "nullable": true
+          },
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "stateId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "weight": {
+            "$ref": "#/components/schemas/ParcelWeightDto"
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          },
+          "hubStockId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateParcelResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateParcelStateSituationHistorySupplierRequest": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "workflowId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parcelStateHistoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "situation": {
+            "$ref": "#/components/schemas/SituationDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateParcelStateSituationHistorySupplierResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreatePaymentRequestRequest": {
+        "type": "object",
+        "properties": {
+          "requestedDate": {
+            "type": "string",
+            "format": "date"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreatePaymentRequestResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreatePickupBagRequest": {
+        "type": "object",
+        "properties": {
+          "parcelIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreatePickupBagResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "successes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PickupBagParcelSuccess"
+            },
+            "nullable": true
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PickupBagParcelFailure"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateProductRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "localStock": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sku": {
+            "type": "string",
+            "nullable": true
+          },
+          "categoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "subCategoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "basePrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "purchasePrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "length": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "width": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "height": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "weight": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateProductResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateProductStockMovementUserRequest": {
+        "type": "object",
+        "properties": {
+          "products": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProductStockRequest"
+            },
+            "nullable": true
+          },
+          "hubStockId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateProductStockMovementUserResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateUserKeyRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiresInDays": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomerImportResult": {
+        "type": "object",
+        "properties": {
+          "succeededs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SucceededImportCustomerResult"
+            },
+            "nullable": true
+          },
+          "faileds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FailedImportCustomerResult"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomerResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "dateOfBirth": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "instruction": {
+            "type": "string",
+            "nullable": true
+          },
+          "timeSlot": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryPreference": {
+            "type": "string",
+            "nullable": true
+          },
+          "companyId": {
+            "type": "string",
+            "nullable": true
+          },
+          "companyContactPerson": {
+            "type": "string",
+            "nullable": true
+          },
+          "addresses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AddressResponse"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteBulkParcelsByTrackingNumberRequest": {
+        "type": "object",
+        "properties": {
+          "trackingNumbers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteBulkParcelsByTrackingNumberResponse": {
+        "type": "object",
+        "properties": {
+          "totalRequested": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "successCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "failureCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "successes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkParcelDeleteByTrackingNumberSuccess"
+            },
+            "nullable": true
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkParcelDeleteByTrackingNumberFailure"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteBulkParcelsRequest": {
+        "type": "object",
+        "properties": {
+          "parcelIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteBulkParcelsResponse": {
+        "type": "object",
+        "properties": {
+          "totalRequested": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "successCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "failureCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "successes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkParcelDeleteSuccess"
+            },
+            "nullable": true
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkParcelDeleteFailure"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteClaimResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteCustomerAddressResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteCustomerResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteParcelModificationRequestResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteParcelRespone": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeletePaymentRequestResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeletePickupBagResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteProductResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeliveryAddressInputDto": {
+        "type": "object",
+        "properties": {
+          "cityTerritoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "districtTerritoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "street": {
+            "type": "string",
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeliveryCapability": {
+        "type": "object",
+        "properties": {
+          "hasHomeDelivery": {
+            "type": "boolean"
+          },
+          "hasPickupPoint": {
+            "type": "boolean"
+          },
+          "canSend": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeliveryType": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DimensionsResponse": {
+        "type": "object",
+        "properties": {
+          "length": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "width": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "height": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DownloadExportReportResponse": {
+        "type": "object",
+        "properties": {
+          "sasUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DownloadProductsReportResponse": {
+        "type": "object",
+        "properties": {
+          "sasUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DownloadReportByIdResponse": {
+        "type": "object",
+        "properties": {
+          "sasUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DownloadReportResponse": {
+        "type": "object",
+        "properties": {
+          "sasUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "EndpointDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "eventTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "EndpointHeadersOut": {
+        "required": [
+          "headers",
+          "sensitive"
+        ],
+        "type": "object",
+        "properties": {
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "sensitive": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/ErrorType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ErrorType": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "ExportCustomersRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ExportProductsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ExportReportResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tenantId": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/UserSnapshot"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "fileId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ExportSupplierParcelsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "stateIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          },
+          "parcelTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ExportSupplierPaymentsCurrentSupplierRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FailedImportCustomerResult": {
+        "type": "object",
+        "properties": {
+          "rowIndex": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "FailedImportParcelResult": {
+        "type": "object",
+        "properties": {
+          "rowIndex": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "FailedImportProductResult": {
+        "type": "object",
+        "properties": {
+          "rowIndex": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Filter": {
+        "type": "object",
+        "properties": {
+          "logic": {
+            "type": "string",
+            "nullable": true
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Filter"
+            },
+            "nullable": true
+          },
+          "field": {
+            "type": "string",
+            "nullable": true
+          },
+          "operator": {
+            "type": "string",
+            "nullable": true
+          },
+          "value": {
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GenerateIndividualLabelsPdfRequest": {
+        "required": [
+          "trackingNumbers"
+        ],
+        "type": "object",
+        "properties": {
+          "trackingNumbers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "format": {
+            "$ref": "#/components/schemas/PdfLabelFormat"
+          },
+          "isPreview": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GenerateIndividualLabelsPdfResponse": {
+        "type": "object",
+        "properties": {
+          "parcelLabelFiles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParcelLabelPdfFile"
+            },
+            "nullable": true
+          },
+          "failedTrackingNumbers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GenerateIndividualLabelsRequest": {
+        "required": [
+          "trackingNumbers"
+        ],
+        "type": "object",
+        "properties": {
+          "trackingNumbers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GenerateIndividualLabelsResponse": {
+        "type": "object",
+        "properties": {
+          "parcelLabelFiles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParcelLabelFile"
+            },
+            "nullable": true
+          },
+          "failedTrackingNumbers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GenerateMultipleLabelsPdfRequest": {
+        "required": [
+          "trackingNumbers"
+        ],
+        "type": "object",
+        "properties": {
+          "trackingNumbers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "format": {
+            "$ref": "#/components/schemas/PdfLabelFormat"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GenerateMultipleLabelsPdfResponse": {
+        "type": "object",
+        "properties": {
+          "fileUrl": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true
+          },
+          "failedTrackingNumbers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GenerateMultipleLabelsRequest": {
+        "required": [
+          "trackingNumbers"
+        ],
+        "type": "object",
+        "properties": {
+          "trackingNumbers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GenerateMultipleLabelsResponse": {
+        "type": "object",
+        "properties": {
+          "fileUrl": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true
+          },
+          "failedTrackingNumbers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneratePickupBagLabelPdfRequest": {
+        "required": [
+          "trackingNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneratePickupBagLabelPdfResponse": {
+        "type": "object",
+        "properties": {
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "fileUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetAllRatesResponse": {
+        "type": "object",
+        "properties": {
+          "rates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TerritoryRateDto"
+            },
+            "nullable": true
+          },
+          "appliedDiscounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AppliedDiscountDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetCategoryClaimResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameEnglish": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameArabic": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetClaimSupplierRequest": {
+        "type": "object",
+        "properties": {
+          "claimId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetCustomerResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "dateOfBirth": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "instruction": {
+            "type": "string",
+            "nullable": true
+          },
+          "timeSlot": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryPreference": {
+            "type": "string",
+            "nullable": true
+          },
+          "companyId": {
+            "type": "string",
+            "nullable": true
+          },
+          "companyContactPerson": {
+            "type": "string",
+            "nullable": true
+          },
+          "addresses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AddressResponse"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetDeliveryPersonWithHubDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "assignedPriceListId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "phone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "hub": {
+            "$ref": "#/components/schemas/GetHubDto"
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "isUnavailable": {
+            "type": "boolean"
+          },
+          "isAccountActivated": {
+            "type": "boolean"
+          },
+          "penalities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PenalityDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetEndpointHeadersResponse": {
+        "type": "object",
+        "properties": {
+          "headers": {
+            "$ref": "#/components/schemas/EndpointHeadersOut"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetEndpointResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "eventTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "headers": {
+            "$ref": "#/components/schemas/EndpointHeadersOut"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetEndpointSecretResponse": {
+        "type": "object",
+        "properties": {
+          "secret": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetHubDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "isReturnCenter": {
+            "type": "boolean"
+          },
+          "address": {
+            "$ref": "#/components/schemas/AddressDto"
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HubServiceDto"
+            },
+            "nullable": true
+          },
+          "paymentRequestEligibilityCutoffTime": {
+            "type": "string",
+            "format": "time",
+            "nullable": true
+          },
+          "paymentRequestEligibilityCutoffTimezoneId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetPriceListDeliveryPriceDetailDto": {
+        "type": "object",
+        "properties": {
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "price": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetPriceListDeliveryPriceDto": {
+        "type": "object",
+        "properties": {
+          "toTerritory": {
+            "$ref": "#/components/schemas/TerritoryResponse"
+          },
+          "deliveryPriceDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GetPriceListDeliveryPriceDetailDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetPriceListResponse": {
+        "type": "object",
+        "properties": {
+          "priceLists": {
+            "$ref": "#/components/schemas/PriceListDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetProductRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "includeReceipts": {
+            "type": "boolean"
+          },
+          "includeStockMovement": {
+            "type": "boolean"
+          },
+          "includeWarehouseStock": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetProductResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "sku": {
+            "type": "string",
+            "nullable": true
+          },
+          "category": {
+            "$ref": "#/components/schemas/CategoryResponse"
+          },
+          "subCategory": {
+            "$ref": "#/components/schemas/SubCategoryResponse"
+          },
+          "price": {
+            "$ref": "#/components/schemas/PriceResponse"
+          },
+          "purchasePrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "dimensions": {
+            "$ref": "#/components/schemas/DimensionsResponse"
+          },
+          "localStock": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "warehouseStocks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WarehouseStockResponse"
+            },
+            "nullable": true
+          },
+          "weight": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VariantResponse"
+            },
+            "nullable": true
+          },
+          "stockMovements": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StockMovementResponse"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetRateResponse": {
+        "type": "object",
+        "properties": {
+          "toTerritoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "toTerritoryName": {
+            "type": "string",
+            "nullable": true
+          },
+          "toTerritoryNameArabic": {
+            "type": "string",
+            "nullable": true
+          },
+          "toTerritoryLevel": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryPrices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RateDeliveryPriceDto"
+            },
+            "nullable": true
+          },
+          "appliedDiscounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AppliedDiscountDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetReceiptResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "referenceId": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "totalProducts": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "supplier": {
+            "$ref": "#/components/schemas/SupplierInfoDto"
+          },
+          "address": {
+            "$ref": "#/components/schemas/ReceiptAddressDto"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "receivedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "stockMovements": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StockMovementsReceiptResponse"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetSupplierHubRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "includeServices": {
+            "type": "boolean"
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-span",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetSupplierOwnerDto": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetSupplierParcelResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "customer": {
+            "$ref": "#/components/schemas/ParcelCustomerDto"
+          },
+          "supplier": {
+            "$ref": "#/components/schemas/ParcelSupplierDto"
+          },
+          "deliveryAddress": {
+            "$ref": "#/components/schemas/ParcelAddressDto"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "amount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "deliveryPrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "returnPrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "paymentMethod": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "weight": {
+            "$ref": "#/components/schemas/WeightDto"
+          },
+          "bagId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "deliveryPersonId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "deliveryPerson": {
+            "$ref": "#/components/schemas/GetDeliveryPersonWithHubDto"
+          },
+          "state": {
+            "$ref": "#/components/schemas/StateDto"
+          },
+          "lastStateSituationId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "lastStateSitutationHistoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "lastStateHistoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "situation": {
+            "$ref": "#/components/schemas/SituationDto"
+          },
+          "tenantId": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastLocationHubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "lastStateUpdateAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastSituationUpdateAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastStateHistoryAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "hubStockId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "productsDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "productsStockType": {
+            "type": "string",
+            "nullable": true
+          },
+          "isReturn": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "canBeReturned": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "deliveredAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "markedAsReturnAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "returnedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "controlInfo": {
+            "$ref": "#/components/schemas/ControlInfoDto"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "isExchanged": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "originalParcelId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "returnParcelId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "pickupBagId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstConfirmationAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "hubDeliveryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "hasActiveModificationRequest": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "orderedProducts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderedProductResponse"
+            },
+            "nullable": true
+          },
+          "oldTrackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "swap": {
+            "$ref": "#/components/schemas/SupplierSwapInfoDto"
+          },
+          "modificationCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "phoneChangeCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "phoneChangePaymentCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "phoneChangePrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "applicablePhoneChangeThreshold": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "applicableModificationThreshold": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "applicableSwapThreshold": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "isEligibleForModification": {
+            "type": "boolean"
+          },
+          "isEligibleForPhoneChange": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetSupplierPaymentCurrentSupplierRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetSupplierRequest": {
+        "type": "object",
+        "properties": {
+          "supplierId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "includeServices": {
+            "type": "boolean"
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-span",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetSupplierResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "codeName": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "assignedPriceListId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "hubName": {
+            "type": "string",
+            "nullable": true
+          },
+          "address": {
+            "$ref": "#/components/schemas/AddressDto"
+          },
+          "phone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "supportPhone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "tenantId": {
+            "type": "string",
+            "nullable": true
+          },
+          "legalInformation": {
+            "$ref": "#/components/schemas/SupplierLegalInformationDto"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/GetSupplierOwnerDto"
+          },
+          "paymentDays": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SupplierServiceDto"
+            },
+            "nullable": true
+          },
+          "isBlocked": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetSupplierStatsAmountResponse": {
+        "type": "object",
+        "properties": {
+          "totalAmountPaid": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalAmountReadyToBePaid": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalAmountDelivered": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalAmountNotReadyCashed": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalAmountReadyToBeCashed": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HubServiceDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "HubSnapshot": {
+        "type": "object",
+        "properties": {
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "readOnly": true
+          },
+          "hubName": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "hubCity": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "hubCityTerritoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "readOnly": true
+          },
+          "hubDistrict": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "hubDistrictTerritoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "readOnly": true
+          },
+          "hubType": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "isReturnCenter": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "subContractorId": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportIndividualCustomersFormData": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "nullable": true
+          },
+          "columnsAndTheirPropertyNames": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportParcelsFormData": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "nullable": true
+          },
+          "columnsAndTheirPropertyNames": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportProductFormData": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "nullable": true
+          },
+          "columnsAndTheirPropertyNames": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ListEndpointsResponse": {
+        "type": "object",
+        "properties": {
+          "endpoints": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EndpointDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LocationSnapshot": {
+        "type": "object",
+        "properties": {
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "readOnly": true
+          },
+          "hubName": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "hubCity": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "hubDistrict": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "membership": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "hubTerritoryCityId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "OrderedProductDto": {
+        "type": "object",
+        "properties": {
+          "productId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "productName": {
+            "type": "string",
+            "nullable": true
+          },
+          "productSku": {
+            "type": "string",
+            "nullable": true
+          },
+          "unitPrice": {
+            "type": "number",
+            "format": "double"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "length": {
+            "type": "number",
+            "format": "double"
+          },
+          "width": {
+            "type": "number",
+            "format": "double"
+          },
+          "height": {
+            "type": "number",
+            "format": "double"
+          },
+          "weight": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "stockType": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "OrderedProductResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "productId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "productName": {
+            "type": "string",
+            "nullable": true
+          },
+          "productSku": {
+            "type": "string",
+            "nullable": true
+          },
+          "unitPrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "stockType": {
+            "type": "string",
+            "nullable": true
+          },
+          "dimensions": {
+            "$ref": "#/components/schemas/DimensionsResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_CategoryResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CategoryResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_ClaimCommentResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClaimCommentResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_ClaimResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClaimResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_ClaimWorkflowResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClaimWorkflowResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_CustomerResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomerResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_ExportReportResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExportReportResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_ParcelModificationRequestResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParcelModificationRequestResult"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_PaymentRequestResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentRequestResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_PickupBagParcelResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PickupBagParcelResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_SearchClaimCategoryResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchClaimCategoryResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_SearchOrdersReportsResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchOrdersReportsResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_SearchProductResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchProductResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_SearchProductsReportsResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchProductsReportsResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_SearchReceiptResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchReceiptResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_SearchReportsResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchReportsResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_SearchSupplierParcelResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchSupplierParcelResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_SupplierHubResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SupplierHubResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_SupplierPaymentResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SupplierPaymentResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_SupplierPickupBagResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SupplierPickupBagResult"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_TerritoryResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TerritoryResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_TreasurySupplierPaymentTransactionResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TreasurySupplierPaymentTransactionResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedList_WorkflowResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkflowResponse"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPrevious": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParcelAddressDto": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "cityTerritoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "district": {
+            "type": "string",
+            "nullable": true
+          },
+          "districtTerritoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "cityTerritoryCode": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "postalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "coordinates": {
+            "$ref": "#/components/schemas/Coordinates"
+          },
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "hubName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParcelCustomerDto": {
+        "type": "object",
+        "properties": {
+          "customerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParcelImportResult": {
+        "type": "object",
+        "properties": {
+          "succeededs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SucceededImportParcelResult"
+            },
+            "nullable": true
+          },
+          "faileds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FailedImportParcelResult"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParcelInfoClaimDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "district": {
+            "type": "string",
+            "nullable": true
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "stateName": {
+            "type": "string",
+            "nullable": true
+          },
+          "customerFullName": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParcelInfoResponse": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "customerFullName": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryPrice": {
+            "type": "number",
+            "format": "double"
+          },
+          "returnPrice": {
+            "type": "number",
+            "format": "double"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "weight": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalSwap": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          },
+          "stateName": {
+            "type": "string",
+            "nullable": true
+          },
+          "managementFee": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParcelLabelFile": {
+        "type": "object",
+        "properties": {
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "fileUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParcelLabelPdfFile": {
+        "type": "object",
+        "properties": {
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "fileUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParcelModificationRequestResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parcelTrackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "clientName": {
+            "type": "string",
+            "nullable": true
+          },
+          "parcelProductsDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "parcelState": {
+            "$ref": "#/components/schemas/StateDto"
+          },
+          "parcelPhone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "parcelAmount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "parcelDeliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parcelDeliveryAddress": {
+            "$ref": "#/components/schemas/ParcelAddressDto"
+          },
+          "newPhone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "newAmount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "newDeliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "newDeliveryAddress": {
+            "$ref": "#/components/schemas/ParcelAddressDto"
+          },
+          "newCustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "oldPhone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "oldAmount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "oldDeliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "oldDeliveryAddress": {
+            "$ref": "#/components/schemas/ParcelAddressDto"
+          },
+          "oldCustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "validatedBy": {
+            "$ref": "#/components/schemas/UserSnapshot"
+          },
+          "validatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isApproved": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "isSwap": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "oldTrackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "newTrackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isManagedByProDelivery": {
+            "type": "boolean"
+          },
+          "parcelSubContractorId": {
+            "type": "string",
+            "nullable": true
+          },
+          "canValidate": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParcelStateHistoryDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "previousState": {
+            "$ref": "#/components/schemas/StateDto"
+          },
+          "newState": {
+            "$ref": "#/components/schemas/StateDto"
+          },
+          "modifiedBy": {
+            "$ref": "#/components/schemas/UserSnapshot"
+          },
+          "location": {
+            "$ref": "#/components/schemas/LocationSnapshot"
+          },
+          "arrivalHub": {
+            "$ref": "#/components/schemas/HubSnapshot"
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "situations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParcelStateSituationHistoryDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParcelStateSituationHistoryDto": {
+        "type": "object",
+        "properties": {
+          "situationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "situationSlug": {
+            "type": "string",
+            "nullable": true
+          },
+          "situationDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "$ref": "#/components/schemas/UserSnapshot"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": { },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParcelSupplierDto": {
+        "type": "object",
+        "properties": {
+          "supplierName": {
+            "type": "string",
+            "nullable": true
+          },
+          "supplierCityTerritoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "supplierHubId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "supplierHubCityTerritoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "supplierHubName": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "supportPhone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParcelWeightDto": {
+        "type": "object",
+        "properties": {
+          "weight": {
+            "type": "number",
+            "format": "double"
+          },
+          "dimensionalWeight": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PaymentRequestResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tenantId": {
+            "type": "string",
+            "nullable": true
+          },
+          "supplierHubId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "supplierName": {
+            "type": "string",
+            "nullable": true
+          },
+          "hubName": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestedDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "validatedBy": {
+            "$ref": "#/components/schemas/UserSnapshot"
+          },
+          "validatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isApproved": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PdfLabelFormat": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PenalityDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "reducedCommission": {
+            "type": "number",
+            "format": "double"
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhoneDto": {
+        "type": "object",
+        "properties": {
+          "number1": {
+            "type": "string",
+            "nullable": true
+          },
+          "number2": {
+            "type": "string",
+            "nullable": true
+          },
+          "number3": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PickupBagParcelFailure": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "errorCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PickupBagParcelResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "pickupBagId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "supplier": {
+            "$ref": "#/components/schemas/PickupBagParcelSupplierResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PickupBagParcelSuccess": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PickupBagParcelSupplierResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PickupBagSupplierDto": {
+        "type": "object",
+        "properties": {
+          "supplierName": {
+            "type": "string",
+            "nullable": true
+          },
+          "supplierCityTerritoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "supplierHubId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PriceListDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "fromTerritory": {
+            "$ref": "#/components/schemas/TerritoryResponse"
+          },
+          "deliveryPrices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GetPriceListDeliveryPriceDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PriceResponse": {
+        "type": "object",
+        "properties": {
+          "base": {
+            "type": "number",
+            "format": "double"
+          },
+          "promotional": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "promotionStart": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "promotionEnd": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": { }
+      },
+      "ProductImportResult": {
+        "type": "object",
+        "properties": {
+          "succeededs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SucceededImportProductResult"
+            },
+            "nullable": true
+          },
+          "faileds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FailedImportProductResult"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProductInfoResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "price": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProductStockRequest": {
+        "type": "object",
+        "properties": {
+          "productId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RateDeliveryPriceDto": {
+        "type": "object",
+        "properties": {
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "price": {
+            "type": "number",
+            "format": "double"
+          },
+          "discountedPrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "isSpecificPrice": {
+            "type": "boolean"
+          },
+          "specificPriceId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "priceTtc": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "discountedPriceTtc": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "vatRate": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReceiptAddressDto": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "cityTerritoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "district": {
+            "type": "string",
+            "nullable": true
+          },
+          "districtTerritoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "postalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "coordinates": {
+            "$ref": "#/components/schemas/Coordinates"
+          },
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "hubName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReceiptResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "totalProducts": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "referenceId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RemoveParcelFromPickupBagRequest": {
+        "type": "object",
+        "properties": {
+          "pickupBagId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RemoveParcelsFromPickupBagResponse": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Result_CreateCompanyCustomerResponse": {
+        "type": "object",
+        "properties": {
+          "isSuccess": {
+            "type": "boolean"
+          },
+          "isFailure": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "error": {
+            "$ref": "#/components/schemas/Error"
+          },
+          "value": {
+            "$ref": "#/components/schemas/CreateCompanyCustomerResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Search": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchCategoriesRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "includeSubCategories": {
+            "type": "boolean"
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-span",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchClaimCategoriesRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-span",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchClaimCategoryResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameEnglish": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameArabic": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchClaimCommentsCurrentSupplierRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "claimId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchClaimWorkflowsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-span",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchClaimsSupplierRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchCustomersRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "includeAllAddresses": {
+            "type": "boolean"
+          },
+          "includePrimaryAddressOnly": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchExportReportsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchGlobalCustomerResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "phoneNumber1": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "district": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchGlobalSupplierParcelResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "oldTrackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "isReturn": {
+            "type": "boolean"
+          },
+          "customerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "customerPhone": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryDistrict": {
+            "type": "string",
+            "nullable": true
+          },
+          "stateName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchOrdersReportsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchOrdersReportsResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tenantId": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/UserSnapshot"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "request": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchParcelModificationRequestsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "onlyPending": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchPaymentRequestsCurrentSupplierRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "onlyPending": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchProductResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tenantId": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "sku": {
+            "type": "string",
+            "nullable": true
+          },
+          "localStock": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "categoryName": {
+            "type": "string",
+            "nullable": true
+          },
+          "categoryNameArabic": {
+            "type": "string",
+            "nullable": true
+          },
+          "categoryNameEnglish": {
+            "type": "string",
+            "nullable": true
+          },
+          "subCategoryName": {
+            "type": "string",
+            "nullable": true
+          },
+          "subCategoryNameArabic": {
+            "type": "string",
+            "nullable": true
+          },
+          "subCategoryNameEnglish": {
+            "type": "string",
+            "nullable": true
+          },
+          "price": {
+            "$ref": "#/components/schemas/PriceResponse"
+          },
+          "purchasePrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "dimensions": {
+            "$ref": "#/components/schemas/DimensionsResponse"
+          },
+          "warehouseStock": {
+            "$ref": "#/components/schemas/WarehouseStockResponse"
+          },
+          "weight": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VariantResponse"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchProductsReportsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchProductsReportsResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tenantId": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/UserSnapshot"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "fileId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchProductsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchReceiptResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "referenceId": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "totalProducts": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "supplier": {
+            "$ref": "#/components/schemas/SupplierInfoDto"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "receivedBy": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchReceiptsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchReportsResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tenantId": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "frequency": {
+            "type": "string",
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/UserSnapshot"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchSupplierHubsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "onlySortingCentersWhenAvailable": {
+            "type": "boolean"
+          },
+          "includeServices": {
+            "type": "boolean"
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-span",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchSupplierParcelResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "customer": {
+            "$ref": "#/components/schemas/ParcelCustomerDto"
+          },
+          "supplier": {
+            "$ref": "#/components/schemas/ParcelSupplierDto"
+          },
+          "deliveryAddress": {
+            "$ref": "#/components/schemas/ParcelAddressDto"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "amount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "returnPrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "deliveryPrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "paymentMethod": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "weight": {
+            "$ref": "#/components/schemas/WeightDto"
+          },
+          "bagId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "deliveryPersonId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "state": {
+            "$ref": "#/components/schemas/StateDto"
+          },
+          "lastStateSituationId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "lastStateSitutationHistoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "lastStateHistoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "hubStockId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "situation": {
+            "$ref": "#/components/schemas/SituationDto"
+          },
+          "tenantId": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastLocationHubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "lastStateUpdateAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastSituationUpdateAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastStateHistoryAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "productsDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "productsStockType": {
+            "type": "string",
+            "nullable": true
+          },
+          "isReturn": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "canBeReturned": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "deliveredAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "markedAsReturnAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "returnedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "controlInfo": {
+            "$ref": "#/components/schemas/ControlInfoDto"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "isExchanged": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "originalParcelId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "returnParcelId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "pickupBagId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstConfirmationAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "hubDeliveryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "oldTrackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "swap": {
+            "$ref": "#/components/schemas/SupplierSwapInfoDto"
+          },
+          "modificationCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "firstConfirmationHubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "phoneChangeCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "phoneChangePaymentCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "phoneChangePrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "applicablePhoneChangeThreshold": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "applicableModificationThreshold": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "applicableSwapThreshold": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "isEligibleForModification": {
+            "type": "boolean"
+          },
+          "isEligibleForPhoneChange": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchSupplierParcelsModificationRequestsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "onlyPending": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchSupplierParcelsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "stateIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          },
+          "parcelTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchSupplierPaymentsCurrentSupplierRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchSupplierPickupBagByTrackingNumberRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "onlyUnprocessedParcels": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchSupplierPickupBagsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "onlyUnprocessed": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchTerritoriesRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-span",
+            "nullable": true,
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "deliveryType": {
+            "$ref": "#/components/schemas/DeliveryType"
+          },
+          "includeUnavailable": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchTreasuryReportsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchTreasuryTransactionsSupplierPaymentBySupplierPaymentIdRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "supplierPaymentId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchUserKeysRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchWorkflowsRequest": {
+        "type": "object",
+        "properties": {
+          "advancedSearch": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "keyword": {
+            "type": "string",
+            "nullable": true
+          },
+          "advancedFilter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "pageSize": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "maximum": 10000,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "orderBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-span",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServicePricingResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "supplierName": {
+            "type": "string",
+            "nullable": true
+          },
+          "labelingPrice": {
+            "type": "number",
+            "format": "double"
+          },
+          "weightingPrice": {
+            "type": "number",
+            "format": "double"
+          },
+          "swapSameCityPrice": {
+            "type": "number",
+            "format": "double"
+          },
+          "swapDifferentCityPrice": {
+            "type": "number",
+            "format": "double"
+          },
+          "phoneChangePrice": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SingleParcelCreationRequest": {
+        "type": "object",
+        "properties": {
+          "customer": {
+            "$ref": "#/components/schemas/ParcelCustomerDto"
+          },
+          "deliveryAddress": {
+            "$ref": "#/components/schemas/DeliveryAddressInputDto"
+          },
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "orderedProducts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderedProductDto"
+            },
+            "nullable": true
+          },
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "weight": {
+            "$ref": "#/components/schemas/ParcelWeightDto"
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          },
+          "hubStockId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "stateId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SingleParcelExchangeRequest": {
+        "type": "object",
+        "properties": {
+          "customer": {
+            "$ref": "#/components/schemas/ParcelCustomerDto"
+          },
+          "deliveryAddress": {
+            "$ref": "#/components/schemas/DeliveryAddressInputDto"
+          },
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "orderedProducts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderedProductDto"
+            },
+            "nullable": true
+          },
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "weight": {
+            "$ref": "#/components/schemas/ParcelWeightDto"
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          },
+          "hubStockId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "originalParcelTrackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "stateId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SingleParcelRefundRequest": {
+        "type": "object",
+        "properties": {
+          "customer": {
+            "$ref": "#/components/schemas/ParcelCustomerDto"
+          },
+          "deliveryAddress": {
+            "$ref": "#/components/schemas/DeliveryAddressInputDto"
+          },
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SituationDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "slug": {
+            "type": "string",
+            "nullable": true
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": { },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SituationResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "slug": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "requirements": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "metadataType": {
+            "type": "string",
+            "nullable": true
+          },
+          "metadataConfiguration": {
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "StateClaimResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "isBlocking": {
+            "type": "boolean"
+          },
+          "isLocked": {
+            "type": "boolean"
+          },
+          "color": {
+            "type": "string",
+            "nullable": true
+          },
+          "ranking": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "StateDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "isBlocking": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "isLocked": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "visibleFor": {
+            "$ref": "#/components/schemas/ActorVisibilities"
+          },
+          "editableBy": {
+            "$ref": "#/components/schemas/ActorVisibilities"
+          },
+          "color": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "StateResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "ranking": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "visibleFor": {
+            "$ref": "#/components/schemas/ActorVisibilities"
+          },
+          "editableBy": {
+            "$ref": "#/components/schemas/ActorVisibilities"
+          },
+          "color": {
+            "type": "string",
+            "nullable": true
+          },
+          "requirements": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "transitions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransitionResponseDto"
+            },
+            "nullable": true
+          },
+          "situations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SituationResponseDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "StockMovementResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "productInfo": {
+            "$ref": "#/components/schemas/ProductInfoResponse"
+          },
+          "receipt": {
+            "$ref": "#/components/schemas/ReceiptResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "StockMovementsReceiptResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "productInfo": {
+            "$ref": "#/components/schemas/ProductInfoResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SubCategoryResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameArabic": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameEnglish": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SucceededImportCustomerResult": {
+        "type": "object",
+        "properties": {
+          "rowIndex": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "customerId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SucceededImportParcelResult": {
+        "type": "object",
+        "properties": {
+          "rowIndex": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SucceededImportProductResult": {
+        "type": "object",
+        "properties": {
+          "rowIndex": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "productId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SupplierHubResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "isPickupPoint": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "type": "boolean"
+          },
+          "isReturnCenter": {
+            "type": "boolean"
+          },
+          "address": {
+            "$ref": "#/components/schemas/AddressDto"
+          },
+          "openingHours": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentRequestEligibilityCutoffTime": {
+            "type": "string",
+            "format": "time"
+          },
+          "paymentRequestEligibilityCutoffTimezoneId": {
+            "type": "string",
+            "nullable": true
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HubServiceDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SupplierInfoDto": {
+        "type": "object",
+        "properties": {
+          "supplierId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SupplierLegalInformationDto": {
+        "type": "object",
+        "properties": {
+          "rc": {
+            "type": "string",
+            "nullable": true
+          },
+          "nif": {
+            "type": "string",
+            "nullable": true
+          },
+          "ai": {
+            "type": "string",
+            "nullable": true
+          },
+          "nis": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SupplierParcelsStatsResponseItem": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/StateDto"
+          },
+          "parcelCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SupplierPaymentResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "supplier": {
+            "$ref": "#/components/schemas/TreasurySupplierResponse"
+          },
+          "amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalParcelsDelivered": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalParcelsCancelled": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalRefundsCredited": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalRefundsDebited": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemLabeling": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "labelingAmount": {
+            "type": "number",
+            "format": "double"
+          },
+          "storage": {
+            "type": "number",
+            "format": "double"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "acceptedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "cashDrawer": {
+            "$ref": "#/components/schemas/CashDrawerResponse"
+          },
+          "referenceId": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "paymentRequestId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SupplierPaymentSupplierResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "supplier": {
+            "$ref": "#/components/schemas/TreasurySupplierResponse"
+          },
+          "amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalParcelsDelivered": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalParcelsCancelled": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalRefundsCredited": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalRefundsDebited": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemLabeling": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "labelingAmount": {
+            "type": "number",
+            "format": "double"
+          },
+          "storage": {
+            "type": "number",
+            "format": "double"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "referenceId": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "paymentRequestId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SupplierPickupBagResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "unprocessedParcelsCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "state": {
+            "type": "string",
+            "nullable": true
+          },
+          "supplier": {
+            "$ref": "#/components/schemas/PickupBagSupplierDto"
+          },
+          "totalParcels": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SupplierServiceDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SupplierSituationParcelsStatsResponseItem": {
+        "type": "object",
+        "properties": {
+          "situation": {
+            "$ref": "#/components/schemas/SituationDto"
+          },
+          "parcelCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SupplierSwapInfoDto": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sameCityCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "differentCityCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "swappedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "sameCityPrice": {
+            "type": "number",
+            "format": "double"
+          },
+          "differentCityPrice": {
+            "type": "number",
+            "format": "double"
+          },
+          "isEligibleForSwap": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SupplierTransactionStatsDto": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TenantMembershipDto": {
+        "type": "object",
+        "properties": {
+          "tenantId": {
+            "type": "string",
+            "nullable": true
+          },
+          "tenantName": {
+            "type": "string",
+            "nullable": true
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "supplierType": {
+            "type": "string",
+            "nullable": true
+          },
+          "membership": {
+            "type": "string",
+            "nullable": true
+          },
+          "subContractorNameSubDomain": {
+            "type": "string",
+            "nullable": true
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TerritoryRateDto": {
+        "type": "object",
+        "properties": {
+          "toTerritoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "toTerritoryCode": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "toTerritoryName": {
+            "type": "string",
+            "nullable": true
+          },
+          "toTerritoryNameArabic": {
+            "type": "string",
+            "nullable": true
+          },
+          "toTerritoryLevel": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryPrices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RateDeliveryPriceDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TerritoryResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameArabic": {
+            "type": "string",
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "level": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "delivery": {
+            "$ref": "#/components/schemas/DeliveryCapability"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TransitionClaimResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "actionName": {
+            "type": "string",
+            "nullable": true
+          },
+          "fromStateId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "toStateId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TransitionResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "actionName": {
+            "type": "string",
+            "nullable": true
+          },
+          "fromStateId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "toStateId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TreasuryHubResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "address": {
+            "$ref": "#/components/schemas/AddressDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TreasurySupplierOwnerDto": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TreasurySupplierPaymentTransactionResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "weightCost": {
+            "type": "number",
+            "format": "double"
+          },
+          "swapCost": {
+            "type": "number",
+            "format": "double"
+          },
+          "phoneChangeCost": {
+            "type": "number",
+            "format": "double"
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "supplier": {
+            "$ref": "#/components/schemas/SupplierInfoDto"
+          },
+          "parcel": {
+            "$ref": "#/components/schemas/ParcelInfoResponse"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "cashReceiptId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "supplierPaymentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "supplierPaymentReference": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TreasurySupplierResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "tenantId": {
+            "type": "string",
+            "nullable": true
+          },
+          "address": {
+            "$ref": "#/components/schemas/AddressDto"
+          },
+          "paymentDays": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "phone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/TreasurySupplierOwnerDto"
+          },
+          "legalInformation": {
+            "$ref": "#/components/schemas/SupplierLegalInformationDto"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateAmountRequest": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateAmountResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateClaimCommentResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateClaimDetailsRequest": {
+        "type": "object",
+        "properties": {
+          "claimId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "categoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateClaimDetailsResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateCustomerAddressRequest": {
+        "type": "object",
+        "properties": {
+          "customerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "addressId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "street": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "cityTerritoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "district": {
+            "type": "string",
+            "nullable": true
+          },
+          "districtTerritoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "coordinates": {
+            "$ref": "#/components/schemas/Coordinates"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateCustomerAddressResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateCustomerRequest": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateCustomerResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateDeliveryAddressRequest": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deliveryAddress": {
+            "$ref": "#/components/schemas/DeliveryAddressInputDto"
+          },
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateDeliveryAddressResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateDiscountRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "promotionalPrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "promotionStart": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "promotionEnd": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateDiscountResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateEndpointRequest": {
+        "type": "object",
+        "properties": {
+          "endpointId": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "eventTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateEndpointResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "eventTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateIndividualCustomerRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "$ref": "#/components/schemas/PhoneDto"
+          },
+          "timeSlot": {
+            "type": "string",
+            "nullable": true
+          },
+          "instruction": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryPreference": {
+            "type": "string",
+            "nullable": true
+          },
+          "dateOfBirth": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateIndividualCustomerResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateOrderProductsResponse": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateOrderedProductsRequest": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "orderedProducts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderedProductDto"
+            },
+            "nullable": true
+          },
+          "amount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "hubStockId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateParcelModificationRequestRequest": {
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "deliveryType": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveryAddress": {
+            "$ref": "#/components/schemas/DeliveryAddressInputDto"
+          },
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateParcelModificationRequestResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateParcelRefundStateRequest": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "newStateId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deliveryPersonId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "arrivalHubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateParcelRefundStateResponse": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "newStateId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "newStateName": {
+            "type": "string",
+            "nullable": true
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateParcelStateRequest": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "newStateId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deliveryPersonId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "arrivalHubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateParcelStateResponse": {
+        "type": "object",
+        "properties": {
+          "parcelId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "newStateId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "newStateName": {
+            "type": "string",
+            "nullable": true
+          },
+          "trackingNumber": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdatePaymentRequestDateRequest": {
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "requestedDate": {
+            "type": "string",
+            "format": "date"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdatePaymentRequestDateResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdatePriceRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "basePrice": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdatePriceResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateProductLocalStockRequest": {
+        "type": "object",
+        "properties": {
+          "productId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "localStock": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateProductLocalStockResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateProductRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "categoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "subCategoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "length": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "purchasePrice": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "width": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "height": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "weight": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "sku": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateProductResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateSupplierBlockedStatusRequest": {
+        "type": "object",
+        "properties": {
+          "supplierId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "isBlocked": {
+            "type": "boolean"
+          },
+          "cachedRequestsToInvalidate": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateSupplierBlockedStatusResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UserDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "phoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "memberships": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TenantMembershipDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UserSnapshot": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "readOnly": true
+          },
+          "fullName": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "VariantResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "color": {
+            "type": "string",
+            "nullable": true
+          },
+          "stockQuantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "price": {
+            "$ref": "#/components/schemas/PriceResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "WarehouseStockResponse": {
+        "type": "object",
+        "properties": {
+          "damageQuantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "availableQuantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pendingReceptionQuantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "withdrawalQuantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "underDeliveryQuantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "deliveredQuantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "hubId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "hubName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "WeightDto": {
+        "type": "object",
+        "properties": {
+          "weight": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "dimensionalWeight": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "effectiveWeight": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "WorkflowResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "states": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StateResponseDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "description": "Enter your token in the text input below.\r\n\r\nExample: \"ejlklm533123\" without Bearer prefix",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      },
+      "apiKey": {
+        "type": "apiKey",
+        "description": "API Key Authentication\r\n\r\nEnter your API key in the format: \"X-Api-Key: your-api-key\"",
+        "name": "X-Api-Key",
+        "in": "header"
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": [ ],
+      "apiKey": [ ]
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,7 @@ router.openapi(myRoute.route, myRoute.handler);
 | `codflow-setup` | Setting up the project |
 | `whatsapp-otp` | WhatsApp OTP verification feature (dzverify) |
 | `Ecotrack` | EcoTrack carrier integration |
+| `zr-express` | ZR Express delivery platform integration (129 endpoints, organized per domain) |
 | **`diagnosing-bugs`** | **Debug production issues (orders, delivery, payments)** |
 | **`domain-modeling`** | **Design data models for complex domain** |
 | **`implement`** | **Turn specs into working code** |

--- a/cod-client-astro/src/features/orders/model.test.ts
+++ b/cod-client-astro/src/features/orders/model.test.ts
@@ -179,7 +179,10 @@ describe("orders model", () => {
       shipmentCapabilities("zr_express", "dispatched", true),
     ).toMatchObject({
       canUpdate: true,
-      canCancel: false,
+      // DELETE /parcels/bulk/by-tracking-number works (live-verified 2026-09-10;
+      // the old 405 came from wrongly using POST) — cancel is offered while the
+      // order is not in a terminal status.
+      canCancel: true,
       canRemark: false,
       canTrack: true,
     });

--- a/cod-client-astro/src/features/orders/model.ts
+++ b/cod-client-astro/src/features/orders/model.ts
@@ -114,8 +114,10 @@ export function shipmentCapabilities(
     companyCode === "ecotrack" || companyCode.endsWith("_ecotrack");
   const supportsUpdate =
     isEcotrack || ["noest", "yalidine", "zr_express"].includes(companyCode);
+  // ZR Express deletion works via DELETE /parcels/bulk/by-tracking-number
+  // (live-verified 2026-09-10; the earlier 405 came from a wrong POST).
   const supportsCancel =
-    isEcotrack || ["noest", "yalidine"].includes(companyCode);
+    isEcotrack || ["noest", "yalidine", "zr_express"].includes(companyCode);
   const canUpdate =
     isEcotrack || companyCode === "zr_express"
       ? !isTerminalStatus(status)

--- a/cod-server/src/endpoints/delivery-companies/providers/zr_express/adapter.test.ts
+++ b/cod-server/src/endpoints/delivery-companies/providers/zr_express/adapter.test.ts
@@ -6,8 +6,12 @@
  *   - createShipment goes through customer creation → territory resolve → parcel
  *   - parcelId comes back in rawResponse (so the handler can use it for updates)
  *   - phone numbers are normalized to +213 format
- *   - updateShipment treats the first arg as parcelId UUID and posts to the right
- *     per-field endpoints with parcelId in the body
+ *   - stop-desk parcels send a real hub id (not a territory UUID) as hubId
+ *   - updateShipment treats the first arg as parcelId UUID, GETs the parcel
+ *     first, and PATCHes the per-field endpoints with parcelId in the body
+ *   - deleteShipment sends DELETE (POST answers 405) and throws on failure
+ *   - getTrackingInfo resolves the parcel UUID first (state-history 404s on
+ *     tracking numbers), then maps rows to {activity, description, date}
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -48,21 +52,20 @@ describe("ZrExpressProvider.createShipment", () => {
   });
 
   it("creates customer → resolves territory → creates parcel → fetches tracking", async () => {
+    const cityItem = { id: "city-uuid", level: "wilaya", code: 16, name: "Alger" };
+    const districtItem = {
+      id: "district-uuid",
+      level: "commune",
+      parentId: "city-uuid",
+      name: "Alger Centre",
+    };
     fetchMock
       // 1) POST /v1/customers/individual
       .mockResolvedValueOnce(jsonResponse({ id: "cust-uuid" }))
-      // 2) POST /v1/territories/search (city, by name "Alger")
-      .mockResolvedValueOnce(
-        jsonResponse({
-          items: [{ id: "city-uuid", level: "wilaya", code: 16, name: "Alger" }],
-        })
-      )
-      // 3) POST /v1/territories/search (district, by commune)
-      .mockResolvedValueOnce(
-        jsonResponse({
-          items: [{ id: "district-uuid", parentId: "city-uuid", name: "Alger Centre" }],
-        })
-      )
+      // 2) POST /v1/territories/search (city, by accent-stripped name "Alger")
+      .mockResolvedValueOnce(jsonResponse({ items: [cityItem] }))
+      // 3) POST /v1/territories/search (district — parent must match city)
+      .mockResolvedValueOnce(jsonResponse({ items: [districtItem] }))
       // 4) POST /v1/parcels
       .mockResolvedValueOnce(jsonResponse({ id: PARCEL_UUID }))
       // 5) GET /v1/parcels/:id
@@ -106,31 +109,38 @@ describe("ZrExpressProvider.createShipment", () => {
     expect(raw.parcelId).toBe(PARCEL_UUID);
   });
 
-  it("uses the stationCode UUID as districtTerritoryId for stop-desk orders", async () => {
-    const STOP_DESK_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+  it("sends hub id as hubId", async () => {
+    const HUB_ID = "hub-uuid-1";
+    const hub = {
+      id: HUB_ID,
+      isPickupPoint: true,
+      address: { districtTerritoryId: "hub-district-uuid", cityTerritoryId: "hub-city-uuid" },
+    };
     fetchMock
       .mockResolvedValueOnce(jsonResponse({ id: "cust-uuid" }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          items: [{ id: "city-uuid", level: "wilaya", code: 16, name: "Alger" }],
-        })
-      )
-      // 4) POST /v1/parcels — district lookup is skipped because stationCode is a UUID
+      .mockResolvedValueOnce(jsonResponse({ items: [hub], totalPages: 1 }))
       .mockResolvedValueOnce(jsonResponse({ id: PARCEL_UUID }))
       .mockResolvedValueOnce(
-        jsonResponse({ id: PARCEL_UUID, trackingNumber: "16-XYZ-ZR" })
+        jsonResponse({ id: PARCEL_UUID, trackingNumber: "16-PP-ZR" })
       );
 
     const provider = new ZrExpressProvider(TOKEN, TENANT);
-    await provider.createShipment({
+    const result = await provider.createShipment({
       ...baseInput,
       stopDesk: true,
-      stationCode: STOP_DESK_UUID,
+      stationCode: HUB_ID,
     });
+
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      "https://api.zrexpress.app/api/v1/hubs/search"
+    );
 
     const parcelBody = JSON.parse(fetchMock.mock.calls[2][1].body as string);
     expect(parcelBody.deliveryType).toBe("pickup-point");
-    expect(parcelBody.deliveryAddress.districtTerritoryId).toBe(STOP_DESK_UUID);
+    expect(parcelBody.hubId).toBe(HUB_ID);
+    expect(parcelBody.deliveryAddress.districtTerritoryId).toBe("hub-district-uuid");
+    expect(parcelBody.deliveryAddress.cityTerritoryId).toBe("hub-city-uuid");
+    expect(result.trackingNumber).toBe("16-PP-ZR");
   });
 
   it("throws if no wilaya territory matches", async () => {
@@ -165,71 +175,105 @@ describe("ZrExpressProvider.updateShipment", () => {
     global.fetch = fetchMock as unknown as typeof fetch;
   });
 
-  it("treats the first arg as parcelId UUID — calls /amount, /customer, /deliveryAddress", async () => {
+  it("gets parcel then patches", async () => {
+    const snap = {
+      id: PARCEL_UUID,
+      amount: 4500,
+      customer: { name: "Karim Benali", phone: { number1: "+213551234567" } },
+      deliveryAddress: {
+        street: "Rue 1, Alger",
+        cityTerritoryId: "city-uuid",
+        districtTerritoryId: "district-uuid",
+      },
+    };
     fetchMock
-      .mockResolvedValueOnce(jsonResponse({}))  // amount
-      .mockResolvedValueOnce(jsonResponse({}))  // customer
-      .mockResolvedValueOnce(jsonResponse({})); // deliveryAddress
+      .mockResolvedValueOnce(jsonResponse(snap))
+      .mockResolvedValueOnce(jsonResponse({}))
+      .mockResolvedValueOnce(jsonResponse({}))
+      .mockResolvedValueOnce(jsonResponse({ items: [{ id: "city-uuid", level: "wilaya", code: 16 }] }))
+      .mockResolvedValueOnce(jsonResponse({ items: [{ id: "district-uuid", level: "commune", parentId: "city-uuid" }] }))
+      .mockResolvedValueOnce(jsonResponse({}));
 
     const provider = new ZrExpressProvider(TOKEN, TENANT);
     const ok = await provider.updateShipment(PARCEL_UUID, {
       amount: 5000,
       customerName: "Karim Updated",
       phone: "0552222222",
-      address: "Rue 2",
+      address: "Rue 2, Alger",
+      commune: "Alger Centre",
+      wilayaId: 16,
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
 
     expect(fetchMock.mock.calls[0][0]).toBe(
+      `https://api.zrexpress.app/api/v1/parcels/${PARCEL_UUID}`
+    );
+
+    expect(fetchMock.mock.calls[1][0]).toBe(
       `https://api.zrexpress.app/api/v1/parcels/${PARCEL_UUID}/amount`
     );
-    expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({
+    expect(fetchMock.mock.calls[1][1].method).toBe("PATCH");
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body as string)).toEqual({
       parcelId: PARCEL_UUID,
       amount: 5000,
     });
 
-    expect(fetchMock.mock.calls[1][0]).toBe(
+    expect(fetchMock.mock.calls[2][0]).toBe(
       `https://api.zrexpress.app/api/v1/parcels/${PARCEL_UUID}/customer`
     );
-    expect(JSON.parse(fetchMock.mock.calls[1][1].body as string)).toEqual({
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body as string)).toEqual({
       parcelId: PARCEL_UUID,
       name: "Karim Updated",
       phone: "+213552222222",
     });
 
-    expect(fetchMock.mock.calls[2][0]).toBe(
+    expect(fetchMock.mock.calls[3][0]).toBe(
+      "https://api.zrexpress.app/api/v1/territories/search"
+    );
+    expect(fetchMock.mock.calls[5][0]).toBe(
       `https://api.zrexpress.app/api/v1/parcels/${PARCEL_UUID}/deliveryAddress`
     );
-    expect(JSON.parse(fetchMock.mock.calls[2][1].body as string)).toEqual({
-      parcelId: PARCEL_UUID,
-      deliveryAddress: { street: "Rue 2" },
-    });
+    const addrBody = JSON.parse(fetchMock.mock.calls[5][1].body as string);
+    expect(addrBody.parcelId).toBe(PARCEL_UUID);
+    expect(addrBody.deliveryAddress.cityTerritoryId).toBe("city-uuid");
+    expect(addrBody.deliveryAddress.districtTerritoryId).toBe("district-uuid");
 
     expect(ok).toBe(true);
   });
 
-  it("only hits the endpoints whose fields are provided", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({}));
+  it("skips unchanged fields", async () => {
+    const snap = {
+      id: PARCEL_UUID,
+      amount: 4500,
+      customer: { name: "Karim Benali", phone: { number1: "+213551234567" } },
+    };
+    fetchMock.mockResolvedValueOnce(jsonResponse(snap));
 
     const provider = new ZrExpressProvider(TOKEN, TENANT);
-    await provider.updateShipment(PARCEL_UUID, { amount: 100 });
+    await provider.updateShipment(PARCEL_UUID, {
+      amount: 4500,
+      customerName: "Karim Benali",
+      phone: "+213551234567",
+    });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0][0]).toMatch(/\/amount$/);
   });
 
-  it("returns false (does not throw) when carrier rejects an update", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ message: "Locked" }, 400));
+  it("throws when carrier rejects an update", async () => {
+    const snap = { id: PARCEL_UUID, amount: 4500 };
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(snap))
+      .mockResolvedValueOnce(jsonResponse({ detail: "Locked" }, 400));
     const provider = new ZrExpressProvider(TOKEN, TENANT);
-    expect(await provider.updateShipment(PARCEL_UUID, { amount: 1 })).toBe(false);
+    await expect(provider.updateShipment(PARCEL_UUID, { amount: 1 })).rejects.toThrow();
   });
 });
 
 describe("ZrExpressProvider.deleteShipment", () => {
-  it("POSTs trackingNumber to /parcels/bulk/by-tracking-number", async () => {
+  it("sends DELETE and returns true", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(jsonResponse({ successCount: 1, failureCount: 0 }));
+      .mockResolvedValueOnce(jsonResponse({ successCount: 1, failures: [] }));
     global.fetch = fetchMock as unknown as typeof fetch;
 
     const provider = new ZrExpressProvider(TOKEN, TENANT);
@@ -241,43 +285,68 @@ describe("ZrExpressProvider.deleteShipment", () => {
     expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({
       trackingNumbers: ["16-ABCDEF-ZR"],
     });
+    expect(fetchMock.mock.calls[0][1].method).toBe("DELETE");
   });
 
-  it("returns false on the documented HTTP 405 (carrier-side delete is broken)", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ message: "Not allowed" }, 405));
+  it("treats not-found as success", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({ successCount: 0, failures: [{ errorMessage: "Parcel not found" }] })
+    );
     global.fetch = fetchMock as unknown as typeof fetch;
 
     const provider = new ZrExpressProvider(TOKEN, TENANT);
-    expect(await provider.deleteShipment("16-ABCDEF-ZR")).toBe(false);
+    expect(await provider.deleteShipment("16-ABCDEF-ZR")).toBe(true);
+  });
+
+  it("throws on carrier failure", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({ successCount: 0, failures: [{ errorMessage: "Already delivered" }] })
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = new ZrExpressProvider(TOKEN, TENANT);
+    await expect(provider.deleteShipment("16-ABCDEF-ZR")).rejects.toThrow(/failed to delete/);
   });
 });
 
 describe("ZrExpressProvider.getTrackingInfo", () => {
-  it("maps state-history rows to {activity, description, date}", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce(
-      jsonResponse([
-        {
-          newState: { name: "PickupStarted", description: "Picked up by courier" },
-          createdAt: "2026-04-25T10:00:00Z",
-        },
-        {
-          newState: { name: "Delivered", description: "Delivered to customer" },
-          createdAt: "2026-04-26T14:00:00Z",
-        },
-      ])
-    );
+  it("resolves uuid then reads history", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ id: PARCEL_UUID, trackingNumber: "16-ABCDEF-ZR" }))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            newState: { name: "commande_recue", description: "Commande recue" },
+            createdAt: "2026-04-25T10:00:00Z",
+          },
+          {
+            newState: { name: "livre", description: "Livre au client" },
+            createdAt: "2026-04-26T14:00:00Z",
+          },
+        ])
+      );
     global.fetch = fetchMock as unknown as typeof fetch;
 
     const provider = new ZrExpressProvider(TOKEN, TENANT);
     const events = await provider.getTrackingInfo("16-ABCDEF-ZR");
 
-    expect(fetchMock.mock.calls[0][0]).toBe(
-      "https://api.zrexpress.app/api/v1/parcels/16-ABCDEF-ZR/state-history"
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      `https://api.zrexpress.app/api/v1/parcels/${PARCEL_UUID}/state-history`
     );
     expect(events).toEqual([
-      { activity: "PickupStarted", description: "Picked up by courier", date: "2026-04-25T10:00:00Z" },
-      { activity: "Delivered", description: "Delivered to customer", date: "2026-04-26T14:00:00Z" },
+      { activity: "commande_recue", description: "Commande recue", date: "2026-04-25T10:00:00Z" },
+      { activity: "livre", description: "Livre au client", date: "2026-04-26T14:00:00Z" },
     ]);
+  });
+
+  it("returns empty for unknown tracking", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({ title: "Not Found" }, 404)
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = new ZrExpressProvider(TOKEN, TENANT);
+    expect(await provider.getTrackingInfo("16-NOPE-ZR")).toEqual([]);
   });
 });
 

--- a/cod-server/src/endpoints/delivery-companies/providers/zr_express/adapter.ts
+++ b/cod-server/src/endpoints/delivery-companies/providers/zr_express/adapter.ts
@@ -4,18 +4,28 @@
  * Implements the DeliveryProvider interface for ZR Express (https://api.zrexpress.app).
  * Auth: X-Api-Key: {secretKey}  +  X-Tenant: {tenantId}
  *
- * Key design points:
- *  - ZR uses UUID-based territories for city + district (not wilaya_id + commune strings)
- *  - No separate "validate shipment" step — parcels are active immediately after creation
- *  - Single create returns a parcel UUID; tracking number comes back in GET /parcels/{id}
- *  - Bulk create (POST /parcels/bulk) returns trackingNumber directly in the response
- *  - Territory resolution is cached in-instance (city cache keyed by wilayaId)
+ * Key design points (live-verified 2026-09-10 against the production API):
+ *  - ZR uses UUID-based territories (wilaya/commune); its search is ACCENT-SENSITIVE
+ *    and its territory DB stores accent-free names — all name searches run stripped.
+ *  - Stop desks are HUBS (`POST /hubs/search`, isPickupPoint) — parcel creation and
+ *    pickup-point address updates require a real hub id as `hubId`; a territory UUID
+ *    answers 404 HubNotFound.
+ *  - No separate "validate shipment" step — parcels are active immediately after creation.
+ *  - Single create returns a parcel UUID; tracking number comes back in GET /parcels/{id}.
+ *    GET /parcels/{trackingNumber} also works, but /state-history only accepts the UUID.
+ *  - Bulk create (POST /parcels/bulk) returns trackingNumber directly in the response.
+ *  - Deletes go through DELETE /parcels/bulk/by-tracking-number (POST answers 405).
+ *  - Territory / hub lookups are cached in-instance.
  *
  * Endpoints used:
  *  createShipment        → POST /v1/customers/individual + territory search + POST /v1/parcels
  *  createShipmentsBulk   → POST /v1/customers/individual (×N) + POST /v1/parcels/bulk
  *  validateShipment      → no-op (ZR auto-activates on creation)
- *  getStopDesks          → POST /v1/territories/search (deliveryType=pickup-point)
+ *  updateShipment        → GET /v1/parcels/{id} + PATCH amount|customer|deliveryAddress
+ *  deleteShipment        → DELETE /v1/parcels/bulk/by-tracking-number
+ *  getTrackingInfo       → GET /v1/parcels/{trackingNumber} → GET /v1/parcels/{id}/state-history
+ *  getStopDesks          → POST /v1/hubs/search (+ territory wilaya map)
+ *  getLabelUrl           → POST /v1/parcels/labels/individual/pdf
  */
 
 import type {
@@ -46,13 +56,13 @@ import type {
   ZrUpdateDeliveryAddressRequest,
   ZrGenerateLabelRequest,
   ZrGenerateLabelResponse,
+  ZrHubItem,
+  ZrPagedListHubs,
 } from "./types";
+import { stripAccents } from "./text";
 
 const BASE_URL = "https://api.zrexpress.app";
 const API_VERSION = "1";
-
-/** UUID v4 regex — used to detect when stationCode is already a ZR territory UUID. */
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export class ZrExpressProvider implements DeliveryProvider {
   readonly code = "zr_express";
@@ -156,6 +166,25 @@ export class ZrExpressProvider implements DeliveryProvider {
     return (json ?? {}) as TRes;
   }
 
+  private async delete<TReq, TRes>(path: string, body: TReq): Promise<TRes> {
+    const res = await fetch(`${BASE_URL}${path}`, {
+      method: "DELETE",
+      headers: this.headers(),
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    let json: unknown = text ? undefined : {};
+    if (text) {
+      try {
+        json = JSON.parse(text);
+      } catch {
+        throw new Error(`ZR Express HTTP ${res.status} — response is not valid JSON`);
+      }
+    }
+    if (!res.ok) throw this.parseError(json, res.status);
+    return (json ?? {}) as TRes;
+  }
+
   // ─── Territory resolution ──────────────────────────────────────────────────
 
   private async searchTerritories(
@@ -176,38 +205,55 @@ export class ZrExpressProvider implements DeliveryProvider {
   }
 
   /**
-   * Resolve the ZR city territory UUID for a given wilayaId.
-   * Uses the wilaya name (from CreateShipmentInput.wilaya) as a keyword,
-   * then finds the matching territory by code == wilayaId and level == "wilaya".
+   * Resolve the ZR city (wilaya) territory for a given wilayaId.
+   *
+   * Strategy (live-verified 2026-09-10 over all 58 wilayas):
+   *  1. Search by the accent-stripped wilaya name — resolves 51/58 directly
+   *     (ZR stores accent-free names; the raw accented name misses).
+   *  2. Fallback: search by the wilaya number as keyword (page size 200 — the
+   *     default page of 50 often omits the wilaya row).
+   *  3. Otherwise throw. Four wilayas (33 Illizi, 37 Tindouf, 50 Bordj Badji
+   *     Mokhtar, 56 Djanet) have NO territory in ZR at all — the carrier does
+   *     not serve them, and parcel creation cannot proceed.
+   *
    * Results are cached in-instance for the lifetime of this adapter.
    */
   private async resolveCityId(wilayaId: number, wilayaName: string): Promise<ZrTerritoryItem> {
     const cached = this.cityCache.get(wilayaId);
     if (cached) return cached;
 
-    const items = await this.searchTerritories(wilayaName);
-    // ✅ FIX: ZR uses "wilaya" not "state" for territory level
-    const match = items.find((t) => t.code === wilayaId && t.level === "wilaya");
-    if (!match) {
-      const itemsByCode = await this.searchTerritories(String(wilayaId));
-      const matchByCode = itemsByCode.find((t) => t.code === wilayaId && t.level === "wilaya");
-      if (!matchByCode) {
-        throw new Error(
-          `ZR Express: Could not resolve territory for wilaya ${wilayaId} ("${wilayaName}"). ` +
-          `Check that the wilaya name matches ZR Express territory names.`
-        );
-      }
+    // ZR territory levels: "wilaya" | "commune" (never "state").
+    const isTarget = (t: ZrTerritoryItem) => t.code === wilayaId && t.level === "wilaya";
+
+    const byName = await this.searchTerritories(stripAccents(wilayaName));
+    const match = byName.find(isTarget);
+    if (match) {
+      this.cityCache.set(wilayaId, match);
+      return match;
+    }
+
+    const byCode = await this.searchTerritories(String(wilayaId), { pageSize: 200 });
+    const matchByCode = byCode.find(isTarget);
+    if (matchByCode) {
       this.cityCache.set(wilayaId, matchByCode);
       return matchByCode;
     }
 
-    this.cityCache.set(wilayaId, match);
-    return match;
+    throw new Error(
+      `ZR Express: no territory for wilaya ${wilayaId} ("${wilayaName}"). ` +
+      `The carrier does not serve this wilaya (verified unserved: 33 Illizi, ` +
+      `37 Tindouf, 50 Bordj Badji Mokhtar, 56 Djanet), or the name does not ` +
+      `match ZR's territory list.`
+    );
   }
 
   /**
-   * Resolve the ZR district territory UUID for a commune name within a city.
-   * For stop-desk deliveries, filters to pickup-point capable territories only.
+   * Resolve the ZR district (commune) territory for a commune name within a city.
+   *
+   * Strict on purpose: an unmatched commune must FAIL the dispatch, never fall
+   * back to an arbitrary commune (the previous `items[0]` fallback could
+   * silently deliver to the wrong commune — live-verified that accented names
+   * like "Bir Mourad Raïs" return 0 results while "Bir Mourad Rais" matches).
    */
   private async resolveDistrictId(
     communeName: string,
@@ -217,19 +263,70 @@ export class ZrExpressProvider implements DeliveryProvider {
     const extra: Partial<ZrSearchTerritoriesRequest> = isStopDesk
       ? { deliveryType: { value: "pickup-point" } }
       : {};
-    const items = await this.searchTerritories(communeName, extra);
+    const items = await this.searchTerritories(stripAccents(communeName), extra);
+    const communes = items.filter((t) => t.level === "commune");
 
-    const match = items.find((t) => t.parentId === cityItem.id);
-    if (!match) {
-      const fallback = items.find((t) => t.parentId != null) ?? items[0];
-      if (!fallback) {
-        throw new Error(
-          `ZR Express: Could not resolve territory for commune "${communeName}" in ${cityItem.name ?? cityItem.id}.`
-        );
-      }
-      return fallback;
+    // 1) Exact: a commune whose parent is the resolved city.
+    const byParent = communes.find((t) => t.parentId === cityItem.id);
+    if (byParent) return byParent;
+
+    // 2) Accent-insensitive name match among the returned communes.
+    const needle = stripAccents(communeName).toLowerCase();
+    const byName = communes.find((t) => stripAccents(t.name ?? "").toLowerCase() === needle);
+    if (byName) return byName;
+
+    throw new Error(
+      `ZR Express: could not resolve commune "${communeName}" in ` +
+      `${cityItem.name ?? cityItem.id}. Check the commune name against ZR's ` +
+      `territory list (accent-free spellings).`
+    );
+  }
+
+  // ─── Hub resolution (pickup points) ────────────────────────────────────────
+
+  /** In-instance hub cache, populated lazily by loadHubs(). */
+  private hubCache: ZrHubItem[] | null = null;
+
+  /**
+   * Fetch all hubs once per adapter instance. Pickup points are hubs with
+   * `isPickupPoint: true` — NOT territories. Creating a pickup-point parcel
+   * with a territory UUID as `hubId` fails with `HubErrors.HubNotFound`
+   * (live-verified); only real hub IDs are accepted.
+   */
+  private async loadHubs(): Promise<ZrHubItem[]> {
+    if (this.hubCache) return this.hubCache;
+    const hubs: ZrHubItem[] = [];
+    const pageSize = 200;
+    for (let page = 1; page <= 10; page++) {
+      const res = await this.post<{ pageSize: number; pageNumber: number }, ZrPagedListHubs>(
+        `/api/v${API_VERSION}/hubs/search`,
+        { pageSize, pageNumber: page }
+      );
+      const items = res.items ?? [];
+      hubs.push(...items);
+      const totalPages = res.totalPages ?? 1;
+      if (items.length === 0 || page >= totalPages) break;
     }
-    return match;
+    this.hubCache = hubs;
+    return hubs;
+  }
+
+  /**
+   * Resolve the hub backing a stop-desk station code.
+   *  - New syncs store the **hub id** itself as stationCode.
+   *  - Legacy syncs stored the pickup-point **territory UUID**; match it
+   *    against `hub.address.districtTerritoryId` so old orders keep working.
+   */
+  private async resolveHubForStation(stationCode: string): Promise<ZrHubItem> {
+    const hubs = await this.loadHubs();
+    const byId = hubs.find((h) => h.id === stationCode);
+    if (byId) return byId;
+    const byDistrict = hubs.find((h) => h.address?.districtTerritoryId === stationCode);
+    if (byDistrict) return byDistrict;
+    throw new Error(
+      `ZR Express: stop desk "${stationCode}" no longer matches any hub. ` +
+      `Re-sync the stop desks for this delivery company.`
+    );
   }
 
   // ─── Helpers ───────────────────────────────────────────────────────────────
@@ -276,22 +373,34 @@ export class ZrExpressProvider implements DeliveryProvider {
 
     const zrCustomerId = await this.createZrCustomer(input.customerName, phone1, phone2);
 
-    const wilayaName = input.wilaya ?? input.commune;
-    const cityItem = await this.resolveCityId(input.wilayaId, wilayaName);
-
+    let cityId: string;
     let districtId: string;
-    if (input.stationCode && UUID_RE.test(input.stationCode)) {
-      districtId = input.stationCode;
+    let hubId: string | null = null;
+    if (input.stopDesk) {
+      // Pickup-point parcels are delivered to a HUB. ZR rejects the create
+      // call with `HubErrors.HubNotFound` when `hubId` is a territory UUID —
+      // only real hub IDs (POST /hubs/search, isPickupPoint) are accepted.
+      // The hub carries its own district + city territories, so no separate
+      // territory search is needed.
+      if (!input.stationCode) {
+        throw new Error("ZR Express: stop-desk dispatch requires a station code (hub id).");
+      }
+      const hub = await this.resolveHubForStation(input.stationCode);
+      districtId = hub.address?.districtTerritoryId ?? "";
+      cityId = hub.address?.cityTerritoryId ?? "";
+      hubId = hub.id;
+      if (!districtId || !cityId) {
+        throw new Error(
+          `ZR Express: hub ${hub.id} has no district/city territory — cannot build the delivery address.`
+        );
+      }
     } else {
-      const districtItem = await this.resolveDistrictId(input.commune, cityItem, input.stopDesk);
+      const wilayaName = input.wilaya ?? input.commune;
+      const cityItem = await this.resolveCityId(input.wilayaId, wilayaName);
+      const districtItem = await this.resolveDistrictId(input.commune, cityItem);
+      cityId = cityItem.id;
       districtId = districtItem.id;
     }
-
-    // For pickup-point parcels ZR rejects the create call with
-    // `General.Validation — HubId is required` unless we send the pickup-point
-    // territory UUID as `hubId`. The desk we resolved above (districtId, which
-    // for stop-desk equals the pickup-point territory UUID) IS the hub.
-    const hubId = input.stopDesk ? districtId : null;
 
     return {
       customer: {
@@ -303,7 +412,7 @@ export class ZrExpressProvider implements DeliveryProvider {
         },
       },
       deliveryAddress: {
-        cityTerritoryId: cityItem.id,
+        cityTerritoryId: cityId,
         districtTerritoryId: districtId,
         street: input.address || null,
       },
@@ -395,9 +504,16 @@ export class ZrExpressProvider implements DeliveryProvider {
     const successByBulkIdx = new Map(
       (res.successes ?? []).map((s) => [s.index, s])
     );
-    const failureByBulkIdx = new Map(
-      (res.failures ?? []).map((f) => [f.index, f])
-    );
+    // A parcel can produce MULTIPLE validation failures for the same index
+    // (live-verified: "Name is required" AND "Description is required") —
+    // collect them all instead of letting a Map collapse to the last one.
+    const failuresByBulkIdx = new Map<number, string[]>();
+    for (const f of res.failures ?? []) {
+      const message = f.errorMessage ?? f.errorCode ?? "unknown error";
+      const list = failuresByBulkIdx.get(f.index) ?? [];
+      list.push(message);
+      failuresByBulkIdx.set(f.index, list);
+    }
 
     return inputs.map((input, i) => {
       if (buildErrors.has(i)) {
@@ -412,8 +528,8 @@ export class ZrExpressProvider implements DeliveryProvider {
         return { input, trackingNumber: success.trackingNumber };
       }
 
-      const failure = failureByBulkIdx.get(entry.bulkIdx);
-      return { input, error: failure?.errorMessage ?? "No result from bulk API" };
+      const failures = failuresByBulkIdx.get(entry.bulkIdx);
+      return { input, error: failures?.join("; ") ?? "No result from bulk API" };
     });
   }
 
@@ -424,91 +540,193 @@ export class ZrExpressProvider implements DeliveryProvider {
 
   /**
    * Delete a shipment by tracking number.
-   * ZR uses bulk delete endpoint even for single parcels.
+   * ZR uses the bulk endpoint even for single parcels — the documented method
+   * is DELETE (`DELETE /api/v1/parcels/bulk/by-tracking-number`). A POST to
+   * the same path answers 405 (live-verified), which is what the previous
+   * implementation sent, making deletion permanently fail.
+   *
+   * Throws on carrier-side failure (house convention, cf. EcoTrack) so the
+   * caller can surface it instead of silently resetting the order. A parcel
+   * that is already gone is treated as success (idempotent cancel).
    */
   async deleteShipment(trackingNumber: string): Promise<boolean> {
+    let res: ZrDeleteBulkResponse;
     try {
-      const res = await this.post<
+      res = await this.delete<
         { trackingNumbers: string[] },
         ZrDeleteBulkResponse
       >(`/api/v${API_VERSION}/parcels/bulk/by-tracking-number`, {
         trackingNumbers: [trackingNumber],
       });
-      return res.successCount === 1;
     } catch (err) {
-      // If parcel doesn't exist or can't be deleted, return false instead of throwing
-      console.error(`ZR Express: Failed to delete parcel ${trackingNumber}:`, err);
-      return false;
+      // Parcel already deleted / never existed → cancel goal achieved.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/not found/i.test(msg) || /404/.test(msg)) {
+        console.warn(`ZR Express: parcel ${trackingNumber} already absent at carrier`);
+        return true;
+      }
+      throw err;
     }
+
+    if (res.successCount === 1) return true;
+
+    const failures = res.failures ?? [];
+    const allNotFound = failures.length > 0
+      && failures.every((f) => /not found/i.test(f.errorMessage ?? ""));
+    if (allNotFound) return true;
+
+    const reason = failures.map((f) => f.errorMessage ?? f.errorCode ?? "unknown").join("; ");
+    throw new Error(`ZR Express: failed to delete parcel ${trackingNumber} — ${reason}`);
   }
 
   /**
    * Update shipment information.
-   * ZR has separate PATCH endpoints for amount, customer, and address.
+   * ZR exposes separate PATCH endpoints for amount, customer, and address.
    *
    * ⚠️ The first argument MUST be the ZR **parcel UUID**, not the tracking number.
    * The handler resolves it from companyShipments.rawResponse.parcelId.
    *
-   * Field coverage from UpdateShipmentInput:
-   *   amount       → POST /parcels/:id/amount
-   *   customerName → POST /parcels/:id/customer
-   *   phone        → POST /parcels/:id/customer
-   *   address      → POST /parcels/:id/deliveryAddress (street only)
-   *
-   * Not yet wired (would require a separate territory-resolution call):
-   *   commune, wilayaId — would need cityTerritoryId / districtTerritoryId.
-   *   phone2, weight, fragile, remarks — no carrier endpoint exposes these for updates.
+   * Verified constraints (live 2026-09-10):
+   *  - `PATCH /parcels/{id}/deliveryAddress` REQUIRES the full
+   *    `DeliveryAddressInputDto` (cityTerritoryId + districtTerritoryId) — a
+   *    street-only body answers 400. Pickup-point parcels additionally require
+   *    `hubId` (`ParcelUpdateAddressHubIdRequired`), so the hub is resolved
+   *    from the parcel's district territory.
+   *  - Failures THROW (surface as ExternalApiError) instead of being swallowed
+   *    into a silent `false` that the caller ignored.
    */
   async updateShipment(parcelId: string, input: UpdateShipmentInput): Promise<boolean> {
-    try {
-      if (input.amount !== undefined) {
-        const amountReq: ZrUpdateAmountRequest = { parcelId, amount: input.amount };
-        await this.patch(`/api/v${API_VERSION}/parcels/${parcelId}/amount`, amountReq);
-      }
+    const parcel = await this.get<ZrGetParcelResponse>(
+      `/api/v${API_VERSION}/parcels/${parcelId}`
+    );
 
-      if (input.customerName || input.phone) {
-        const customerUpdate: ZrUpdateCustomerRequest = { parcelId };
-        if (input.customerName) customerUpdate.name = input.customerName;
-        if (input.phone) customerUpdate.phone = this.normalizePhone(input.phone);
-        await this.patch(`/api/v${API_VERSION}/parcels/${parcelId}/customer`, customerUpdate);
-      }
+    // ── amount ────────────────────────────────────────────────────────────
+    if (input.amount !== undefined && input.amount !== parcel.amount) {
+      const amountReq: ZrUpdateAmountRequest = { parcelId, amount: input.amount };
+      await this.patch(`/api/v${API_VERSION}/parcels/${parcelId}/amount`, amountReq);
+    }
 
-      if (input.address) {
+    // ── customer (name / phone) ───────────────────────────────────────────
+    const currentName = parcel.customer?.name ?? null;
+    const currentPhone = parcel.customer?.phone?.number1 ?? null;
+    const nextName = input.customerName ?? null;
+    const nextPhone = input.phone ? this.normalizePhone(input.phone) : null;
+    if (
+      (nextName !== null && nextName !== currentName)
+      || (nextPhone !== null && nextPhone !== currentPhone)
+    ) {
+      const customerUpdate: ZrUpdateCustomerRequest = { parcelId };
+      if (nextName !== null) customerUpdate.name = nextName;
+      if (nextPhone !== null) customerUpdate.phone = nextPhone;
+      await this.patch(`/api/v${API_VERSION}/parcels/${parcelId}/customer`, customerUpdate);
+    }
+
+    // ── delivery address ──────────────────────────────────────────────────
+    if (input.address !== undefined) {
+      const current = parcel.deliveryAddress ?? {};
+      const streetChanged = input.address !== (current.street ?? null)
+        && input.address !== (current.street ?? "");
+
+      // Territory change: the caller sends wilayaId + commune together
+      // (shipment-operations pre-fills both from the order).
+      const wilayaChanged =
+        input.wilayaId !== undefined
+        && current.cityTerritoryCode !== undefined
+        && input.wilayaId !== current.cityTerritoryCode;
+      const communeChanged =
+        input.commune !== undefined
+        && input.commune !== (current.district ?? null);
+
+      if (streetChanged || wilayaChanged || communeChanged) {
+        let cityTerritoryId = current.cityTerritoryId ?? null;
+        let districtTerritoryId = current.districtTerritoryId ?? null;
+
+        if (wilayaChanged || communeChanged) {
+          if (!input.wilayaId || !input.commune) {
+            throw new Error(
+              "ZR Express: changing the delivery address requires both wilayaId and commune."
+            );
+          }
+          const cityItem = await this.resolveCityId(
+            input.wilayaId,
+            // UpdateShipmentInput carries no wilaya name; the stripped
+            // code-based fallback in resolveCityId resolves it.
+            String(input.wilayaId)
+          );
+          const districtItem = await this.resolveDistrictId(input.commune, cityItem);
+          cityTerritoryId = cityItem.id;
+          districtTerritoryId = districtItem.id;
+        }
+
         const addressUpdate: ZrUpdateDeliveryAddressRequest = {
           parcelId,
-          deliveryAddress: { street: input.address },
+          deliveryAddress: {
+            street: input.address,
+            cityTerritoryId: cityTerritoryId ?? undefined,
+            districtTerritoryId: districtTerritoryId ?? undefined,
+          },
         };
+
+        // Pickup-point parcels additionally require the hub on every address
+        // update — resolve it from the (possibly new) district territory.
+        if (parcel.deliveryType === "pickup-point") {
+          if (!districtTerritoryId) {
+            throw new Error(
+              "ZR Express: cannot update a pickup-point address without a district territory."
+            );
+          }
+          const hubs = await this.loadHubs();
+          const hub = hubs.find((h) => h.address?.districtTerritoryId === districtTerritoryId);
+          if (!hub) {
+            throw new Error(
+              `ZR Express: no hub serves district territory ${districtTerritoryId} — ` +
+              `cannot update this pickup-point address.`
+            );
+          }
+          addressUpdate.hubId = hub.id;
+        }
+
         await this.patch(`/api/v${API_VERSION}/parcels/${parcelId}/deliveryAddress`, addressUpdate);
       }
-
-      return true;
-    } catch (err) {
-      console.error(`ZR Express: Failed to update parcel ${parcelId}:`, err);
-      return false;
     }
+
+    return true;
   }
 
   /**
    * Get tracking information (state history) for a parcel.
-   * Returns the parcel's state transition history as TrackingEvent array.
-   * 
-   * @param trackingNumber - Can be either tracking number or parcel ID (both work with ZR API)
+   *
+   * `GET /parcels/{id}/state-history` only accepts the parcel **UUID** — the
+   * same path with a tracking number answers 404 (live-verified; the swagger
+   * path parameter is `{parcelId}`). Resolve the UUID first via
+   * `GET /parcels/{trackingNumber}`, then read the history.
    */
   async getTrackingInfo(trackingNumber: string): Promise<TrackingEvent[]> {
+    let parcel: ZrGetParcelResponse;
     try {
-      const history = await this.get<ZrStateHistoryResponse>(
-        `/api/v${API_VERSION}/parcels/${trackingNumber}/state-history`
+      parcel = await this.get<ZrGetParcelResponse>(
+        `/api/v${API_VERSION}/parcels/${trackingNumber}`
       );
-
-      return history.map((h) => ({
-        activity: h.newState.name,
-        description: h.newState.description,
-        date: h.createdAt,
-      }));
     } catch (err) {
-      console.error(`ZR Express: Failed to get tracking info for ${trackingNumber}:`, err);
-      return [];
+      const msg = err instanceof Error ? err.message : String(err);
+      // Unknown tracking number (deleted/never dispatched at ZR) → no events.
+      if (/not found/i.test(msg) || /404/.test(msg)) {
+        console.warn(`ZR Express: parcel ${trackingNumber} not found — no tracking events`);
+        return [];
+      }
+      throw err;
     }
+    if (!parcel.id) return [];
+
+    const history = await this.get<ZrStateHistoryResponse>(
+      `/api/v${API_VERSION}/parcels/${parcel.id}/state-history`
+    );
+
+    return (history ?? []).map((h) => ({
+      activity: h.newState.name,
+      description: h.newState.description,
+      date: h.createdAt,
+    }));
   }
 
   /**
@@ -529,26 +747,53 @@ export class ZrExpressProvider implements DeliveryProvider {
     return false;
   }
 
+  /**
+   * Map of wilaya territory UUID → wilaya number (1–58), built by paging the
+   * territory list once per adapter instance and keeping wilaya-level rows.
+   */
+  private wilayaCodeByTerritory: Map<string, number> | null = null;
+
+  private async loadWilayaCodeMap(): Promise<Map<string, number>> {
+    if (this.wilayaCodeByTerritory) return this.wilayaCodeByTerritory;
+    const map = new Map<string, number>();
+    const pageSize = 1000;
+    for (let page = 1; page <= 5; page++) {
+      const res = await this.post<ZrSearchTerritoriesRequest, ZrPagedListTerritories>(
+        `/api/v${API_VERSION}/territories/search`,
+        { keyword: "", pageSize, pageNumber: page }
+      );
+      const items = res.items ?? [];
+      for (const t of items) {
+        if (t.level === "wilaya" && typeof t.code === "number") {
+          map.set(t.id, t.code);
+        }
+      }
+      const totalPages = res.totalPages ?? 1;
+      if (items.length === 0 || page >= totalPages) break;
+    }
+    this.wilayaCodeByTerritory = map;
+    return map;
+  }
+
+  /**
+   * Stop desks for ZR Express are **hubs** with `isPickupPoint: true`
+   * (`POST /hubs/search`) — not pickup-point territories. The hub id is what
+   * parcel creation expects as `stationCode` → `hubId`; passing a territory
+   * UUID fails with `HubErrors.HubNotFound` (live-verified 2026-09-10).
+   * Each hub's wilaya is resolved from `address.cityTerritoryId`.
+   */
   async getStopDesks(): Promise<StopDesk[]> {
     try {
-      const items = await this.searchTerritories("", {
-        deliveryType: { value: "pickup-point" },
-        pageSize: 200,
-      });
-      return items
-        .filter((t) => t.delivery?.hasPickupPoint)
-        .map((t) => {
-          // ZR territory `code` is supposed to be the wilaya number for pickup-point
-          // territories at the wilaya level, but for sub-district pickup points it
-          // can be undefined or a non-1–58 value. Clamp out-of-range to null so the
-          // FK to wilayas doesn't break the whole sync batch.
-          const wid = typeof t.code === "number" && t.code >= 1 && t.code <= 58 ? t.code : null;
-          return {
-            code: t.id,            // ZR stop-desk stationCode = territory UUID
-            name: t.name ?? t.id,
-            wilayaId: wid,
-          };
-        });
+      const [hubs, wilayaCodes] = await Promise.all([this.loadHubs(), this.loadWilayaCodeMap()]);
+      return hubs
+        .filter((h) => h.isPickupPoint)
+        .map((h) => ({
+          code: h.id,          // ZR stop-desk stationCode = hub UUID
+          name: h.name ?? h.id,
+          wilayaId: (h.address?.cityTerritoryId
+            ? wilayaCodes.get(h.address.cityTerritoryId) ?? null
+            : null),
+        }));
     } catch {
       return [];
     }

--- a/cod-server/src/endpoints/delivery-companies/providers/zr_express/capabilities.ts
+++ b/cod-server/src/endpoints/delivery-companies/providers/zr_express/capabilities.ts
@@ -19,7 +19,6 @@ export const ZR_EXPRESS_CAPABILITIES: ProviderCapabilities = {
   canStopDesk: true,
   
   // ─── Lifecycle ────────────────────────────────────────────────────────
-  // Source: Test script has no validate test
   // Source: Note "ZR Express auto-validates on creation"
   autoValidates: true,
   
@@ -28,14 +27,15 @@ export const ZR_EXPRESS_CAPABILITIES: ProviderCapabilities = {
   // Source: Test "Update Parcel Address"
   canUpdateBeforeValidation: true,
   
-  // Source: No rejection in tests, flexible update system
+  // Live-verified 2026-09-10: amount/customer/address PATCHes succeed on a
+  // fresh parcel (state commande_recue — the state ZR assigns on creation).
   canUpdateAfterValidation: true,
   
-  // Source: Test "Delete Parcel"
-  // ⚠️ Test returned HTTP 405 - endpoint not working
-  canDeleteBeforeValidation: false,
+  // Source: DELETE /parcels/bulk/by-tracking-number → 200 (deleted).
+  // Live-verified 2026-09-10 — the previous 405 came from wrongly using POST.
+  canDeleteBeforeValidation: true,
   
-  // Source: Delete doesn't work at all
+  // Delete is only proven while the parcel has not been picked up; unverified after.
   canDeleteAfterValidation: false,
   
   // ─── Package Options ──────────────────────────────────────────────────

--- a/cod-server/src/endpoints/delivery-companies/providers/zr_express/text.ts
+++ b/cod-server/src/endpoints/delivery-companies/providers/zr_express/text.ts
@@ -1,0 +1,15 @@
+/**
+ * ZR Express text normalization helpers.
+ *
+ * ZR's territory DB and workflow states store accent-free text ("Bechar",
+ * "Setif", "MSila", "livre") while our reference data and ZR's display text
+ * use accented French ("Béchar", "Sétif", "Livré"). ZR's keyword search is
+ * accent-sensitive, so every comparison/search must run on the stripped form
+ * (live-verified 2026-09-10: "Béchar" → 0 results, "Bechar" → wilaya 8).
+ */
+export function stripAccents(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[''`]/g, "");
+}

--- a/cod-server/src/endpoints/delivery-companies/providers/zr_express/types.ts
+++ b/cod-server/src/endpoints/delivery-companies/providers/zr_express/types.ts
@@ -112,6 +112,21 @@ export interface ZrCreateParcelResponse {
 export interface ZrGetParcelResponse {
   id: string;
   trackingNumber: string | null;
+  customer?: {
+    customerId?: string;
+    name?: string | null;
+    phone?: { number1?: string | null; number2?: string | null } | null;
+  } | null;
+  deliveryAddress?: {
+    street?: string | null;
+    city?: string | null;
+    cityTerritoryId?: string | null;
+    district?: string | null;
+    districtTerritoryId?: string | null;
+    /** Integer wilaya code (e.g. 16 for Alger) echoed by the API. */
+    cityTerritoryCode?: number | null;
+    postalCode?: string | null;
+  } | null;
   state?: {
     id?: string;
     name: string | null;
@@ -126,6 +141,40 @@ export interface ZrGetParcelResponse {
   deliveryType?: string | null;
   description?: string | null;
   productsDescription?: string | null;
+  isReturn?: boolean;
+}
+
+// ─── Hubs ─────────────────────────────────────────────────────────────────────
+
+/** GET/POST /api/v1/hubs/search — pickup points are hubs with isPickupPoint=true. */
+export interface ZrHubAddressDto {
+  street?: string | null;
+  city?: string | null;
+  cityTerritoryId?: string | null;
+  district?: string | null;
+  districtTerritoryId?: string | null;
+  postalCode?: string | null;
+  country?: string | null;
+}
+
+export interface ZrHubItem {
+  id: string;
+  name: string | null;
+  /** "hub" | "sorting-center-hub" | "sorting-center" | … */
+  type?: string | null;
+  isPickupPoint?: boolean;
+  isVisible?: boolean;
+  isReturnCenter?: boolean;
+  address?: ZrHubAddressDto | null;
+  openingHours?: string | null;
+}
+
+export interface ZrPagedListHubs {
+  items: ZrHubItem[] | null;
+  pageNumber?: number;
+  pageSize?: number;
+  totalCount?: number;
+  totalPages?: number;
 }
 
 // ─── Create Bulk Parcels ──────────────────────────────────────────────────────

--- a/cod-server/src/endpoints/delivery-companies/webhook-handlers.ts
+++ b/cod-server/src/endpoints/delivery-companies/webhook-handlers.ts
@@ -14,14 +14,12 @@ import { eq } from "drizzle-orm";
 import { deliveryCompanies } from "@/db/schema";
 import { getDeliveryCompanyRaw } from "./queries";
 import { NotFoundError, ValidationError, ExternalApiError } from "@/lib/errors/classes";
+import { ORDER_STATUSES } from "@/endpoints/orders/validation";
 
 const ZR_BASE_URL = "https://api.zrexpress.app";
 
 /** Our valid order status strings — used to validate custom mapping keys. */
-const VALID_OUR_STATUSES = new Set([
-  "new", "preparing", "assigned", "out_for_delivery",
-  "delivered", "returned", "cancelled",
-]);
+const VALID_OUR_STATUSES = new Set<string>(ORDER_STATUSES);
 
 // ─── ZR Express — Register ────────────────────────────────────────────────────
 
@@ -82,16 +80,22 @@ export async function registerZrWebhook(c: Context<AppContext>) {
   }
 
   // Register new endpoint with ZR.
-  // Only "parcel.state.updated" is a documented valid eventType filter.
-  // parcel.state.situation.created and parcel.isReturn.updated are received
-  // automatically (all-events default) — do NOT include them in eventTypes.
+  // Subscribe to ALL event types the receiver understands. The handler
+  // processes parcel.state.updated (status mapping), parcel.isReturn.updated
+  // (hardcoded → returned) and logs parcel.state.situation.created. Other ZR
+  // consumers in this tenant register all three; with only state.updated
+  // subscribed, return signals would never arrive.
   const registerRes = await fetch(`${ZR_BASE_URL}/api/v1/webhooks/endpoints`, {
     method: "POST",
     headers: zrHeaders,
     body: JSON.stringify({
       url: webhookUrl,
       description: "CodFlow — parcel status updates",
-      eventTypes: ["parcel.state.updated"],
+      eventTypes: [
+        "parcel.state.updated",
+        "parcel.isReturn.updated",
+        "parcel.state.situation.created",
+      ],
     }),
   });
 

--- a/cod-server/src/endpoints/orders/orders.test.ts
+++ b/cod-server/src/endpoints/orders/orders.test.ts
@@ -945,7 +945,7 @@ describe("Orders — targeted business-logic tests", () => {
       );
 
       const mockProvider = {
-        deleteShipment: vi.fn(async () => undefined),
+        deleteShipment: vi.fn(async () => true),
       };
       vi.mocked(registry.getProvider).mockReturnValue(mockProvider as any);
       vi.mocked(registry.isEcotrackCompany).mockReturnValue(false);
@@ -987,7 +987,7 @@ describe("Orders — targeted business-logic tests", () => {
       vi.mocked(deliveryCompanyQueries.getDeliveryCompanyRaw).mockResolvedValue(
         companyRow() as any
       );
-      const mockProvider = { deleteShipment: vi.fn(async () => undefined) };
+      const mockProvider = { deleteShipment: vi.fn(async () => true) };
       vi.mocked(registry.getProvider).mockReturnValue(mockProvider as any);
       vi.mocked(registry.isEcotrackCompany).mockReturnValue(false);
       vi.mocked(shipments.getShipmentByOrder).mockResolvedValue(null as any);

--- a/cod-server/src/endpoints/orders/shipment-operations.ts
+++ b/cod-server/src/endpoints/orders/shipment-operations.ts
@@ -219,7 +219,17 @@ export async function cancelShipment(c: Context<AppContext>) {
 
   const startMs = Date.now();
   try {
-    await provider.deleteShipment(order.trackingNumber);
+    const deleted = await provider.deleteShipment(order.trackingNumber);
+    if (!deleted) {
+      // Carrier refused (e.g. already validated/picked up) — surface it and
+      // keep the shipment: resetting the order here would desync us from the
+      // carrier (the parcel would keep moving with no local tracking).
+      throw new BusinessLogicError(
+        `The carrier refused to cancel shipment ${order.trackingNumber} — it may already be validated or picked up`,
+        ERROR_CODES.OPERATION_NOT_SUPPORTED,
+        { orderId, provider: company.code, trackingNumber: order.trackingNumber }
+      );
+    }
     const durationMs = Date.now() - startMs;
 
     await logApiCall(db, {

--- a/cod-server/src/endpoints/webhooks/handlers.ts
+++ b/cod-server/src/endpoints/webhooks/handlers.ts
@@ -158,8 +158,13 @@ export async function handleZrWebhook(c: Context<AppContext>) {
     } else if (eventType === "parcel.state.updated") {
       const state = data.state as Record<string, unknown> | undefined;
       const stateName = (state?.name as string | undefined) ?? null;
+      const stateDescription = (state?.description as string | undefined) ?? null;
       const customMap = parseCustomMapping(company.webhookStatusMapping ?? null);
-      const mappedZr = mapZrStateName(stateName, customMap);
+      // Match the slug name first, then the French display description —
+      // tenants that rename slugs usually keep the description text.
+      const mappedZr =
+        mapZrStateName(stateName, customMap)
+        ?? mapZrStateName(stateDescription, customMap);
       if (mappedZr === null || !isOrderStatus(mappedZr)) {
         newStatus = null;
         await updateWebhookEvent(db, webhookEventId, {

--- a/cod-server/src/endpoints/webhooks/zr-status-mapper.test.ts
+++ b/cod-server/src/endpoints/webhooks/zr-status-mapper.test.ts
@@ -1,0 +1,149 @@
+/**
+ * ZR Express status mapper tests.
+ *
+ * Every default-workflow slug below comes from `POST /workflows/search`
+ * (23 states, captured live 2026-09-10 — see
+ * .agents/skills/zr-express/CONFORMANCE.md BUG-5). Real parcels carry the
+ * slug in `state.name` and the French display text in `state.description`.
+ *
+ * The drift guard pins the default map's size so a renamed/removed slug
+ * fails CI instead of silently recording live webhook events as `unmapped`.
+ */
+import { describe, it, expect } from "vitest";
+import { mapZrStateName, parseCustomMapping } from "./zr-status-mapper";
+
+describe("mapZrStateName — terminal mappings", () => {
+  it("maps the delivered family", () => {
+    for (const slug of ["livre", "livre au client", "encaisse", "recouvert"]) {
+      expect(mapZrStateName(slug, null)).toBe("delivered");
+    }
+  });
+
+  it("maps the returned family", () => {
+    for (const slug of [
+      "retour_sous_traitant",
+      "colis_recupere",
+      "attente_recuperation_fournisseur",
+      "reinjecte_dans_stock",
+      "recupere_par_fournisseur",
+      "remboursement_reinjecte",
+    ]) {
+      expect(mapZrStateName(slug, null)).toBe("returned");
+    }
+  });
+
+  it("maps the out-for-delivery family", () => {
+    expect(mapZrStateName("en_livraison", null)).toBe("out_for_delivery");
+    expect(mapZrStateName("sortie_en_livraison", null)).toBe("out_for_delivery");
+  });
+});
+
+describe("mapZrStateName — pre-delivery progression", () => {
+  it("maps the live-observed creation state", () => {
+    // Real parcel payload observed live: state.name = "commande_recue".
+    expect(mapZrStateName("commande_recue", null)).toBe("preparing");
+  });
+
+  it("maps the remaining default-workflow slugs", () => {
+    expect(mapZrStateName("en_traitement", null)).toBe("preparing");
+    expect(mapZrStateName("appel_confirmation", null)).toBe("preparing");
+    expect(mapZrStateName("commande_confirmee", null)).toBe("confirmed");
+    expect(mapZrStateName("en_preparation", null)).toBe("preparing");
+    expect(mapZrStateName("pret_a_expedier", null)).toBe("ready");
+    expect(mapZrStateName("confirme_au_bureau", null)).toBe("assigned");
+    expect(mapZrStateName("confirme_chez_partenaire", null)).toBe("assigned");
+    expect(mapZrStateName("dispatch", null)).toBe("assigned");
+    expect(mapZrStateName("vers_wilaya", null)).toBe("assigned");
+  });
+
+  it("keeps the legacy English aliases working", () => {
+    expect(mapZrStateName("out for delivery", null)).toBe("out_for_delivery");
+    expect(mapZrStateName("in transit", null)).toBe("assigned");
+    expect(mapZrStateName("at hub", null)).toBe("assigned");
+  });
+});
+
+describe("mapZrStateName — normalization", () => {
+  it("matches case-insensitively (slugs arrive in mixed case from tenants)", () => {
+    expect(mapZrStateName("LIVRE", null)).toBe("delivered");
+    expect(mapZrStateName("En_Livraison", null)).toBe("out_for_delivery");
+  });
+
+  it("matches accent-insensitively (display text like 'Commande reçue')", () => {
+    expect(mapZrStateName("commande_reçue", null)).toBe("preparing");
+    expect(mapZrStateName("Commande reçue", null)).toBeNull(); // display text is NOT a slug — handler matches description separately
+  });
+
+  it("trims whitespace before matching", () => {
+    expect(mapZrStateName("  livre  ", null)).toBe("delivered");
+  });
+});
+
+describe("mapZrStateName — custom mapping", () => {
+  it("custom mapping wins over defaults", () => {
+    const custom = { cancelled: ["livre"] };
+    expect(mapZrStateName("livre", custom)).toBe("cancelled");
+  });
+
+  it("custom entries match case- and accent-insensitively", () => {
+    const custom = { delivered: ["Livré chez le client"] };
+    expect(mapZrStateName("livre chez le client", custom)).toBe("delivered");
+    expect(mapZrStateName("LIVRÉ CHEZ LE CLIENT", custom)).toBe("delivered");
+  });
+
+  it("ignores malformed custom values and still falls back to defaults", () => {
+    const custom = { delivered: "livre", cancelled: [42, null] } as unknown as Record<string, string[]>;
+    expect(mapZrStateName("livre", custom)).toBe("delivered");
+  });
+});
+
+describe("mapZrStateName — unknown + degenerate inputs", () => {
+  it("unknown state → null (caller must log 'unmapped' and not change the order)", () => {
+    expect(mapZrStateName("etat_inconnu_personnalise", null)).toBeNull();
+  });
+
+  it("null / undefined / empty → null", () => {
+    for (const input of [null, undefined, "", "   "]) {
+      expect(mapZrStateName(input, null)).toBeNull();
+    }
+  });
+});
+
+describe("parseCustomMapping", () => {
+  it("parses a valid mapping", () => {
+    expect(parseCustomMapping('{"delivered":["Livre"]}')).toEqual({
+      delivered: ["Livre"],
+    });
+  });
+
+  it("returns null for missing / invalid / non-object JSON", () => {
+    for (const input of [null, undefined, "", "not json", "[1,2]", "42"]) {
+      expect(parseCustomMapping(input)).toBeNull();
+    }
+  });
+});
+
+describe("drift guard", () => {
+  it("default map covers every state of the live default workflow that is mappable", () => {
+    // 23 states in the live default workflow; 3 are situation-only states the
+    // handler ignores (parcel.state.situation.created) and the remaining 20
+    // delivery states are all mapped above — 24 keys here include 3 legacy
+    // English aliases. If this fails, someone renamed or removed a slug and
+    // live webhook events would silently log as 'unmapped'.
+    const slugs = [
+      "livre", "livre au client", "encaisse", "recouvert",
+      "retour_sous_traitant", "colis_recupere",
+      "attente_recuperation_fournisseur", "reinjecte_dans_stock",
+      "recupere_par_fournisseur", "remboursement_reinjecte",
+      "en_livraison", "sortie_en_livraison",
+      "commande_recue", "en_traitement", "appel_confirmation",
+      "commande_confirmee", "en_preparation", "pret_a_expedier",
+      "confirme_au_bureau", "confirme_chez_partenaire",
+      "dispatch", "vers_wilaya",
+      "out for delivery", "in transit", "at hub",
+    ];
+    for (const slug of slugs) {
+      expect(mapZrStateName(slug, null)).not.toBeNull();
+    }
+  });
+});

--- a/cod-server/src/endpoints/webhooks/zr-status-mapper.ts
+++ b/cod-server/src/endpoints/webhooks/zr-status-mapper.ts
@@ -2,27 +2,66 @@
  * ZR Express Status Mapper
  *
  * ZR state names are company-configurable free text — NOT a fixed enum.
- * Confirmed/mentioned state names in ZR Express docs:
- *   - "Out for Delivery"  — confirmed in example payload (data.state.name)
- *   - "In Transit"        — mentioned in docs description as example
- *   - "At Hub"            — mentioned in docs description as example
+ * The DEFAULT tenant workflow ("New Delivery Workflow") uses French slugs as
+ * `state.name` with French display text as `state.description`. Both were
+ * captured live on 2026-09-10 via `POST /workflows/search` (23 states) and a
+ * real parcel payload (`state.name = "commande_recue"`).
  *
- * All other state names (Delivered, Returned, Cancelled, etc.) are NOT documented.
- * Admins must add them via the custom mapping UI after observing real state names
- * in their ZR account.
+ * Matching is accent- and case-insensitive, and the webhook handler falls back
+ * to matching `state.description` when `state.name` misses, so renamed tenants
+ * with French display text still map.
  *
- * Custom mapping format stored in delivery_companies.webhook_status_mapping:
- *   { "delivered": ["Delivered", "Livraison effectuée"], "returned": ["Returned"] }
- * Keys = our order status strings. Values = exact ZR state names (case-insensitive match).
+ * Only delivery-relevant states are defaulted. Intermediate call-center states
+ * (en_traitement, appel_confirmation, …) map to their nearest our-status; the
+ * webhook rank guard in cod-shared (updateOrderStatusWebhook) makes any
+ * non-advancing mapping a no-op, so these can never regress an order.
+ * Admins extend/override via the custom mapping UI
+ * (delivery_companies.webhook_status_mapping):
+ *   { "delivered": ["Livraison effectuée"], "returned": ["Returned"] }
+ * Keys = our order status strings. Values = exact ZR state names.
  */
 
-// Only state names confirmed or mentioned in ZR Express documentation.
-// Keys are lowercased for case-insensitive lookup.
-const ZR_DEFAULT_STATE_MAP: Record<string, string> = {
-  "out for delivery": "out_for_delivery", // confirmed in example payload
-  "in transit":       "assigned",         // mentioned in docs description
-  "at hub":           "assigned",         // mentioned in docs description
+import { stripAccents } from "../delivery-companies/providers/zr_express/text";
+
+// Default workflow vocabulary (POST /workflows/search, verified live) plus the
+// legacy English aliases kept for tenants that customize names.
+const ZR_DEFAULT_STATE_MAP_RAW: Record<string, string> = {
+  // ── delivered family ──
+  "livre":                                "delivered",
+  "livre au client":                      "delivered",
+  "encaisse":                             "delivered",
+  "recouvert":                            "delivered",
+  // ── returned family ──
+  "retour_sous_traitant":                 "returned",
+  "colis_recupere":                       "returned",
+  "attente_recuperation_fournisseur":     "returned",
+  "reinjecte_dans_stock":                 "returned",
+  "recupere_par_fournisseur":             "returned",
+  "remboursement_reinjecte":              "returned",
+  // ── out for delivery family ──
+  "en_livraison":                         "out_for_delivery",
+  "sortie_en_livraison":                  "out_for_delivery",
+  // ── pre-delivery carrier progression (rank-guard no-ops once dispatched) ──
+  "commande_recue":                       "preparing",
+  "en_traitement":                        "preparing",
+  "appel_confirmation":                   "preparing",
+  "commande_confirmee":                   "confirmed",
+  "en_preparation":                       "preparing",
+  "pret_a_expedier":                      "ready",
+  "confirme_au_bureau":                   "assigned",
+  "confirme_chez_partenaire":             "assigned",
+  "dispatch":                             "assigned",
+  "vers_wilaya":                          "assigned",
+  // ── legacy English aliases (kept for customized tenants) ──
+  "out for delivery":                     "out_for_delivery",
+  "in transit":                           "assigned",
+  "at hub":                               "assigned",
 };
+
+// Normalized lookup keys (accent-stripped, lowercased) → our status.
+const ZR_DEFAULT_STATE_MAP: Record<string, string> = Object.fromEntries(
+  Object.entries(ZR_DEFAULT_STATE_MAP_RAW).map(([k, v]) => [stripAccents(k).toLowerCase(), v])
+);
 
 /**
  * Parse the custom mapping JSON stored in DB.
@@ -49,8 +88,9 @@ export function parseCustomMapping(
  *
  * Lookup order:
  *   1. Custom mapping from DB (admin-configured)
- *   2. Code defaults (3 doc-confirmed entries)
+ *   2. Code defaults (default-workflow vocabulary, verified live)
  *
+ * Matching is case- and accent-insensitive on both sides.
  * Returns null if the state name is not found in either mapping.
  * Caller must log result='unmapped' and NOT change the order status.
  */
@@ -59,14 +99,17 @@ export function mapZrStateName(
   custom: Record<string, string[]> | null
 ): string | null {
   if (!stateName) return null;
-  const normalized = stateName.toLowerCase().trim();
+  const normalized = stripAccents(stateName).toLowerCase().trim();
 
-  // Check custom mapping first (case-insensitive)
+  // Check custom mapping first (accent/case-insensitive)
   if (custom) {
     for (const [ourStatus, zrNames] of Object.entries(custom)) {
       if (Array.isArray(zrNames)) {
         for (const zrName of zrNames) {
-          if (typeof zrName === "string" && zrName.toLowerCase().trim() === normalized) {
+          if (
+            typeof zrName === "string"
+            && stripAccents(zrName).toLowerCase().trim() === normalized
+          ) {
             return ourStatus;
           }
         }

--- a/cod-server/src/middleware/cors.test.ts
+++ b/cod-server/src/middleware/cors.test.ts
@@ -165,4 +165,50 @@ describe("CORS Middleware", () => {
       expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://app.example.com");
     });
   });
+
+  describe("Raw Response handlers (streamed bodies)", () => {
+    beforeEach(() => {
+      app = new Hono<AppContext>();
+      app.use("*", async (c, next) => {
+        c.env = {
+          ENVIRONMENT: "production",
+          ALLOWED_ORIGINS: "https://app.example.com",
+        } as any;
+        await next();
+      });
+      app.use("*", corsMiddleware);
+    });
+
+    // Regression: handlers returning a raw `new Response(...)` (label PDF
+    // proxy, R2 image streaming) bypass Hono's prepared-header application,
+    // so headers set before next() never reached them and the browser
+    // blocked the response with a CORS error despite the 200.
+    it("adds CORS headers to a raw Response", async () => {
+      app.get("/raw", () => new Response("raw-body", {
+        status: 200,
+        headers: { "Content-Type": "application/pdf" },
+      }));
+
+      const res = await app.request("/raw", {
+        method: "GET",
+        headers: { origin: "https://app.example.com" },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://app.example.com");
+      expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    });
+
+    it("does not duplicate CORS headers on context-built responses", async () => {
+      app.get("/json", (c) => c.json({ ok: true }));
+
+      const res = await app.request("/json", {
+        method: "GET",
+        headers: { origin: "https://app.example.com" },
+      });
+
+      expect(res.status).toBe(200);
+      expect([...res.headers.keys()].filter((k) => k === "access-control-allow-origin")).toHaveLength(1);
+    });
+  });
 });

--- a/cod-server/src/middleware/cors.ts
+++ b/cod-server/src/middleware/cors.ts
@@ -31,17 +31,20 @@ export async function corsMiddleware(c: Context<AppContext>, next: Next) {
     allowedOrigin = requestOrigin;
   }
 
-  // Set CORS headers
-  c.header("Access-Control-Allow-Origin", allowedOrigin);
-  c.header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
-  c.header("Access-Control-Allow-Headers", "Content-Type, X-API-Key, X-Store-API-Key, Accept, Authorization");
-  c.header("Access-Control-Expose-Headers", "Content-Type, X-API-Key, X-Store-API-Key");
-  c.header("Access-Control-Max-Age", "86400");
-  
-  // Only set credentials header if origin is specific (not *)
-  if (allowedOrigin !== "*") {
-    c.header("Access-Control-Allow-Credentials", "true");
-  }
+  const applyCorsHeaders = () => {
+    c.header("Access-Control-Allow-Origin", allowedOrigin);
+    c.header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
+    c.header("Access-Control-Allow-Headers", "Content-Type, X-API-Key, X-Store-API-Key, Accept, Authorization");
+    c.header("Access-Control-Expose-Headers", "Content-Type, X-API-Key, X-Store-API-Key");
+    c.header("Access-Control-Max-Age", "86400");
+
+    // Only set credentials header if origin is specific (not *)
+    if (allowedOrigin !== "*") {
+      c.header("Access-Control-Allow-Credentials", "true");
+    }
+  };
+
+  applyCorsHeaders();
 
   // Handle preflight requests
   if (c.req.method === "OPTIONS") {
@@ -54,5 +57,10 @@ export async function corsMiddleware(c: Context<AppContext>, next: Next) {
   }
 
   await next();
+
+  // Handlers that return a raw `new Response(...)` (streamed PDFs, R2 objects)
+  // bypass Hono's prepared-header application, so the headers set before
+  // `next()` never reach them — re-apply on the final response.
+  applyCorsHeaders();
 }
 


### PR DESCRIPTION
## Problem

A live audit of the ZR Express integration (every adapter call exercised against the production API, see `.agents/skills/zr-express/CONFORMANCE.md`) found that only the happy-path single home-delivery flow worked. Several flows were silently broken:

- **Tracking always empty** — `GET /parcels/{trackingNumber}/state-history` 404s; the endpoint only accepts the parcel UUID, and the error was swallowed, so every ZR order showed no tracking events.
- **Cancel never worked** — deletion used POST on a DELETE-only endpoint (405), and a failed cancel silently reset the order to `ready` while the parcel kept moving at the carrier.
- **Address updates always failed** — a street-only body answers 400 (`CityTerritoryId is required`), and the failure was swallowed into a false success.
- **Stop-desk dispatch impossible** — a pickup-point territory UUID was sent as `hubId`; ZR requires a real hub id (404 `HubNotFound`).
- **Geo resolution fragile** — ZR stores accent-free territory names, so accented wilaya/commune searches missed; a fallback could silently pick an unrelated commune; 4 wilayas are not served by ZR at all and failed with no clear error.
- **Webhook status mapping mismatched** — defaults assumed English state names; the real default workflow uses French slugs (`commande_recue`, `en_livraison`, `livre`, …), so terminal events recorded as `unmapped`. Registration also subscribed to only one of the three event types the receiver understands.
- **Print label blocked by CORS** — the label proxy streams the PDF via a raw `Response`, which bypassed Hono's prepared-header application, so the 200 response reached the browser without `Access-Control-Allow-Origin` and was blocked.

## Solution

**ZR adapter (`cod-server`, `cod-shared` untouched):**
- Tracking: resolve the parcel UUID via `GET /parcels/{trackingNumber}` first, then read state-history.
- Cancel: use the documented `DELETE /parcels/bulk/by-tracking-number`; enable `canDeleteBeforeValidation` + dashboard cancel; carrier refusals now surface as errors instead of resetting the order.
- Address updates: send the full `DeliveryAddressInputDto` (`cityTerritoryId` + `districtTerritoryId`, plus `hubId` for pickup-point parcels); failures throw instead of being swallowed.
- Stop desk: `getStopDesks` lists hubs (`isPickupPoint`) with wilayas resolved from `address.cityTerritoryId`; dispatch and address updates resolve the real hub for the station.
- Geo: accent-stripped searches, strict commune matching (fail loudly, never deliver to the wrong commune), clear error naming the 4 unserved wilayas (33, 37, 50, 56).
- Webhooks: subscribe to all three event types; status mapper defaults use the live-verified slug vocabulary with case/accent-insensitive matching and a description fallback; all order statuses accepted in the custom mapping UI.
- Bulk create: keep all failure messages per parcel index.

**CORS middleware:** re-apply the CORS headers to the final response after the handler runs, so raw streamed responses (label PDF proxy, R2 image streaming) carry them.

**Dashboard (`cod-client-astro`):** enable the cancel button for ZR orders (non-terminal statuses).

**Docs:** add the `zr-express` skill (endpoint references, schemas, conformance audit) under `.agents/skills/`.

## Testing

- `cod-server`: typecheck clean, **1919/1919 tests pass** (incl. new `zr-status-mapper.test.ts` with a drift guard over the live-verified slug vocabulary, and CORS regression tests for raw + context-built responses).
- `cod-client-astro`: typecheck clean, **147/147 tests pass**.
- Live API verification: geo sweep over all 58 wilayas (54 resolve; 33/37/50/56 confirmed unserved), delete → 200 + parcel gone, hubs/pickup points (77, all with address territories), webhook register/secret/delete with all three event types, label generation + PDF fetch for all existing ZR orders and a fresh test parcel (created and cleaned up via the API).
- Deployed to production Workers and verified in the live dashboard: print label downloads, cancel works, tracking events render.

No schema changes, no new dependencies, no other carriers touched.