### PR TITLE
fix(theme01): keep footer at bottom on short pages

### DIFF
--- a/cod-astro/theme01/src/theme/styles/global.css
+++ b/cod-astro/theme01/src/theme/styles/global.css
@@ -112,7 +112,12 @@ body {
   min-height: -webkit-fill-available;
   line-height: 1.5;
   overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
 }
+
+/* ── Sticky footer — main grows so short pages still push the footer down ── */
+body > main { flex: 1 0 auto; }
 
 /* ── View transition animations — more app-like ─────────────────────────── */
 @keyframes slide-up {


### PR DESCRIPTION
## What does this PR do?

On storefront pages with little content (e.g. a 2-product category), the footer rendered right after the content instead of staying at the viewport bottom.

Fix: make `body` a flex column and let `main` grow (`body > main { flex: 1 0 auto; }`) in `cod-astro/theme01/src/theme/styles/global.css`. Theme layer only — `src/core/` untouched, no hardcoded design tokens. Long pages, RTL, and the fixed mobile nav are unaffected.

Before / After:

<img width="1470" height="1326" alt="image" src="https://github.com/user-attachments/assets/fce732c1-c79c-4829-9513-75065ade1d1b" />
<img width="1472" height="1327" alt="image" src="https://github.com/user-attachments/assets/efcc7e4a-f7de-412d-885e-adf2801b8e14" />

## Related issues

None — visual bug found while running the storefront locally.

## How to test

```sh
cd cod-astro/theme01
npx astro check   # 0 errors (this package's typecheck)
npm test          # 21/21 pass
npm run validate:styles  # 0 violations
```

Then `npm run dev`, open a short page (e.g. `/products` filtered to a small category), hard-refresh, and confirm the footer sits at the bottom.

- [x] I ran `npm run typecheck` and `npm test` in the affected package(s)

## Checklist

- [x] No secrets, API keys, or live credentials are introduced
- [x] Tests cover the change (or an existing test covers it) — CSS-only change; existing theme01 suite (21 tests) passes
- [x] README/docs claims match the implemented behavior (no unbuilt features claimed)
- [x] Conventional commit message (`feat:`, `fix:`, `chore:`, `docs:`, ...)

## Areas affected

cod-astro/theme01